### PR TITLE
Add a GHA workflow file to auto-merge PRs opened through docs automation

### DIFF
--- a/.github/workflows/automerge-automation-prs.yml
+++ b/.github/workflows/automerge-automation-prs.yml
@@ -1,0 +1,39 @@
+jobs:
+  automerge:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: Automerge Workflow
+    runs-on: ubuntu-18.04
+    steps:
+      - if: env.GITHUB_TOKEN != null
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          MERGE_COMMIT_MESSAGE: pull-request-title
+          MERGE_FORKS: "false"
+          MERGE_LABELS: automation/merge
+          MERGE_METHOD: squash
+          MERGE_REMOVE_LABELS: automation/merge
+          MERGE_RETRIES: "30"
+          MERGE_RETRY_SLEEP: "60000"
+          UPDATE_LABELS: automation/update
+          UPDATE_METHOD: rebase
+        name: Automerge
+        uses: pascalgn/automerge-action@v0.13.1
+name: Automerge workflow
+"on":
+  check_suite:
+    types:
+      - completed
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  status: {}


### PR DESCRIPTION
Related to https://github.com/pulumi/pulumi-service/issues/7461.

This is a companion PR for https://github.com/pulumi/docs/pull/6575 that allows PRs opened in this repo for updating metadata files to be auto-merged.