### PR TITLE
Intermediate fix to make the tabs more mobile-friendly

### DIFF
--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -41,19 +41,26 @@
     </div>
 
     {{ with .GetPage (path.Join "registry/packages" $packageName) }}
-        <div class="lg:flex mb-8 font-display text-lg">
-            <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
+        <div class="flex mb-8 font-display text-base md:text-lg">
+            <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2">
                 <a class="flex items-center" href="{{ relref . .File.Dir }}">Overview</a>
             </div>
-            <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">Installation & Configuration</a>
+            <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 md:mx-4">
+                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">
+                    <span class="md:hidden">Install</span>
+                    <span class="hidden md:block">Installation &amp; Configuration</span>
+                </a>
             </div>
-            <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
-                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "api-docs") }}">API Docs</a>
+            <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 md:mx-4">
+                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "api-docs") }}">
+                    <span class="md:hidden">API</span>
+                    <span class="hidden md:block">API Docs</span>
+                </a>
             </div>
-            <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 pl-2 pr-2 mr-8">
+            <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2">
                 <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
-                    <span>How-to Guides</span>
+                    <span class="md:hidden">Guides</span>
+                    <span class="hidden md:block">How-to Guides</span>
                     {{ if gt $guidesCount 0 }}
                         {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
                     {{ end }}


### PR DESCRIPTION
Occurred to me that for now, we could just do something like what we do in the language chooser, and reduce the horizontal real-estate required by the tabs:

https://user-images.githubusercontent.com/274700/136858729-2c145256-cd70-47df-82f8-649d8c24b349.mov

All this does is tweake the tab labels a bit (to shorten them) and tighten up the horizontal spacing on smaller screens, while we ponder ways to make our tabs more convertible/mobile-friendly in general.

