### PR TITLE
Regenerate package metadata files

### DIFF
--- a/themes/default/data/registry/packages/aiven.yaml
+++ b/themes/default/data/registry/packages/aiven.yaml
@@ -1,8 +1,8 @@
 name: aiven
 title: aiven
 description: A Pulumi package for creating and managing Aiven cloud resources.
-logo: /logos/pkg/aiven.svg
-updated_on: 1631644519
+logo_url: ""
+updated_on: 1632258772
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/akamai.yaml
+++ b/themes/default/data/registry/packages/akamai.yaml
@@ -1,8 +1,8 @@
 name: akamai
 title: akamai
 description: A Pulumi package for creating and managing akamai cloud resources.
-logo: /logos/pkg/akamai.svg
-updated_on: 1631644521
+logo_url: ""
+updated_on: 1632258775
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/alicloud.yaml
+++ b/themes/default/data/registry/packages/alicloud.yaml
@@ -1,8 +1,8 @@
 name: alicloud
 title: alicloud
 description: A Pulumi package for creating and managing AliCloud resources.
-logo: /logos/pkg/alicloud.svg
-updated_on: 1631644523
+logo_url: ""
+updated_on: 1632258778
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/auth0.yaml
+++ b/themes/default/data/registry/packages/auth0.yaml
@@ -1,8 +1,8 @@
 name: auth0
 title: auth0
 description: A Pulumi package for creating and managing auth0 cloud resources.
-logo: /logos/pkg/auth0.svg
-updated_on: 1631644525
+logo_url: ""
+updated_on: 1632258780
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/aws.yaml
+++ b/themes/default/data/registry/packages/aws.yaml
@@ -2,11 +2,11 @@ name: aws
 title: aws
 description: A Pulumi package for creating and managing Amazon Web Services (AWS)
   cloud resources.
-logo: /logos/pkg/aws.svg
-updated_on: 1631644529
+logo_url: ""
+updated_on: 1632258785
 publisher: Pulumi
 category: Cloud
 package_status: ga
-version: v4.20.0
+version: v4.21.1
 featured: true
 native: false

--- a/themes/default/data/registry/packages/azure-native.yaml
+++ b/themes/default/data/registry/packages/azure-native.yaml
@@ -1,11 +1,11 @@
 name: azure-native
 title: azure-native
 description: A native Pulumi package for creating and managing Azure resources.
-logo: /logos/pkg/azure-native.svg
-updated_on: 1631644565
+logo_url: ""
+updated_on: 1632258807
 publisher: Pulumi
 category: Cloud
 package_status: ga
-version: v1.28.0
+version: v1.29.0
 featured: true
 native: true

--- a/themes/default/data/registry/packages/azure.yaml
+++ b/themes/default/data/registry/packages/azure.yaml
@@ -3,8 +3,8 @@ title: azure
 description: A Pulumi package based on the azurerm Terraform Provider for creating
   and managing Microsoft Azure cloud resources. Consider using the Pulumi Azure Native
   package for full coverage of Azure resources.
-logo: /logos/pkg/azure.svg
-updated_on: 1631644533
+logo_url: ""
+updated_on: 1632258789
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/azuread.yaml
+++ b/themes/default/data/registry/packages/azuread.yaml
@@ -1,8 +1,8 @@
 name: azuread
 title: azuread
 description: A Pulumi package for creating and managing azuread cloud resources.
-logo: /logos/pkg/azuread.svg
-updated_on: 1631644568
+logo_url: ""
+updated_on: 1632258811
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/azuredevops.yaml
+++ b/themes/default/data/registry/packages/azuredevops.yaml
@@ -1,8 +1,8 @@
 name: azuredevops
 title: azuredevops
 description: A Pulumi package for creating and managing Azure DevOps.
-logo: /logos/pkg/azuredevops.svg
-updated_on: 1631644570
+logo_url: ""
+updated_on: 1632258813
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/civo.yaml
+++ b/themes/default/data/registry/packages/civo.yaml
@@ -1,8 +1,8 @@
 name: civo
 title: civo
 description: A Pulumi package for creating and managing Civo cloud resources.
-logo: /logos/pkg/civo.svg
-updated_on: 1631644573
+logo_url: ""
+updated_on: 1632258815
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/cloudamqp.yaml
+++ b/themes/default/data/registry/packages/cloudamqp.yaml
@@ -1,8 +1,8 @@
 name: cloudamqp
 title: cloudamqp
 description: A Pulumi package for creating and managing CloudAMQP resources.
-logo: /logos/pkg/cloudamqp.svg
-updated_on: 1631644575
+logo_url: ""
+updated_on: 1632258818
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/cloudflare.yaml
+++ b/themes/default/data/registry/packages/cloudflare.yaml
@@ -1,8 +1,8 @@
 name: cloudflare
 title: cloudflare
 description: A Pulumi package for creating and managing Cloudflare cloud resources.
-logo: /logos/pkg/cloudflare.svg
-updated_on: 1631644577
+logo_url: ""
+updated_on: 1632258820
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/cloudinit.yaml
+++ b/themes/default/data/registry/packages/cloudinit.yaml
@@ -1,8 +1,8 @@
 name: cloudinit
 title: cloudinit
 description: A Pulumi package for creating and managing cloudinit cloud resources.
-logo: /logos/pkg/cloudinit.svg
-updated_on: 1631644579
+logo_url: ""
+updated_on: 1632258823
 publisher: Pulumi
 category: Utility
 package_status: ga

--- a/themes/default/data/registry/packages/consul.yaml
+++ b/themes/default/data/registry/packages/consul.yaml
@@ -1,8 +1,8 @@
 name: consul
 title: consul
 description: A Pulumi package for creating and managing consul resources.
-logo: /logos/pkg/consul.svg
-updated_on: 1631644581
+logo_url: ""
+updated_on: 1632258825
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/datadog.yaml
+++ b/themes/default/data/registry/packages/datadog.yaml
@@ -1,8 +1,8 @@
 name: datadog
 title: datadog
 description: A Pulumi package for creating and managing Datadog resources.
-logo: /logos/pkg/datadog.svg
-updated_on: 1631644584
+logo_url: ""
+updated_on: 1632258827
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/digitalocean.yaml
+++ b/themes/default/data/registry/packages/digitalocean.yaml
@@ -1,8 +1,8 @@
 name: digitalocean
 title: digitalocean
 description: A Pulumi package for creating and managing Digital Ocean cloud resources.
-logo: /logos/pkg/digitalocean.svg
-updated_on: 1631644586
+logo_url: ""
+updated_on: 1632258830
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/dnsimple.yaml
+++ b/themes/default/data/registry/packages/dnsimple.yaml
@@ -1,8 +1,8 @@
 name: dnsimple
 title: dnsimple
 description: A Pulumi package for creating and managing dnsimple cloud resources.
-logo: /logos/pkg/dnsimple.svg
-updated_on: 1631644588
+logo_url: ""
+updated_on: 1632258832
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/docker.yaml
+++ b/themes/default/data/registry/packages/docker.yaml
@@ -1,8 +1,8 @@
 name: docker
 title: docker
 description: A Pulumi package for interacting with Docker in Pulumi programs
-logo: /logos/pkg/docker.svg
-updated_on: 1631644591
+logo_url: ""
+updated_on: 1632258834
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/eks.yaml
+++ b/themes/default/data/registry/packages/eks.yaml
@@ -1,8 +1,8 @@
 name: eks
 title: eks
 description: Pulumi Amazon Web Services (AWS) EKS Components.
-logo: /logos/pkg/eks.svg
-updated_on: 1631644595
+logo_url: ""
+updated_on: 1632258838
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/equinix-metal.yaml
+++ b/themes/default/data/registry/packages/equinix-metal.yaml
@@ -1,8 +1,8 @@
 name: equinix-metal
 title: equinix-metal
 description: A Pulumi package for creating and managing equinix-metal cloud resources.
-logo: /logos/pkg/equinix-metal.svg
-updated_on: 1631644593
+logo_url: ""
+updated_on: 1632258836
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/f5bigip.yaml
+++ b/themes/default/data/registry/packages/f5bigip.yaml
@@ -1,8 +1,8 @@
 name: f5bigip
 title: f5bigip
 description: A Pulumi package for creating and managing F5 BigIP resources.
-logo: /logos/pkg/f5bigip.svg
-updated_on: 1631644600
+logo_url: ""
+updated_on: 1632258842
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/fastly.yaml
+++ b/themes/default/data/registry/packages/fastly.yaml
@@ -1,8 +1,8 @@
 name: fastly
 title: fastly
 description: A Pulumi package for creating and managing fastly cloud resources.
-logo: /logos/pkg/fastly.svg
-updated_on: 1631644597
+logo_url: ""
+updated_on: 1632258840
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/gcp.yaml
+++ b/themes/default/data/registry/packages/gcp.yaml
@@ -1,11 +1,11 @@
 name: gcp
 title: gcp
 description: A Pulumi package for creating and managing Google Cloud Platform resources.
-logo: /logos/pkg/gcp.svg
-updated_on: 1631644604
+logo_url: ""
+updated_on: 1632258847
 publisher: Pulumi
 category: Cloud
 package_status: ga
-version: v5.19.0
+version: v5.20.0
 featured: false
 native: false

--- a/themes/default/data/registry/packages/github.yaml
+++ b/themes/default/data/registry/packages/github.yaml
@@ -1,8 +1,8 @@
 name: github
 title: github
 description: A Pulumi package for creating and managing github cloud resources.
-logo: /logos/pkg/github.svg
-updated_on: 1631644611
+logo_url: ""
+updated_on: 1632258851
 publisher: Pulumi
 category: Version Control System
 package_status: ga

--- a/themes/default/data/registry/packages/gitlab.yaml
+++ b/themes/default/data/registry/packages/gitlab.yaml
@@ -1,8 +1,8 @@
 name: gitlab
 title: gitlab
 description: A Pulumi package for creating and managing GitLab resources.
-logo: /logos/pkg/gitlab.svg
-updated_on: 1631644613
+logo_url: ""
+updated_on: 1632258853
 publisher: Pulumi
 category: Version Control System
 package_status: ga

--- a/themes/default/data/registry/packages/google-native.yaml
+++ b/themes/default/data/registry/packages/google-native.yaml
@@ -1,8 +1,8 @@
 name: google-native
 title: google-native
 description: A native Pulumi package for creating and managing Google Cloud resources.
-logo: /logos/pkg/google-native.svg
-updated_on: 1631644608
+logo_url: ""
+updated_on: 1632258849
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/hcloud.yaml
+++ b/themes/default/data/registry/packages/hcloud.yaml
@@ -1,8 +1,8 @@
 name: hcloud
 title: hcloud
 description: A Pulumi package for creating and managing hcloud cloud resources.
-logo: /logos/pkg/hcloud.svg
-updated_on: 1631644616
+logo_url: ""
+updated_on: 1632258855
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/kafka.yaml
+++ b/themes/default/data/registry/packages/kafka.yaml
@@ -1,8 +1,8 @@
 name: kafka
 title: kafka
 description: A Pulumi package for creating and managing Kafka.
-logo: /logos/pkg/kafka.svg
-updated_on: 1631644619
+logo_url: ""
+updated_on: 1632258858
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/keycloak.yaml
+++ b/themes/default/data/registry/packages/keycloak.yaml
@@ -1,8 +1,8 @@
 name: keycloak
 title: keycloak
 description: A Pulumi package for creating and managing keycloak cloud resources.
-logo: /logos/pkg/keycloak.svg
-updated_on: 1631644624
+logo_url: ""
+updated_on: 1632258863
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/kong.yaml
+++ b/themes/default/data/registry/packages/kong.yaml
@@ -1,8 +1,8 @@
 name: kong
 title: kong
 description: A Pulumi package for creating and managing Kong resources.
-logo: /logos/pkg/kong.svg
-updated_on: 1631644626
+logo_url: ""
+updated_on: 1632258865
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/kubernetes.yaml
+++ b/themes/default/data/registry/packages/kubernetes.yaml
@@ -1,11 +1,11 @@
 name: kubernetes
 title: kubernetes
 description: A Pulumi package for creating and managing Kubernetes resources.
-logo: /logos/pkg/kubernetes.svg
-updated_on: 1631644622
+logo_url: ""
+updated_on: 1632258861
 publisher: Pulumi
 category: Cloud
 package_status: ga
-version: v3.7.1
+version: v3.7.2
 featured: true
 native: true

--- a/themes/default/data/registry/packages/linode.yaml
+++ b/themes/default/data/registry/packages/linode.yaml
@@ -1,8 +1,8 @@
 name: linode
 title: linode
 description: A Pulumi package for creating and managing linode cloud resources.
-logo: /logos/pkg/linode.svg
-updated_on: 1631644628
+logo_url: ""
+updated_on: 1632258867
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/mailgun.yaml
+++ b/themes/default/data/registry/packages/mailgun.yaml
@@ -1,8 +1,8 @@
 name: mailgun
 title: mailgun
 description: A Pulumi package for creating and managing Mailgun resources.
-logo: /logos/pkg/mailgun.svg
-updated_on: 1631644630
+logo_url: ""
+updated_on: 1632258869
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/mongodbatlas.yaml
+++ b/themes/default/data/registry/packages/mongodbatlas.yaml
@@ -1,8 +1,8 @@
 name: mongodbatlas
 title: mongodbatlas
 description: A Pulumi package for creating and managing mongodbatlas cloud resources.
-logo: /logos/pkg/mongodbatlas.svg
-updated_on: 1631644633
+logo_url: ""
+updated_on: 1632258872
 publisher: Pulumi
 category: Database
 package_status: ga

--- a/themes/default/data/registry/packages/mysql.yaml
+++ b/themes/default/data/registry/packages/mysql.yaml
@@ -1,8 +1,8 @@
 name: mysql
 title: mysql
 description: A Pulumi package for creating and managing mysql cloud resources.
-logo: /logos/pkg/mysql.svg
-updated_on: 1631644635
+logo_url: ""
+updated_on: 1632258874
 publisher: Pulumi
 category: Database
 package_status: ga

--- a/themes/default/data/registry/packages/newrelic.yaml
+++ b/themes/default/data/registry/packages/newrelic.yaml
@@ -1,8 +1,8 @@
 name: newrelic
 title: newrelic
 description: A Pulumi package for creating and managing New Relic resources.
-logo: /logos/pkg/newrelic.svg
-updated_on: 1631644637
+logo_url: ""
+updated_on: 1632258876
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/ns1.yaml
+++ b/themes/default/data/registry/packages/ns1.yaml
@@ -1,8 +1,8 @@
 name: ns1
 title: ns1
 description: A Pulumi package for creating and managing ns1 cloud resources.
-logo: /logos/pkg/ns1.svg
-updated_on: 1631644639
+logo_url: ""
+updated_on: 1632258878
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/okta.yaml
+++ b/themes/default/data/registry/packages/okta.yaml
@@ -1,8 +1,8 @@
 name: okta
 title: okta
 description: A Pulumi package for creating and managing okta resources.
-logo: /logos/pkg/okta.svg
-updated_on: 1631644642
+logo_url: ""
+updated_on: 1632258880
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/openstack.yaml
+++ b/themes/default/data/registry/packages/openstack.yaml
@@ -1,8 +1,8 @@
 name: openstack
 title: openstack
 description: A Pulumi package for creating and managing OpenStack cloud resources.
-logo: /logos/pkg/openstack.svg
-updated_on: 1631644644
+logo_url: ""
+updated_on: 1632258882
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/opsgenie.yaml
+++ b/themes/default/data/registry/packages/opsgenie.yaml
@@ -1,8 +1,8 @@
 name: opsgenie
 title: opsgenie
 description: A Pulumi package for creating and managing opsgenie cloud resources.
-logo: /logos/pkg/opsgenie.svg
-updated_on: 1631644646
+logo_url: ""
+updated_on: 1632258884
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/packet.yaml
+++ b/themes/default/data/registry/packages/packet.yaml
@@ -1,8 +1,8 @@
 name: packet
 title: packet
 description: A Pulumi package for creating and managing Packet cloud resources.
-logo: /logos/pkg/packet.svg
-updated_on: 1631644649
+logo_url: ""
+updated_on: 1632258886
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/pagerduty.yaml
+++ b/themes/default/data/registry/packages/pagerduty.yaml
@@ -1,8 +1,8 @@
 name: pagerduty
 title: pagerduty
 description: A Pulumi package for creating and managing pagerduty cloud resources.
-logo: /logos/pkg/pagerduty.svg
-updated_on: 1631644651
+logo_url: ""
+updated_on: 1632258888
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/postgresql.yaml
+++ b/themes/default/data/registry/packages/postgresql.yaml
@@ -1,8 +1,8 @@
 name: postgresql
 title: postgresql
 description: A Pulumi package for creating and managing postgresql cloud resources.
-logo: /logos/pkg/postgresql.svg
-updated_on: 1631644653
+logo_url: ""
+updated_on: 1632258890
 publisher: Pulumi
 category: Database
 package_status: ga

--- a/themes/default/data/registry/packages/rabbitmq.yaml
+++ b/themes/default/data/registry/packages/rabbitmq.yaml
@@ -1,8 +1,8 @@
 name: rabbitmq
 title: rabbitmq
 description: A Pulumi package for creating and managing RabbitMQ resources.
-logo: /logos/pkg/rabbitmq.svg
-updated_on: 1631644655
+logo_url: ""
+updated_on: 1632258892
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/rancher2.yaml
+++ b/themes/default/data/registry/packages/rancher2.yaml
@@ -1,8 +1,8 @@
 name: rancher2
 title: rancher2
 description: A Pulumi package for creating and managing rancher2 resources.
-logo: /logos/pkg/rancher2.svg
-updated_on: 1631644657
+logo_url: ""
+updated_on: 1632258894
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/random.yaml
+++ b/themes/default/data/registry/packages/random.yaml
@@ -1,8 +1,8 @@
 name: random
 title: random
 description: A Pulumi package to safely use randomness in Pulumi programs.
-logo: /logos/pkg/random.svg
-updated_on: 1631644660
+logo_url: ""
+updated_on: 1632258897
 publisher: Pulumi
 category: Utility
 package_status: ga

--- a/themes/default/data/registry/packages/signalfx.yaml
+++ b/themes/default/data/registry/packages/signalfx.yaml
@@ -1,8 +1,8 @@
 name: signalfx
 title: signalfx
 description: A Pulumi package for creating and managing SignalFx resources.
-logo: /logos/pkg/signalfx.svg
-updated_on: 1631644662
+logo_url: ""
+updated_on: 1632258899
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/splunk.yaml
+++ b/themes/default/data/registry/packages/splunk.yaml
@@ -1,8 +1,8 @@
 name: splunk
 title: splunk
 description: A Pulumi package for creating and managing splunk cloud resources.
-logo: /logos/pkg/splunk.svg
-updated_on: 1631644666
+logo_url: ""
+updated_on: 1632258904
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/spotinst.yaml
+++ b/themes/default/data/registry/packages/spotinst.yaml
@@ -1,8 +1,8 @@
 name: spotinst
 title: spotinst
 description: A Pulumi package for creating and managing spotinst cloud resources.
-logo: /logos/pkg/spotinst.svg
-updated_on: 1631644664
+logo_url: ""
+updated_on: 1632258901
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/tls.yaml
+++ b/themes/default/data/registry/packages/tls.yaml
@@ -1,8 +1,8 @@
 name: tls
 title: tls
 description: A Pulumi package to create TLS resources in Pulumi programs.
-logo: /logos/pkg/tls.svg
-updated_on: 1631644673
+logo_url: ""
+updated_on: 1632258910
 publisher: Pulumi
 category: Utility
 package_status: ga

--- a/themes/default/data/registry/packages/vault.yaml
+++ b/themes/default/data/registry/packages/vault.yaml
@@ -1,8 +1,8 @@
 name: vault
 title: vault
 description: A Pulumi package for creating and managing vault cloud resources.
-logo: /logos/pkg/vault.svg
-updated_on: 1631644676
+logo_url: ""
+updated_on: 1632258912
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/venafi.yaml
+++ b/themes/default/data/registry/packages/venafi.yaml
@@ -1,8 +1,8 @@
 name: venafi
 title: venafi
 description: A Pulumi package for creating and managing venafi cloud resources.
-logo: /logos/pkg/venafi.svg
-updated_on: 1631644678
+logo_url: ""
+updated_on: 1632258914
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/vsphere.yaml
+++ b/themes/default/data/registry/packages/vsphere.yaml
@@ -1,8 +1,8 @@
 name: vsphere
 title: vsphere
 description: A Pulumi package for creating vsphere resources
-logo: /logos/pkg/vsphere.svg
-updated_on: 1631644669
+logo_url: ""
+updated_on: 1632258906
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/wavefront.yaml
+++ b/themes/default/data/registry/packages/wavefront.yaml
@@ -1,8 +1,8 @@
 name: wavefront
 title: wavefront
 description: A Pulumi package for creating and managing wavefront cloud resources.
-logo: /logos/pkg/wavefront.svg
-updated_on: 1631644671
+logo_url: ""
+updated_on: 1632258908
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/yandex.yaml
+++ b/themes/default/data/registry/packages/yandex.yaml
@@ -1,8 +1,8 @@
 name: yandex
 title: yandex
 description: A Pulumi package for creating and managing yandex cloud resources.
-logo: /logos/pkg/yandex.svg
-updated_on: 1631644681
+logo_url: ""
+updated_on: 1632258916
 publisher: Pulumi
 category: Cloud
 package_status: public_preview


### PR DESCRIPTION
I regenerated the metadata files by using the `gen_all_resource_doc.sh` script from the PR https://github.com/pulumi/docs/pull/6381. With that branch checked out, I comment out the line in that script that invokes the `gen_resource_docs.sh` script since I don't want it to regenerate docs. I just want a sample of the metadata for the registry for all packages in our system. When we are ready, for the real thing, they would always be in sync. That is, we would regenerate a package's metadata file when its resource docs are also regenerated due to a new version being published. The same with when we introduce a new package/component to the registry, we would do them together.