### PR TITLE
Center the how-to guides count pill

### DIFF
--- a/themes/default/layouts/partials/count-pill.html
+++ b/themes/default/layouts/partials/count-pill.html
@@ -1,3 +1,3 @@
 {{ $textColor := cond .selected "text-white" "text-violet-600" }}
 {{ $backgroundColor := cond .selected "bg-violet-600" "" }}
-<span class="px-2 ml-1 rounded-full text-sm border border-violet-600 {{ $textColor }} {{ $backgroundColor }}">{{ .count }}</span>
+<span class="px-2 ml-2 rounded-full text-sm border border-violet-600 {{ $textColor }} {{ $backgroundColor }}">{{ .count }}</span>

--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -43,21 +43,20 @@
     {{ with .GetPage (path.Join "registry/packages" $packageName) }}
         <div class="lg:flex mb-8 font-display text-lg">
             <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                <a class="pb-2" href="{{ relref . .File.Dir }}">Overview</a>
+                <a class="flex items-center" href="{{ relref . .File.Dir }}">Overview</a>
             </div>
             <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                <a class="pb-2" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">Installation & Configuration</a>
+                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">Installation & Configuration</a>
             </div>
             <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                <a class="pb-2" href="{{ relref . (path.Join .File.Dir "api-docs") }}">API Docs</a>
+                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "api-docs") }}">API Docs</a>
             </div>
             <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                <a class="pb-2" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
-                    How-to Guides
+                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
+                    <span>How-to Guides</span>
                     {{ if gt $guidesCount 0 }}
                         {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
                     {{ end }}
-                    </span>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Little thing that's been bugging me visually. This just vertically-aligns the pill with the text to the left of it (it currently sits a bit too low): 

Before:

![image](https://user-images.githubusercontent.com/274700/136471842-3d399704-0301-4343-aadd-5b3d81b402bf.png)

After:

![image](https://user-images.githubusercontent.com/274700/136471980-b42d9af8-d4bd-4b4c-945f-69de8eaedfdd.png)
