### PR TITLE
Update Events & Workshops link to navigate to the #all hash

### DIFF
--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -16,7 +16,7 @@
             <li role="none"><a role="menuitem" href="{{ relref . "/docs" }}">Docs</a></li>
             <li role="none"><a role="menuitem" href="{{ relref . "/blog" }}">Blog</a></li>
             <li role="none"><a role="menuitem" href="{{ relref . "/learn" }}">Learn Pulumi</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . "/resources/#all" }}">Events & Workshops</a></li>
+            <li role="none"><a role="menuitem" href="{{ relref . "/events-workshops/#all" }}">Events & Workshops</a></li>
             <ul role="menu" class="sm:hidden">
                 <li role="none"><a role="menuitem" href="https://github.com/pulumi/pulumi">GitHub</a></li>
                 <li role="none"><a role="menuitem" href="https://slack.pulumi.com">Slack</a></li>


### PR DESCRIPTION
~~Just keeping the link in the registry synced. If you are wondering why it's still pointing to `/resources` it's because https://github.com/pulumi/pulumi-hugo/pull/625 needs to be merged first. Otherwise, registry builds will be blocked due to the broken relrefs. (https://github.com/pulumi/registry/pull/44)~~ Now that pulumi/pulumi-hugo#625 is merged, I have updated the `resources` link to `events-workshops`.

EDIT: This probably can't be merged until `pulumi-hugo` dependency in this repo is updated to the latest and this PR is rebased.