### PR TITLE
Fix left-hand alignment and column width across package templates

### DIFF
--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -32,22 +32,22 @@
 
     {{ with .GetPage (path.Join "registry/packages" $packageName) }}
         <div class="lg:flex mb-8">
-                <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                    <a class="pb-2" href="{{ relref . .File.Dir }}">Overview</a>
-                </div>
-                <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                    <a class="pb-2" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">Installation & Configuration</a>
-                </div>
-                <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                    <a class="pb-2" href="{{ relref . (path.Join .File.Dir "api-docs") }}">API Docs</a>
-                </div>
-                <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                    <a class="pb-2" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
-                        How-to Guides
-                        {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
-                        </span>
-                    </a>
-                </div>
+            <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
+                <a class="pb-2" href="{{ relref . .File.Dir }}">Overview</a>
+            </div>
+            <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
+                <a class="pb-2" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">Installation & Configuration</a>
+            </div>
+            <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
+                <a class="pb-2" href="{{ relref . (path.Join .File.Dir "api-docs") }}">API Docs</a>
+            </div>
+            <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
+                <a class="pb-2" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
+                    How-to Guides
+                    {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
+                    </span>
+                </a>
+            </div>
         </div>
     {{ end }}
 

--- a/themes/default/layouts/registry/api.html
+++ b/themes/default/layouts/registry/api.html
@@ -1,32 +1,31 @@
 
 {{ define "main" }}
-<div class="container mx-auto px-4 py-8 mt-2">
-    {{ partial "registry/package/header.html" . }}
+    <div class="container mx-auto px-4 py-8 mt-2">
+        {{ partial "registry/package/header.html" . }}
 
-    <div class="lg:flex">
+        <div class="lg:flex">
+            <div class="lg:w-6/12">
+                {{ .Content }}
+            </div>
 
-        <div class="lg:w-6/12 lg:px-4">
-            {{ .Content }}
-        </div>
-
-        <div class="lg:w-3/12 lg:pl-8">
-            <div class="sticky-sidebar">
-                <div class="ml-2 hidden lg:block">
-                    {{ partial "registry/package/right-nav.html" . }}
+            <div class="lg:w-3/12 lg:pl-8">
+                <div class="sticky-sidebar">
+                    <div class="ml-2 hidden lg:block">
+                        {{ partial "registry/package/right-nav.html" . }}
+                    </div>
                 </div>
             </div>
-        </div>
 
-        <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:pt-0 lg:mt-0">
-            <div class="sticky-sidebar left-nav">
-                <div class="lg:mt-1 mb-6">
-                    {{ partial "registry/left-nav.html" . }}
-                </div>
-                <div>
-                    {{ partial "docs/toc.html" . }}
+            <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:pt-0 lg:mt-0">
+                <div class="sticky-sidebar left-nav">
+                    <div class="lg:mt-1 mb-6">
+                        {{ partial "registry/left-nav.html" . }}
+                    </div>
+                    <div>
+                        {{ partial "docs/toc.html" . }}
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 {{ end }}

--- a/themes/default/layouts/registry/how-to-guide.html
+++ b/themes/default/layouts/registry/how-to-guide.html
@@ -3,7 +3,7 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-9/12 lg:px-4">
+            <div class="lg:w-9/12">
                 {{ .Content }}
             </div>
 

--- a/themes/default/layouts/registry/how-to.html
+++ b/themes/default/layouts/registry/how-to.html
@@ -3,7 +3,7 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-9/12 lg:px-4">
+            <div class="lg:w-9/12">
                 {{ if (eq (len .Pages) 0) }}
                     There are no guides yet for this package.
                 {{ else }}

--- a/themes/default/layouts/registry/installation.html
+++ b/themes/default/layouts/registry/installation.html
@@ -3,7 +3,7 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-9/12 lg:px-4">        
+            <div class="lg:w-9/12">
                 {{ .Content }}
             </div>
 

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -3,7 +3,7 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-12/12 lg:px-4">
+            <div class="lg:w-9/12">
                 {{ .Content }}
             </div>
         </div>


### PR DESCRIPTION
E.g.,

![image](https://user-images.githubusercontent.com/274700/136276651-45352189-af37-407d-b2dc-4dfc9e53201d.png)

Fixes #72.