### PR TITLE
Update package.html

### DIFF
--- a/themes/default/layouts/partials/registry/package.html
+++ b/themes/default/layouts/partials/registry/package.html
@@ -14,7 +14,7 @@
 
 {{ if .package.component }}
     {{ $packageType = "component" }}
-    {{ $packageTypeName := "Component" }}
+    {{ $packageTypeName = "Component" }}
 {{ end }}
 
 <div class="package my-4 w-full lg:w-1/2 px-4">


### PR DESCRIPTION
This causes components to be tagged with a display name of `Provider` instead of `Component` as seen with EKS:

<img width="637" alt="component-with-provider-label" src="https://user-images.githubusercontent.com/1466314/136591352-695c83eb-d294-4a21-823d-8c9f1c93d590.png">