### PR TITLE
Set up Registry repository for package contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/pulumi-package.md
+++ b/.github/ISSUE_TEMPLATE/pulumi-package.md
@@ -1,0 +1,14 @@
+---
+name: Publish or update a Pulumi Package
+about: Submit a new or updated Pulumi Package to Pulumi Registry
+title: '[Package] '
+labels: kind/package
+assignees: ''
+
+---
+
+<!-- Thanks for submitting a Pulumi Package! Just fill in the details below and we'll work with you to get your package published! -->
+
+- Package repository: 
+- Is this a new package or an update to an existing package: 
+- If you've already opened a PR with your package's content, paste the link here: 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-service/issues/7461

This PR adds an issue template (and probably a pull request template as well) to help community members and partners contribute packages to Pulumi Registry. 
