### PR TITLE
Show active filters, allow de-selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211001184016-b02c0404fb7b // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20210927233147-6d9e62ba8825 // indirect
-	github.com/pulumi/theme v0.0.0-20211006171137-0e9b5887a766 // indirect
+	github.com/pulumi/theme v0.0.0-20211006180547-00ead37e9d9e // indirect
 )
 
 // The override is needed because this repo is currently private and module at themes/default

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211001184016-b02c0404fb7b h1:WFJwLQ3aFgyP9W2Dxctr6pq0pV92+in1vvzKDVaGU2E=
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211001184016-b02c0404fb7b/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
+<<<<<<< HEAD
 github.com/pulumi/theme v0.0.0-20211005194956-d75f730aad7c h1:BIBoy7jmqMYStiGCj4pkxgCt/TeqW+7x+TwBvDOgtbY=
 github.com/pulumi/theme v0.0.0-20211005194956-d75f730aad7c/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
 github.com/pulumi/theme v0.0.0-20211006171137-0e9b5887a766 h1:qa0IqRlSKv0nDBpR2Uhu7AC8zMSt2sr74qjn0ylUNS0=
 github.com/pulumi/theme v0.0.0-20211006171137-0e9b5887a766/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+=======
+github.com/pulumi/theme v0.0.0-20211001214832-2c758d993730/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211005232432-80e069d91f30 h1:OtoKkrACGd725JsR2LZYQilqE3MMyfQuZsrdNCaFMCE=
+github.com/pulumi/theme v0.0.0-20211005232432-80e069d91f30/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211005233916-60697d6874e8/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211005235454-0695efb176b6 h1:Gu4v3mhHXIbaosUmqK3XW8hoPd/S7FJbBQNj5TQOeuI=
+github.com/pulumi/theme v0.0.0-20211005235454-0695efb176b6/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211006005534-60048caa7483/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+>>>>>>> d89ac14 (Show active filters, allow de-selection)

--- a/themes/default/layouts/partials/registry/featured-package.html
+++ b/themes/default/layouts/partials/registry/featured-package.html
@@ -8,8 +8,8 @@
                 <a href="{{ $href }}" class="inline-block">
                     {{ partial "registry/package/icon.html" .package }}
                 </a>
-                <h3 class="mt-6 mb-4 text-gray-900">
-                    <a href="{{ $href }}" title="{{ .package.title }}" class="whitespace-nowrap hover:text-blue-600 hover:underline">
+                <h3 class="mt-6 mb-4 text-gray-900 text-center">
+                    <a href="{{ $href }}" title="{{ .package.title }}" class="hover:text-blue-600 hover:underline">
                         {{ .package.title }}
                     </a>
                 </h3>

--- a/themes/default/layouts/partials/registry/package.html
+++ b/themes/default/layouts/partials/registry/package.html
@@ -1,21 +1,31 @@
 {{ $packageName := .package.name }}
 {{ $href := printf "/registry/packages/%s" $packageName }}
 
-<div class="package my-4 lg:w-1/2 px-4">
+{{ $packageCategory := lower .package.category }}
+{{ $packageCategoryName := .package.category }}
+
+{{ $packageType := "provider" }}
+{{ $packageTypeName := "Provider" }}
+
+{{ if .package.native }}
+    {{ $packageType = "native-provider" }}
+    {{ $packageTypeName = "Native Provider" }}
+{{ end }}
+
+{{ if .package.component }}
+    {{ $packageType = "component" }}
+    {{ $packageTypeName := "Component" }}
+{{ end }}
+
+<div class="package my-4 w-full lg:w-1/2 px-4">
     <div class="rounded-xl shadow-lg border border-gray-200 h-full relative">
-        <div class="p-8"
-            data-provider="{{ if ne .package.component true }}true{{ else }}false{{ end }}"
-            data-native="{{ if eq .package.native true }}true{{ else }}false{{ end }}"
-            data-component="{{ if eq .package.component true }}true{{ else }}false{{ end }}"
-            data-type="{{ if .package.component }}component{{ else if .package.native }}native-provider{{ else }}provider{{ end }}"
-            data-category="{{ lower .package.category }}"
-            >
+        <div class="p-8" data-type="{{ $packageType }}" data-category="{{ $packageCategory }}">
             <div class="flex flex-wrap">
                 <div class="flex w-full items-center justify-between mb-4">
-                    <a href="{{ $href }}">
+                    <a href="{{ $href }}" class="md:w-1/2">
                         {{ partial "registry/package/icon.html" .package }}
                     </a>
-                    <a href="{{ $href }}" class="hidden md:block whitespace-nowrap ml-4 text-sm text-blue-600 font-semibold hover:underline">
+                    <a href="{{ $href }}" class="hidden md:block whitespace-nowrap ml-4 text-base text-blue-600 font-semibold hover:underline">
                         View package
                     </a>
                 </div>
@@ -60,16 +70,8 @@
 
                     <!-- Tags are anchored to the bottom of the card. -->
                     <ul class="package-tags mt-2 absolute bottom-8">
-                        <li class="package-tag-type">
-                            {{ if .package.native }}
-                                Native Provider
-                            {{ else if .package.component }}
-                                Component
-                            {{ else }}
-                                Provider
-                            {{ end }}
-                        </li>
-                        <li class="package-tag-category">{{ .package.category }}</li>
+                        <li class="package-tag-type" data-filter-group="type" data-filter-value="{{ $packageType }}">{{ $packageTypeName }}</li>
+                        <li class="package-tag-category" data-filter-group="category" data-filter-value="{{ $packageCategory }}">{{ $packageCategoryName }}</li>
                     </ul>
                 </div>
             </div>

--- a/themes/default/layouts/registry/list.html
+++ b/themes/default/layouts/registry/list.html
@@ -36,35 +36,48 @@
         </section>
 
         <section class="all-packages my-8">
-            <div class="mt-12 mb-2 px-4  relative z-10">
+            <div class="mt-12 mb-2 px-4 relative z-10">
                 <h4 class="text-lg">Filters</h4>
-                <pulumi-filter-select class="flex">
+                <div class="flex flex-col md:flex-row md:items-start">
+                    <pulumi-filter-select>
 
-                    <!-- Package-type options -->
-                    <pulumi-filter-select-option-group name="type">
-                        <div class="toggle" slot="toggle">Type</div>
-                        <div class="options">
-                            <pulumi-filter-select-option value="native">Native Provider</pulumi-option>
-                            <pulumi-filter-select-option value="provider">Provider</pulumi-option>
-                            <pulumi-filter-select-option value="component">Component</pulumi-option>
-                        </div>
-                    </pulumi-filter-select-option-group>
+                        <!-- Package-type options -->
+                        <pulumi-filter-select-option-group name="type">
+                            <div class="toggle" slot="toggle">Type</div>
+                            <div class="options">
+                                <pulumi-filter-select-option value="native-provider" label="Native Provider">Native Provider</pulumi-option>
+                                <pulumi-filter-select-option value="provider" label="Provider">Provider</pulumi-option>
+                                <pulumi-filter-select-option value="component" label="Component">Component</pulumi-option>
+                            </div>
+                        </pulumi-filter-select-option-group>
 
-                    <!-- Use-case options -->
-                    <pulumi-filter-select-option-group name="category" class="mx-1 md:mx-4">
-                        <div class="toggle" slot="toggle">Use Case</div>
-                        <div class="options">
-                            <pulumi-filter-select-option value="cloud">Cloud</pulumi-option>
-                            <pulumi-filter-select-option value="database">Database</pulumi-option>
-                            <pulumi-filter-select-option value="infrastructure">Infrastructure</pulumi-option>
-                            <pulumi-filter-select-option value="monitoring">Monitoring</pulumi-option>
-                            <pulumi-filter-select-option value="network">Network</pulumi-option>
-                            <pulumi-filter-select-option value="utility">Utility</pulumi-option>
-                            <pulumi-filter-select-option value="version control system">Version control</pulumi-option>
-                        </div>
-                    </pulumi-filter-select-option-group>
+                        <!-- Use-case options -->
+                        <pulumi-filter-select-option-group name="category" class="mx-1 md:mx-4">
+                            <div class="toggle" slot="toggle">Use Case</div>
+                            <div class="options">
+                                <pulumi-filter-select-option value="cloud" label="Cloud">Cloud</pulumi-option>
+                                <pulumi-filter-select-option value="database" label="Database">Database</pulumi-option>
+                                <pulumi-filter-select-option value="infrastructure" label="Infrastructure">Infrastructure</pulumi-option>
+                                <pulumi-filter-select-option value="monitoring" label="Monitoring">Monitoring</pulumi-option>
+                                <pulumi-filter-select-option value="network" label="Network">Network</pulumi-option>
+                                <pulumi-filter-select-option value="utility" label="Utility">Utility</pulumi-option>
+                                <pulumi-filter-select-option value="version control system" label="Version Control">Version Control</pulumi-option>
+                            </div>
+                        </pulumi-filter-select-option-group>
 
-                </pulumi-filter-select>
+                    </pulumi-filter-select>
+
+                    <!-- The list of active filters. -->
+                    <ul class="package-tags active-tags"></ul>
+
+                    <!-- The template used for displaying active filters. -->
+                    <template id="active-tag-template">
+                        <li>
+                            <span></span>
+                            <button class="ml-2 text-base hover:text-gray-900" title="Clear filter">&times;</a>
+                        </li>
+                    </template>
+                </div>
             </div>
 
             <h2 class="px-4 inline-flex items-center">


### PR DESCRIPTION
Adds functionality to show the currently selected filters and allow them to be cleared individually. 

https://user-images.githubusercontent.com/274700/136124318-a663eca9-3042-4cc2-a107-9f2b4ad83ae8.mov

This doesn't _quite_ match the latest design in that the filters are displayed alongside the select menus (rather than below them, by group), but I figured better to get this in sooner than later, and that it'd be fine to come back to that grouping in a follow-up.

Closes #18.