### PR TITLE
Pull the 'group' prop out of filter-select-option

### DIFF
--- a/themes/default/layouts/registry/list.html
+++ b/themes/default/layouts/registry/list.html
@@ -1,30 +1,35 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 lg:px-0 py-8 mt-2">
-        <pulumi-filter-select>
-            <pulumi-filter-select-option-group>
+        <pulumi-filter-select class="flex">
+
+            <!-- Package-type options -->
+            <pulumi-filter-select-option-group name="type">
                 <span slot="label">Type</span>
-                <pulumi-filter-select-option kind="type" value="native">Native Provider</pulumi-option>
-                <pulumi-filter-select-option kind="type" value="provider">Provider</pulumi-option>
-                <pulumi-filter-select-option kind="type" value="component">Component</pulumi-option>
+                <pulumi-filter-select-option value="native">Native Provider</pulumi-option>
+                <pulumi-filter-select-option value="provider">Provider</pulumi-option>
+                <pulumi-filter-select-option value="component">Component</pulumi-option>
             </pulumi-filter-select-option-group>
 
-            <pulumi-filter-select-option-group>
+            <!-- Use-case options -->
+            <pulumi-filter-select-option-group name="category" class="mx-16">
                 <span slot="label">Use Case</span>
-                <pulumi-filter-select-option kind="category" value="cloud">Cloud</pulumi-option>
-                <pulumi-filter-select-option kind="category" value="infrastructure">Infrastructure</pulumi-option>
-                <pulumi-filter-select-option kind="category" value="monitoring">Monitoring</pulumi-option>
-                <pulumi-filter-select-option kind="category" value="network">Network</pulumi-option>
-                <pulumi-filter-select-option kind="category" value="database">Database</pulumi-option>
-                <pulumi-filter-select-option kind="category" value="version control">Version control</pulumi-option>
-                <pulumi-filter-select-option kind="category" value="utility">Utility</pulumi-option>
+                <pulumi-filter-select-option value="cloud">Cloud</pulumi-option>
+                <pulumi-filter-select-option value="infrastructure">Infrastructure</pulumi-option>
+                <pulumi-filter-select-option value="monitoring">Monitoring</pulumi-option>
+                <pulumi-filter-select-option value="network">Network</pulumi-option>
+                <pulumi-filter-select-option value="database">Database</pulumi-option>
+                <pulumi-filter-select-option value="version control">Version control</pulumi-option>
+                <pulumi-filter-select-option value="utility">Utility</pulumi-option>
             </pulumi-filter-select-option-group>
 
-            <pulumi-filter-select-option-group>
+            <!-- Status options -->
+            <pulumi-filter-select-option-group name="status">
                 <span slot="label">Status</span>
-                <pulumi-filter-select-option kind="status" value="ga">Generally Available</pulumi-option>
-                <pulumi-filter-select-option kind="status" value="preview">Public Preview</pulumi-option>
-                <pulumi-filter-select-option kind="status" value="deprecated">Deprecated</pulumi-option>
+                <pulumi-filter-select-option value="ga">Generally Available</pulumi-option>
+                <pulumi-filter-select-option value="preview">Public Preview</pulumi-option>
+                <pulumi-filter-select-option value="deprecated">Deprecated</pulumi-option>
             </pulumi-filter-select-option-group>
+
         </pulumi-filter-select>
 
         {{ if and (.Params.h1) (not .Params.notitle) }}


### PR DESCRIPTION
This change is meant to accompany [a change I just made to the `filter-select` component](https://github.com/pulumi/theme/blob/master/stencil/src/components/filter-select/filter-select.tsx#L34) to pull the `group` prop out of the filter option, since it's repetitive and should be inferred from the group the option belongs to.
