### PR TITLE
Regenerate metadata files to get accurate updated_on timestamps for packages

### DIFF
--- a/themes/default/data/registry/packages/aiven.yaml
+++ b/themes/default/data/registry/packages/aiven.yaml
@@ -2,7 +2,7 @@ name: aiven
 title: Aiven
 description: A Pulumi package for creating and managing Aiven cloud resources.
 logo_url: ""
-updated_on: 1633360672
+updated_on: 1633348450
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/akamai.yaml
+++ b/themes/default/data/registry/packages/akamai.yaml
@@ -2,7 +2,7 @@ name: akamai
 title: Akamai
 description: A Pulumi package for creating and managing akamai cloud resources.
 logo_url: ""
-updated_on: 1633360675
+updated_on: 1632763461
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/alicloud.yaml
+++ b/themes/default/data/registry/packages/alicloud.yaml
@@ -2,10 +2,10 @@ name: alicloud
 title: Alibaba Cloud
 description: A Pulumi package for creating and managing AliCloud resources.
 logo_url: ""
-updated_on: 1633360678
+updated_on: 1633365195
 publisher: Pulumi
 category: Cloud
 package_status: ga
-version: v3.7.0
+version: v3.8.0
 featured: false
 native: false

--- a/themes/default/data/registry/packages/auth0.yaml
+++ b/themes/default/data/registry/packages/auth0.yaml
@@ -2,7 +2,7 @@ name: auth0
 title: Auth0
 description: A Pulumi package for creating and managing auth0 cloud resources.
 logo_url: ""
-updated_on: 1633360680
+updated_on: 1622119559
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/aws-native.yaml
+++ b/themes/default/data/registry/packages/aws-native.yaml
@@ -3,7 +3,7 @@ title: AWS Native
 description: A native Pulumi package for creating and managing Amazon Web Services
   (AWS) resources.
 logo_url: ""
-updated_on: 1633360686
+updated_on: 1633005898
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/aws.yaml
+++ b/themes/default/data/registry/packages/aws.yaml
@@ -3,7 +3,7 @@ title: AWS Classic
 description: A Pulumi package for creating and managing Amazon Web Services (AWS)
   cloud resources.
 logo_url: ""
-updated_on: 1633360684
+updated_on: 1632951273
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/azure-native.yaml
+++ b/themes/default/data/registry/packages/azure-native.yaml
@@ -2,7 +2,7 @@ name: azure-native
 title: Azure Native
 description: A native Pulumi package for creating and managing Azure resources.
 logo_url: ""
-updated_on: 1633360695
+updated_on: 1632998815
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/azure.yaml
+++ b/themes/default/data/registry/packages/azure.yaml
@@ -5,7 +5,7 @@ description: A Pulumi package for creating and managing Microsoft Azure cloud re
   to provision Azure infrastructure. Azure Native provides complete coverage of Azure
   resources and same-day access to new resources and resource updates.
 logo_url: ""
-updated_on: 1633360689
+updated_on: 1632852833
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/azuread.yaml
+++ b/themes/default/data/registry/packages/azuread.yaml
@@ -2,7 +2,7 @@ name: azuread
 title: Azure Active Directory
 description: A Pulumi package for creating and managing azuread cloud resources.
 logo_url: ""
-updated_on: 1633360697
+updated_on: 1632753131
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/azuredevops.yaml
+++ b/themes/default/data/registry/packages/azuredevops.yaml
@@ -2,7 +2,7 @@ name: azuredevops
 title: Azure DevOps
 description: A Pulumi package for creating and managing Azure DevOps.
 logo_url: ""
-updated_on: 1633360699
+updated_on: 1631192090
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/civo.yaml
+++ b/themes/default/data/registry/packages/civo.yaml
@@ -2,7 +2,7 @@ name: civo
 title: Civo
 description: A Pulumi package for creating and managing Civo cloud resources.
 logo_url: ""
-updated_on: 1633360701
+updated_on: 1630497634
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/cloudamqp.yaml
+++ b/themes/default/data/registry/packages/cloudamqp.yaml
@@ -2,7 +2,7 @@ name: cloudamqp
 title: CloudAMQP
 description: A Pulumi package for creating and managing CloudAMQP resources.
 logo_url: ""
-updated_on: 1633360704
+updated_on: 1632763018
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/cloudflare.yaml
+++ b/themes/default/data/registry/packages/cloudflare.yaml
@@ -2,7 +2,7 @@ name: cloudflare
 title: Cloudflare
 description: A Pulumi package for creating and managing Cloudflare cloud resources.
 logo_url: ""
-updated_on: 1633360706
+updated_on: 1632754480
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/cloudinit.yaml
+++ b/themes/default/data/registry/packages/cloudinit.yaml
@@ -2,7 +2,7 @@ name: cloudinit
 title: cloud-init
 description: A Pulumi package for creating and managing cloudinit cloud resources.
 logo_url: ""
-updated_on: 1633360708
+updated_on: 1622138229
 publisher: Pulumi
 category: Utility
 package_status: ga

--- a/themes/default/data/registry/packages/confluent.yaml
+++ b/themes/default/data/registry/packages/confluent.yaml
@@ -2,7 +2,7 @@ name: confluent
 title: Confluent Cloud
 description: A Pulumi package for creating and managing confluent cloud resources.
 logo_url: ""
-updated_on: 1633360710
+updated_on: 1628182648
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/consul.yaml
+++ b/themes/default/data/registry/packages/consul.yaml
@@ -2,7 +2,7 @@ name: consul
 title: Consul
 description: A Pulumi package for creating and managing consul resources.
 logo_url: ""
-updated_on: 1633360713
+updated_on: 1630677059
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/datadog.yaml
+++ b/themes/default/data/registry/packages/datadog.yaml
@@ -2,7 +2,7 @@ name: datadog
 title: Datadog
 description: A Pulumi package for creating and managing Datadog resources.
 logo_url: ""
-updated_on: 1633360715
+updated_on: 1632754448
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/digitalocean.yaml
+++ b/themes/default/data/registry/packages/digitalocean.yaml
@@ -2,7 +2,7 @@ name: digitalocean
 title: DigitalOcean
 description: A Pulumi package for creating and managing Digital Ocean cloud resources.
 logo_url: ""
-updated_on: 1633360717
+updated_on: 1630497773
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/dnsimple.yaml
+++ b/themes/default/data/registry/packages/dnsimple.yaml
@@ -2,7 +2,7 @@ name: dnsimple
 title: DNSimple
 description: A Pulumi package for creating and managing dnsimple cloud resources.
 logo_url: ""
-updated_on: 1633360719
+updated_on: 1622138343
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/docker.yaml
+++ b/themes/default/data/registry/packages/docker.yaml
@@ -2,7 +2,7 @@ name: docker
 title: Docker
 description: A Pulumi package for interacting with Docker in Pulumi programs
 logo_url: ""
-updated_on: 1633360721
+updated_on: 1630502018
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/eks.yaml
+++ b/themes/default/data/registry/packages/eks.yaml
@@ -2,7 +2,7 @@ name: eks
 title: Amazon EKS
 description: Pulumi Amazon Web Services (AWS) EKS Components.
 logo_url: ""
-updated_on: 1633360724
+updated_on: 1629311292
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/equinix-metal.yaml
+++ b/themes/default/data/registry/packages/equinix-metal.yaml
@@ -2,7 +2,7 @@ name: equinix-metal
 title: Equinix Metal
 description: A Pulumi package for creating and managing equinix-metal cloud resources.
 logo_url: ""
-updated_on: 1633360726
+updated_on: 1632755071
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/f5bigip.yaml
+++ b/themes/default/data/registry/packages/f5bigip.yaml
@@ -2,7 +2,7 @@ name: f5bigip
 title: f5 BIG-IP
 description: A Pulumi package for creating and managing F5 BigIP resources.
 logo_url: ""
-updated_on: 1633360730
+updated_on: 1632763634
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/fastly.yaml
+++ b/themes/default/data/registry/packages/fastly.yaml
@@ -2,7 +2,7 @@ name: fastly
 title: Fastly
 description: A Pulumi package for creating and managing fastly cloud resources.
 logo_url: ""
-updated_on: 1633360728
+updated_on: 1632754365
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/gcp.yaml
+++ b/themes/default/data/registry/packages/gcp.yaml
@@ -2,7 +2,7 @@ name: gcp
 title: Google Cloud Classic
 description: A Pulumi package for creating and managing Google Cloud Platform resources.
 logo_url: ""
-updated_on: 1633360733
+updated_on: 1632848692
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/github.yaml
+++ b/themes/default/data/registry/packages/github.yaml
@@ -2,7 +2,7 @@ name: github
 title: GitHub
 description: A Pulumi package for creating and managing github cloud resources.
 logo_url: ""
-updated_on: 1633360737
+updated_on: 1633348534
 publisher: Pulumi
 category: Version Control System
 package_status: ga

--- a/themes/default/data/registry/packages/gitlab.yaml
+++ b/themes/default/data/registry/packages/gitlab.yaml
@@ -2,7 +2,7 @@ name: gitlab
 title: GitLab
 description: A Pulumi package for creating and managing GitLab resources.
 logo_url: ""
-updated_on: 1633360739
+updated_on: 1627993993
 publisher: Pulumi
 category: Version Control System
 package_status: ga

--- a/themes/default/data/registry/packages/google-native.yaml
+++ b/themes/default/data/registry/packages/google-native.yaml
@@ -2,7 +2,7 @@ name: google-native
 title: Google Cloud Native
 description: A native Pulumi package for creating and managing Google Cloud resources.
 logo_url: ""
-updated_on: 1633360735
+updated_on: 1628264180
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/hcloud.yaml
+++ b/themes/default/data/registry/packages/hcloud.yaml
@@ -2,7 +2,7 @@ name: hcloud
 title: Hetzner Cloud
 description: A Pulumi package for creating and managing hcloud cloud resources.
 logo_url: ""
-updated_on: 1633360742
+updated_on: 1631191806
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/kafka.yaml
+++ b/themes/default/data/registry/packages/kafka.yaml
@@ -2,7 +2,7 @@ name: kafka
 title: Kafka
 description: A Pulumi package for creating and managing Kafka.
 logo_url: ""
-updated_on: 1633360744
+updated_on: 1620809445
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/keycloak.yaml
+++ b/themes/default/data/registry/packages/keycloak.yaml
@@ -2,7 +2,7 @@ name: keycloak
 title: Keycloak
 description: A Pulumi package for creating and managing keycloak cloud resources.
 logo_url: ""
-updated_on: 1633360749
+updated_on: 1632762936
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/kong.yaml
+++ b/themes/default/data/registry/packages/kong.yaml
@@ -2,7 +2,7 @@ name: kong
 title: Kong
 description: A Pulumi package for creating and managing Kong resources.
 logo_url: ""
-updated_on: 1633360751
+updated_on: 1629366583
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/kubernetes.yaml
+++ b/themes/default/data/registry/packages/kubernetes.yaml
@@ -2,7 +2,7 @@ name: kubernetes
 title: Kubernetes
 description: A Pulumi package for creating and managing Kubernetes resources.
 logo_url: ""
-updated_on: 1633360747
+updated_on: 1633061444
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/libvirt.yaml
+++ b/themes/default/data/registry/packages/libvirt.yaml
@@ -2,7 +2,7 @@ name: libvirt
 title: libvirt
 description: A Pulumi package for creating and managing libvirt cloud resources.
 logo_url: ""
-updated_on: 1633360753
+updated_on: 1619480147
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/linode.yaml
+++ b/themes/default/data/registry/packages/linode.yaml
@@ -2,7 +2,7 @@ name: linode
 title: Linode
 description: A Pulumi package for creating and managing linode cloud resources.
 logo_url: ""
-updated_on: 1633360755
+updated_on: 1632763342
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/mailgun.yaml
+++ b/themes/default/data/registry/packages/mailgun.yaml
@@ -2,7 +2,7 @@ name: mailgun
 title: Mailgun
 description: A Pulumi package for creating and managing Mailgun resources.
 logo_url: ""
-updated_on: 1633360757
+updated_on: 1621593649
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/minio.yaml
+++ b/themes/default/data/registry/packages/minio.yaml
@@ -2,7 +2,7 @@ name: minio
 title: MinIO
 description: A Pulumi package for creating and managing minio cloud resources.
 logo_url: ""
-updated_on: 1633360759
+updated_on: 1625092003
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/mongodbatlas.yaml
+++ b/themes/default/data/registry/packages/mongodbatlas.yaml
@@ -2,7 +2,7 @@ name: mongodbatlas
 title: MongoDB Atlas
 description: A Pulumi package for creating and managing mongodbatlas cloud resources.
 logo_url: ""
-updated_on: 1633360761
+updated_on: 1631192168
 publisher: Pulumi
 category: Database
 package_status: ga

--- a/themes/default/data/registry/packages/mysql.yaml
+++ b/themes/default/data/registry/packages/mysql.yaml
@@ -2,7 +2,7 @@ name: mysql
 title: MySQL
 description: A Pulumi package for creating and managing mysql cloud resources.
 logo_url: ""
-updated_on: 1633360764
+updated_on: 1618844168
 publisher: Pulumi
 category: Database
 package_status: ga

--- a/themes/default/data/registry/packages/newrelic.yaml
+++ b/themes/default/data/registry/packages/newrelic.yaml
@@ -2,7 +2,7 @@ name: newrelic
 title: New Relic
 description: A Pulumi package for creating and managing New Relic resources.
 logo_url: ""
-updated_on: 1633360766
+updated_on: 1628765707
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/ns1.yaml
+++ b/themes/default/data/registry/packages/ns1.yaml
@@ -2,7 +2,7 @@ name: ns1
 title: NS1
 description: A Pulumi package for creating and managing ns1 cloud resources.
 logo_url: ""
-updated_on: 1633360768
+updated_on: 1633348422
 publisher: Pulumi
 category: Network
 package_status: ga

--- a/themes/default/data/registry/packages/okta.yaml
+++ b/themes/default/data/registry/packages/okta.yaml
@@ -2,7 +2,7 @@ name: okta
 title: Okta
 description: A Pulumi package for creating and managing okta resources.
 logo_url: ""
-updated_on: 1633360770
+updated_on: 1633348597
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/openstack.yaml
+++ b/themes/default/data/registry/packages/openstack.yaml
@@ -2,7 +2,7 @@ name: openstack
 title: OpenStack
 description: A Pulumi package for creating and managing OpenStack cloud resources.
 logo_url: ""
-updated_on: 1633360773
+updated_on: 1633348307
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/opsgenie.yaml
+++ b/themes/default/data/registry/packages/opsgenie.yaml
@@ -2,7 +2,7 @@ name: opsgenie
 title: Opsgenie
 description: A Pulumi package for creating and managing opsgenie cloud resources.
 logo_url: ""
-updated_on: 1633360775
+updated_on: 1628767038
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/packet.yaml
+++ b/themes/default/data/registry/packages/packet.yaml
@@ -2,7 +2,7 @@ name: packet
 title: Packet
 description: A Pulumi package for creating and managing Packet cloud resources.
 logo_url: ""
-updated_on: 1633360777
+updated_on: 1605199362
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/pagerduty.yaml
+++ b/themes/default/data/registry/packages/pagerduty.yaml
@@ -2,7 +2,7 @@ name: pagerduty
 title: PagerDuty
 description: A Pulumi package for creating and managing pagerduty cloud resources.
 logo_url: ""
-updated_on: 1633360779
+updated_on: 1632754402
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/postgresql.yaml
+++ b/themes/default/data/registry/packages/postgresql.yaml
@@ -2,7 +2,7 @@ name: postgresql
 title: PostgreSQL
 description: A Pulumi package for creating and managing postgresql cloud resources.
 logo_url: ""
-updated_on: 1633360781
+updated_on: 1630676984
 publisher: Pulumi
 category: Database
 package_status: ga

--- a/themes/default/data/registry/packages/rabbitmq.yaml
+++ b/themes/default/data/registry/packages/rabbitmq.yaml
@@ -2,7 +2,7 @@ name: rabbitmq
 title: RabbitMQ
 description: A Pulumi package for creating and managing RabbitMQ resources.
 logo_url: ""
-updated_on: 1633360783
+updated_on: 1631191834
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/rancher2.yaml
+++ b/themes/default/data/registry/packages/rancher2.yaml
@@ -2,10 +2,10 @@ name: rancher2
 title: Rancher 2
 description: A Pulumi package for creating and managing rancher2 resources.
 logo_url: ""
-updated_on: 1633360786
+updated_on: 1633366961
 publisher: Pulumi
 category: Infrastructure
 package_status: ga
-version: v3.2.0
+version: v3.3.0
 featured: false
 native: false

--- a/themes/default/data/registry/packages/random.yaml
+++ b/themes/default/data/registry/packages/random.yaml
@@ -2,7 +2,7 @@ name: random
 title: random
 description: A Pulumi package to safely use randomness in Pulumi programs.
 logo_url: ""
-updated_on: 1633360788
+updated_on: 1622118022
 publisher: Pulumi
 category: Utility
 package_status: ga

--- a/themes/default/data/registry/packages/rke.yaml
+++ b/themes/default/data/registry/packages/rke.yaml
@@ -2,7 +2,7 @@ name: rke
 title: Rancher RKE
 description: A Pulumi package for creating and managing rke cloud resources.
 logo_url: ""
-updated_on: 1633360790
+updated_on: 1621019180
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/signalfx.yaml
+++ b/themes/default/data/registry/packages/signalfx.yaml
@@ -2,7 +2,7 @@ name: signalfx
 title: SignalFx
 description: A Pulumi package for creating and managing SignalFx resources.
 logo_url: ""
-updated_on: 1633360792
+updated_on: 1632762891
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/snowflake.yaml
+++ b/themes/default/data/registry/packages/snowflake.yaml
@@ -2,7 +2,7 @@ name: snowflake
 title: Snowflake
 description: A Pulumi package for creating and managing snowflake cloud resources.
 logo_url: ""
-updated_on: 1633360794
+updated_on: 1632765197
 publisher: Pulumi
 category: Cloud
 package_status: public_preview

--- a/themes/default/data/registry/packages/splunk.yaml
+++ b/themes/default/data/registry/packages/splunk.yaml
@@ -2,7 +2,7 @@ name: splunk
 title: Splunk
 description: A Pulumi package for creating and managing splunk cloud resources.
 logo_url: ""
-updated_on: 1633360796
+updated_on: 1618855940
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/spotinst.yaml
+++ b/themes/default/data/registry/packages/spotinst.yaml
@@ -2,7 +2,7 @@ name: spotinst
 title: Spotinst
 description: A Pulumi package for creating and managing spotinst cloud resources.
 logo_url: ""
-updated_on: 1633360798
+updated_on: 1633348281
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/sumologic.yaml
+++ b/themes/default/data/registry/packages/sumologic.yaml
@@ -2,7 +2,7 @@ name: sumologic
 title: Sumo Logic
 description: A Pulumi package for creating and managing sumologic cloud resources.
 logo_url: ""
-updated_on: 1633360800
+updated_on: 1621593480
 publisher: Pulumi
 category: Monitoring
 package_status: public_preview

--- a/themes/default/data/registry/packages/tls.yaml
+++ b/themes/default/data/registry/packages/tls.yaml
@@ -2,7 +2,7 @@ name: tls
 title: TLS
 description: A Pulumi package to create TLS resources in Pulumi programs.
 logo_url: ""
-updated_on: 1633360802
+updated_on: 1618839216
 publisher: Pulumi
 category: Utility
 package_status: ga

--- a/themes/default/data/registry/packages/vault.yaml
+++ b/themes/default/data/registry/packages/vault.yaml
@@ -2,7 +2,7 @@ name: vault
 title: Vault
 description: A Pulumi package for creating and managing vault cloud resources.
 logo_url: ""
-updated_on: 1633360805
+updated_on: 1632754528
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/venafi.yaml
+++ b/themes/default/data/registry/packages/venafi.yaml
@@ -2,7 +2,7 @@ name: venafi
 title: Venafi
 description: A Pulumi package for creating and managing venafi cloud resources.
 logo_url: ""
-updated_on: 1633360808
+updated_on: 1632764588
 publisher: Pulumi
 category: Infrastructure
 package_status: ga

--- a/themes/default/data/registry/packages/vsphere.yaml
+++ b/themes/default/data/registry/packages/vsphere.yaml
@@ -2,7 +2,7 @@ name: vsphere
 title: vSphere
 description: A Pulumi package for creating vsphere resources
 logo_url: ""
-updated_on: 1633360811
+updated_on: 1626096955
 publisher: Pulumi
 category: Cloud
 package_status: ga

--- a/themes/default/data/registry/packages/wavefront.yaml
+++ b/themes/default/data/registry/packages/wavefront.yaml
@@ -2,7 +2,7 @@ name: wavefront
 title: Wavefront
 description: A Pulumi package for creating and managing wavefront cloud resources.
 logo_url: ""
-updated_on: 1633360813
+updated_on: 1618855708
 publisher: Pulumi
 category: Monitoring
 package_status: ga

--- a/themes/default/data/registry/packages/yandex.yaml
+++ b/themes/default/data/registry/packages/yandex.yaml
@@ -2,7 +2,7 @@ name: yandex
 title: Yandex
 description: A Pulumi package for creating and managing yandex cloud resources.
 logo_url: ""
-updated_on: 1633360815
+updated_on: 1633348338
 publisher: Pulumi
 category: Cloud
 package_status: public_preview


### PR DESCRIPTION
Most of the files (except for one) have a change just in the `updated_on` TS as I would expect.

Related to https://github.com/pulumi/docs/pull/6566.