### PR TITLE
update akamai logo to svg

### DIFF
--- a/themes/default/data/registry/packages/akamai.yaml
+++ b/themes/default/data/registry/packages/akamai.yaml
@@ -8,4 +8,4 @@ package_status: ga
 version: v2.3.0
 featured: false
 native: false
-logo: "/logos/tech/akamai.png"
+logo: "/logos/tech/akamai.svg"


### PR DESCRIPTION
this is updating the akamai logo to use svg, so it resizes appropriately and looks better
im guessing we will need to make sure the pulumi-hugo pr is live before this merges

https://github.com/pulumi/pulumi-hugo/pull/605