### PR TITLE
Fix what's visible in the nav at intermediate screen sizes

### DIFF
--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -2,10 +2,10 @@
     <div class="top-nav-container lg:container lg:px-4 text-white">
         <div data-track="header-pulumi-logo" class="logo-nav-button" aria-haspopup="true" aria-controls="logo-nav-menu">
             <img class="h-6" src="/images/logo/logo-on-black.svg" alt="Pulumi logo">
-            <i class="fa fa-chevron-down ml-4 pr-1 hidden md:block"></i>
-            <div class="sm:hidden flex-1"></div>
-            <i class="sm:hidden fa fa-bars text-white text-2xl mobile-menu-toggle-icon"></i>
-            <i class="sm:hidden hidden fa fa-times text-white text-2xl mobile-menu-toggle-icon"></i>
+            <i class="fa fa-chevron-down ml-4 pr-1 hidden lg:block"></i>
+            <div class="flex-1"></div>
+            <i class="lg:hidden fa fa-bars text-white text-2xl mobile-menu-toggle-icon"></i>
+            <i class="lg:hidden hidden fa fa-times text-white text-2xl mobile-menu-toggle-icon"></i>
         </div>
         <ul id="logo-nav-menu" role="menu" class="logo-nav-menu hidden">
             <li role="none"><a role="menuitem" href="/">Pulumi Home</a></li>


### PR DESCRIPTION
This doesn't _technically_ fix what's called out in #55 in that the bar itself is still tappable -- and I actually think that's okay, on mobile. What made this a bit weird was that between small and large sizes, you'd see the caret and no hamburger, or sometimes not even the caret. So this change just makes the registry logo and hamburger icons appear at the same breakpoints as the rest of the site. 

Before:

https://user-images.githubusercontent.com/274700/136856077-0d1ed8e5-a85e-4a9c-a69c-7dae90edee06.mov

After:

https://user-images.githubusercontent.com/274700/136856098-679964ba-47a6-4550-80c0-d73c8c5342f0.mov

It's worth noting that the behavior of the mobile nav in the registry and the behavior of the mobile nav on the rest of the website would still be inconsistent, even if we had made the area between the logo and the icon non-interactive for this menu:

* Tapping the logo in the registry mobile nav would open a menu, whereas tapping the logo in the non-registry menu would send you to the home page.
* Tapping the area between the logo and the hamburger icon in the registry mobile nav would do nothing, whereas tapping the same area in the non-registry menu would send you to the homepage.
* The two menus would still be left with differing content.

So rather than refactor _this one_ menu to get exactly the behavior we want, I'd rather we made them both more consistent in the same pass. So I'll file a follow-up issue to handle that post-release.

Second-to-last thing-to-do in #55.
   