### PR TITLE
Fix closing tags on a few elements in the index page code

### DIFF
--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -67,10 +67,10 @@
     </div>
     <div class="dot-overlay"></div>
     <div class="registry-hero-title container mx-auto w-full px-4">
-        <a a href="{{ relref . " /registry" }}">
+        <a href="{{ relref . "/registry" }}">
             <i class="fas fa-archive title-icon"></i>
         </a>
-        <a a href="{{ relref . "/registry" }}">
+        <a href="{{ relref . "/registry" }}">
             <h1 class="title-text-content">Pulumi Registry</h1>
         </a>
     </div>

--- a/themes/default/layouts/registry/api.html
+++ b/themes/default/layouts/registry/api.html
@@ -13,9 +13,9 @@
                 <!--Don't show the title in the top-most index page.-->
                 {{ if not (in .Page.File "api-docs/_index.md") }}
                     {{ if and (.Params.h1) (not .Params.notitle) }}
-                        <h1 class="-mt-2 mb-4">{{ .Params.h1 }}</h1>
+                        <h1 class="-mt-2 mb-8">{{ .Params.h1 }}</h1>
                     {{ else if and (ne .Title "") (not .Params.notitle) }}
-                        <h1 class="-mt-2 mb-4">{{ .Title }}</h1>
+                        <h1 class="-mt-2 mb-8">{{ .Title }}</h1>
                     {{ end }}
                 {{ end }}
                 <section data-swiftype-index="true" class="lg:-mt-2">

--- a/themes/default/layouts/registry/list.html
+++ b/themes/default/layouts/registry/list.html
@@ -31,9 +31,9 @@
                         <pulumi-filter-select-option-group name="type">
                             <div class="toggle" slot="toggle">Type</div>
                             <div class="options">
-                                <pulumi-filter-select-option value="native-provider" label="Native Provider">Native Provider</pulumi-option>
-                                <pulumi-filter-select-option value="provider" label="Provider">Provider</pulumi-option>
-                                <pulumi-filter-select-option value="component" label="Component">Component</pulumi-option>
+                                <pulumi-filter-select-option value="native-provider" label="Native Provider">Native Provider</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="provider" label="Provider">Provider</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="component" label="Component">Component</pulumi-filter-select-option>
                             </div>
                         </pulumi-filter-select-option-group>
 
@@ -41,13 +41,13 @@
                         <pulumi-filter-select-option-group name="category" class="mx-1 md:mx-4">
                             <div class="toggle" slot="toggle">Use Case</div>
                             <div class="options">
-                                <pulumi-filter-select-option value="cloud" label="Cloud">Cloud</pulumi-option>
-                                <pulumi-filter-select-option value="database" label="Database">Database</pulumi-option>
-                                <pulumi-filter-select-option value="infrastructure" label="Infrastructure">Infrastructure</pulumi-option>
-                                <pulumi-filter-select-option value="monitoring" label="Monitoring">Monitoring</pulumi-option>
-                                <pulumi-filter-select-option value="network" label="Network">Network</pulumi-option>
-                                <pulumi-filter-select-option value="utility" label="Utility">Utility</pulumi-option>
-                                <pulumi-filter-select-option value="version control system" label="Version Control">Version Control</pulumi-option>
+                                <pulumi-filter-select-option value="cloud" label="Cloud">Cloud</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="database" label="Database">Database</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="infrastructure" label="Infrastructure">Infrastructure</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="monitoring" label="Monitoring">Monitoring</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="network" label="Network">Network</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="utility" label="Utility">Utility</pulumi-filter-select-option>
+                                <pulumi-filter-select-option value="version control system" label="Version Control">Version Control</pulumi-filter-select-option>
                             </div>
                         </pulumi-filter-select-option-group>
 
@@ -60,7 +60,7 @@
                     <template id="active-tag-template">
                         <li>
                             <span></span>
-                            <button class="ml-2 text-base hover:text-gray-900" title="Clear filter">&times;</a>
+                            <button class="ml-2 text-base hover:text-gray-900" title="Clear filter">&times;</button>
                         </li>
                     </template>
                 </div>


### PR DESCRIPTION
Looks like the weird click behavior was because of incorrect closing tags. So the element was swallowing other elements in its default slot. That caused every checkbox to include all the other checkboxes below it. I remember seeing a change to component's tag names which is likely when this crept-in. Maybe I am misremembering the change I am thinking of...Either way, it's fixed with this PR. I also noticed a few other issues that I fixed.

Also, adjusted the bottom-margin for breadcrumb in API docs to 2rem. (Fixes #125)