### PR TITLE
Package header adjustments

### DIFF
--- a/themes/default/layouts/partials/count-pill.html
+++ b/themes/default/layouts/partials/count-pill.html
@@ -1,3 +1,3 @@
 {{ $textColor := cond .selected "text-white" "text-violet-600" }}
 {{ $backgroundColor := cond .selected "bg-violet-600" "" }}
-<span class="pl-3 pr-3 ml-1 rounded-full border-2 border-violet-600 {{ $textColor }} {{ $backgroundColor }}">{{ .count }}</span>
+<span class="px-2 ml-1 rounded-full text-sm border border-violet-600 {{ $textColor }} {{ $backgroundColor }}">{{ .count }}</span>

--- a/themes/default/layouts/partials/registry/featured-package.html
+++ b/themes/default/layouts/partials/registry/featured-package.html
@@ -2,24 +2,26 @@
 {{ $href := printf "/registry/packages/%s" $packageName }}
 
 <div class="my-4 w-full md:w-1/2 lg:w-1/4 px-4">
-    <div class="rounded-xl shadow-lg border border-gray-200 h-full relative">
-        <div class="p-8">
-            <div class="flex flex-col items-center">
-                <a href="{{ $href }}" class="inline-block">
+    <div class="rounded-xl shadow-lg border border-gray-200 h-full">
+        <div class="p-8 h-full">
+            <div class="flex flex-col items-center h-full">
+                <a href="{{ $href }}" class="flex-none inline-block ">
                     {{ partial "registry/package/icon.html" .package }}
                 </a>
-                <h3 class="mt-6 mb-4 text-gray-900 text-center">
+                <h3 class="flex-none mt-6 mb-4 text-gray-900 text-center">
                     <a href="{{ $href }}" title="{{ .package.title }}" class="hover:text-blue-600 hover:underline">
                         {{ .package.title }}
                     </a>
                 </h3>
-                <a href="{{ $href }}" class="hidden md:block whitespace-nowrap mb-4 text-base text-blue-600 font-semibold hover:underline">
-                    View package
-                </a>
-                <div class="text-sm font-display text-gray-800 leading-relaxed">
-                    <span title="Published on {{ time .package.updated_on | time.Format "Monday, Jan 2, 2006" }}">
-                        {{ .package.version }}
-                    </span>
+                <div class="flex-grow flex flex-col items-center justify-end">
+                    <a href="{{ $href }}" class="hidden md:block whitespace-nowrap mb-4 text-base text-blue-600 font-semibold hover:underline">
+                        View package
+                    </a>
+                    <div class="text-sm font-display text-gray-800 leading-relaxed">
+                        <span title="Published on {{ time .package.updated_on | time.Format "Monday, Jan 2, 2006" }}">
+                            {{ .package.version }}
+                        </span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -2,7 +2,7 @@
 {{ $packageName := index $directories 2 }}
 {{ $packageSection := index (split (index $directories 3) ".") 0 }}
 
-{{ $packageHome := path.Join "registry/" $packageName }}
+{{ $packageHome := path.Join "registry/packages" $packageName }}
 {{ $tutorialsPath := printf "%v" (delimit (slice "/registry/packages/" $packageName "/how-to-guides") "") }}
 
 {{ $guidesCount := 0 }}
@@ -11,13 +11,19 @@
 {{ end }}
 
 <div class="container">
+    <div class="mb-8 text-blue-600 font-display">
+        <span>&larr;</span>
+        <a href="{{ relref . "/registry" }}" class="hover:underline">All packages</a>
+    </div>
+
     {{ with (index $.Site.Data.registry.packages ($packageName)) }}
-        <div class="lg:flex mb-2 pb-4">
+        <div class="lg:flex mb-8">
             {{ partial "registry/package/icon.html" . }}
         </div>
     {{ end }}
+
     <div class="lg:flex mb-2">
-        <h3>{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}</h3>
+        <h2 class="text-4xl">{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}</h2>
     </div>
 
     {{ with (index $.Site.Data.registry.packages ($packageName)) }}
@@ -26,12 +32,16 @@
         </div>
     {{ end }}
 
-    <div class="lg:flex mb-8">
-        <a class="text-blue-600 underline" href="https://github.com/pulumi/pulumi-{{ $packageName }}">Source code</a>
+    <div class="lg:flex items-center mb-8">
+        <i class="fab fa-github text-lg"></i>
+        <span class="text-blue-600 flex flex-wrap items-center">
+            <a class="text-blue-600 underline font-display ml-2 mr-1.5" href="https://github.com/pulumi/pulumi-{{ $packageName }}" target="_blank" rel="noopener noreferrer">Source code</a>
+            <i class="fas fa-external-link-alt text-sm"></i>
+        </span>
     </div>
 
     {{ with .GetPage (path.Join "registry/packages" $packageName) }}
-        <div class="lg:flex mb-8">
+        <div class="lg:flex mb-8 font-display text-lg">
             <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
                 <a class="pb-2" href="{{ relref . .File.Dir }}">Overview</a>
             </div>
@@ -44,7 +54,9 @@
             <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
                 <a class="pb-2" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
                     How-to Guides
-                    {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
+                    {{ if gt $guidesCount 0 }}
+                        {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
+                    {{ end }}
                     </span>
                 </a>
             </div>

--- a/themes/default/layouts/registry/api.html
+++ b/themes/default/layouts/registry/api.html
@@ -1,6 +1,6 @@
 
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container mx-auto px-4 pb-8 mt-2">
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">

--- a/themes/default/layouts/registry/how-to-guide.html
+++ b/themes/default/layouts/registry/how-to-guide.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container mx-auto px-4 pb-8 mt-2">
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">

--- a/themes/default/layouts/registry/how-to.html
+++ b/themes/default/layouts/registry/how-to.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container mx-auto px-4 pb-8 mt-2">
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">

--- a/themes/default/layouts/registry/installation.html
+++ b/themes/default/layouts/registry/installation.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container mx-auto px-4 pb-8 mt-2">
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4 py-8 mt-2">
+    <div class="container mx-auto px-4 pb-8 mt-2">
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">


### PR DESCRIPTION
Fixes #53.
Fixes #91.

Also hides the count pill when there the number of how-to guides is zero.

This does **not** include the publish date/time as shown in the header, though -- @djgrove has a separate PR incoming for that.