### PR TITLE
Use container-2xl for Registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/pulumi/registry
 go 1.16
 
 require (
-	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211001184016-b02c0404fb7b // indirect
+	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211006183715-8bfe690c3b3f // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20210927233147-6d9e62ba8825 // indirect
-	github.com/pulumi/theme v0.0.0-20211007233216-d9dca8e6fd47 // indirect
+	github.com/pulumi/theme v0.0.0-20211008021741-e6cdb736b340 // indirect
 )
 
 // The override is needed because this repo is currently private and module at themes/default

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211001184016-b02c0404fb7b h1:WFJwLQ3aFgyP9W2Dxctr6pq0pV92+in1vvzKDVaGU2E=
-github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211001184016-b02c0404fb7b/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
-github.com/pulumi/theme v0.0.0-20211007233216-d9dca8e6fd47 h1:KwN9fl2f7k7pwwjxU8L7HbFpKWVKcc/Rs3By1JKA42E=
-github.com/pulumi/theme v0.0.0-20211007233216-d9dca8e6fd47/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211006183715-8bfe690c3b3f h1:4vD6liMlq7p5E4mv4xera1UUgBic0YBG5PUntGZFeNE=
+github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211006183715-8bfe690c3b3f/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
+github.com/pulumi/theme v0.0.0-20211007235906-75c3a3dff333 h1:OrpUEEVdxQ+uTUpV2McQwRo5uIvaiCtp1TbZQ+mvXHk=
+github.com/pulumi/theme v0.0.0-20211007235906-75c3a3dff333/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211008021741-e6cdb736b340 h1:pj4efD8AGV2OXqEUop9uDd4ZsBhTwdid4IudIe5mxNk=
+github.com/pulumi/theme v0.0.0-20211008021741-e6cdb736b340/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=

--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -66,7 +66,7 @@
         <div class="dot-background no-animate"></div>
     </div>
     <div class="dot-overlay"></div>
-    <div class="registry-hero-title container mx-auto px-4">
+    <div class="registry-hero-title container mx-auto w-full px-4">
         <a a href="{{ relref . " /registry" }}">
             <i class="fas fa-archive title-icon"></i>
         </a>

--- a/themes/default/layouts/registry/how-to.html
+++ b/themes/default/layouts/registry/how-to.html
@@ -3,7 +3,7 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-9/12">
+            <div class="lg:w-8/12">
                 {{ if (eq (len .Pages) 0) }}
                     There are no guides yet for this package.
                 {{ else }}
@@ -30,6 +30,8 @@
                     </pulumi-choosable>
                 {{ end }}
             </div>
+            <div class="lg:w-1/12"></div>
+            <div class="lg:w-3/12"></div>
         </div>
     </div>
 {{ end }}

--- a/themes/default/layouts/registry/installation.html
+++ b/themes/default/layouts/registry/installation.html
@@ -3,10 +3,10 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-9/12">
+            <div class="lg:w-8/12">
                 {{ .Content }}
             </div>
-
+            <div class="lg:w-1/12"></div>
             <div class="lg:w-3/12 lg:pl-8">
                 <div class="sticky-sidebar">
                     <div class="ml-2 hidden lg:block">

--- a/themes/default/layouts/registry/list.html
+++ b/themes/default/layouts/registry/list.html
@@ -1,12 +1,4 @@
 {{ define "main" }}
-    <div class="container mx-auto px-4">
-        {{ if and (.Params.h1) (not .Params.notitle) }}
-            <h1>{{ .Params.h1 }}</h1>
-        {{ else if and (ne .Title "") (not .Params.notitle) }}
-            <h1>{{ .Title }}</h1>
-        {{ end }}
-    </div>
-
     {{ $allGetStarted := $.Site.Data.registry.getstarted }}
     {{ $allPackages := $.Site.Data.registry.packages }}
 

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -3,10 +3,10 @@
         {{ partial "registry/package/header.html" . }}
 
         <div class="lg:flex">
-            <div class="lg:w-9/12">
+            <div class="lg:w-8/12">
                 {{ .Content }}
             </div>
-
+            <div class="lg:w-1/12"></div>
             <div class="lg:w-3/12 lg:pl-8">
                 <div class="sticky-sidebar">
                     <div class="ml-2 hidden lg:block">


### PR DESCRIPTION
Updates Registry layouts to use the same three-column layout (3 + 6 + 3) we use for the Docs. 

For pages with a left-hand nav (i.e., pretty much only the API Docs tab), it gives 3 columns to the left nav, 6 to the main content area, and 3 to the right-hand nav. This is the same layout as we use in the Docs, so navigating between these two sections of the site should feel pretty seamless.

For pages _without_ a left-hand nav, to keep line lengths under control, I gave 9 columns to the left side as a whole, but kept the main content section to 8, leaving one empty to keep the 3-column right-nav positioned consistently -- so instead of 3 + 6 + 3, it's more like 8 + 1 + 3. Here's how it looks with docs and tutorials in place:

https://user-images.githubusercontent.com/274700/136479201-ff75ca54-008a-4a68-ad0a-db7a01097792.mov



