### PR TITLE
Revert Learn Pulumi and Resources relrefs

### DIFF
--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -15,8 +15,8 @@
             <li role="none"><a role="menuitem" href="{{ relref . "/pricing" }}">Pricing</a></li>
             <li role="none"><a role="menuitem" href="{{ relref . "/docs" }}">Docs</a></li>
             <li role="none"><a role="menuitem" href="{{ relref . "/blog" }}">Blog</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . "/learn-pulumi" }}">Learn Pulumi</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . "/events-workshops" }}">Events & Workshops</a></li>
+            <li role="none"><a role="menuitem" href="{{ relref . "/learn" }}">Learn Pulumi</a></li>
+            <li role="none"><a role="menuitem" href="{{ relref . "/resources" }}">Events & Workshops</a></li>
             <ul role="menu" class="sm:hidden">
                 <li role="none"><a role="menuitem" href="https://github.com/pulumi/pulumi">GitHub</a></li>
                 <li role="none"><a role="menuitem" href="https://slack.pulumi.com">Slack</a></li>


### PR DESCRIPTION
This was originally changed with #23 but because those are new links the final docs build fails because they don't exist yet. I am reverting the links for now. Since we'll have redirects for these in-place once the new URLs are active the old ones will still continue to work and simply redirect to the new place whenever that happens. I was just too eager with my change in the original PR.