### PR TITLE
Remove language from how-to titles

### DIFF
--- a/themes/default/layouts/partials/registry/packages/how-to-language-index.html
+++ b/themes/default/layouts/partials/registry/packages/how-to-language-index.html
@@ -1,6 +1,6 @@
 {{ range where .package.Pages "Params.language" .language }}
     <div class="pb-4">
-        <a class="text-blue-600 underline" href="{{ relref . .Path }}">{{ .Title }}</a>
+        <a class="text-blue-600 underline" href="{{ relref . .Path }}">{{ .Params.h1 }}</a>
     </div>
 {{ end }}
 


### PR DESCRIPTION
Similar to what we do on the docs site today: https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/layouts/shortcodes/tutorials-index.html#L39

Fixes #71.

![image](https://user-images.githubusercontent.com/274700/137045490-84f627cb-f24a-46a5-b282-aa3e4a2f2705.png)
