### PR TITLE
Fix source-code wrap, filter-tag shift, date formatting

### DIFF
--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -27,12 +27,12 @@
     </div>
 
     {{ with (index $.Site.Data.registry.packages ($packageName)) }}
-        <div class="lg:flex mb-4">
-            {{ .version }} published on {{ ((time .updated_on).Format "Mon Jan 2 2006") }} by {{ .publisher }}
+        <div class="lg:flex mb-4 font-display">
+            {{ .version }} published on {{ ((time .updated_on).Format "Monday, Jan 2, 2006") }} by {{ .publisher }}
         </div>
     {{ end }}
 
-    <div class="lg:flex items-center mb-8">
+    <div class="flex items-center mb-8">
         <i class="fab fa-github text-lg"></i>
         <span class="text-blue-600 flex flex-wrap items-center">
             <a class="text-blue-600 underline font-display ml-2 mr-1.5" href="https://github.com/pulumi/pulumi-{{ $packageName }}" target="_blank" rel="noopener noreferrer">Source code</a>

--- a/themes/default/layouts/registry/list.html
+++ b/themes/default/layouts/registry/list.html
@@ -25,7 +25,7 @@
             <div class="mt-12 mb-2 px-4 relative z-10">
                 <h4 class="text-lg">Filters</h4>
                 <div class="flex flex-col md:flex-row md:items-start">
-                    <pulumi-filter-select>
+                    <pulumi-filter-select class="mb-2">
 
                         <!-- Package-type options -->
                         <pulumi-filter-select-option-group name="type">


### PR DESCRIPTION
Fixes #123 (downward shift)
Fixes #122 (wrapping source-code thing)
Closes #53 (date formatting in package headers)

https://user-images.githubusercontent.com/274700/136634937-585647c4-85e6-4195-8979-d86f5b6872e5.mov



