### PR TITLE
Remove the padding above the API Navigation heading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211011201142-d6a7ace2bc4a // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20211011171710-45eb4e243ab7 // indirect
-	github.com/pulumi/theme v0.0.0-20211010000958-6bd881e4195f // indirect
+	github.com/pulumi/theme v0.0.0-20211013175709-2446aecbc620 // indirect
 )
 
 // The override is needed because this repo is currently private and module at themes/default

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,10 @@ github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211011201142-d6a7ace2bc4a 
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211011201142-d6a7ace2bc4a/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
 github.com/pulumi/theme v0.0.0-20211010000958-6bd881e4195f h1:9u0Rt2Gy/A0IBGdDf/Og/UUSSmL3Y+kw9oamTY00RRo=
 github.com/pulumi/theme v0.0.0-20211010000958-6bd881e4195f/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211013173457-6bb0d98b9c6e h1:UuJLrD0Os9kpZhpKFlLyLXjLC2n6BY7XLj8B5Pwdro8=
+github.com/pulumi/theme v0.0.0-20211013173457-6bb0d98b9c6e/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211013173910-8356d2a581e0 h1:7BtvmkI96MJLznUwSnh/k68CGxz7/meLfNhOEyWPfI0=
+github.com/pulumi/theme v0.0.0-20211013173910-8356d2a581e0/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211013175308-591cae663f3f/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211013175709-2446aecbc620 h1:fv9votAkO+rrS4phk2K3phKOVhPvf4JVExUZaI7Nuzc=
+github.com/pulumi/theme v0.0.0-20211013175709-2446aecbc620/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=

--- a/themes/default/layouts/registry/api.html
+++ b/themes/default/layouts/registry/api.html
@@ -33,7 +33,7 @@
 
             <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:pt-0 lg:mt-0">
                 <div class="sticky-sidebar left-nav">
-                    <div class="lg:mt-1 mb-6">
+                    <div class="mb-6">
                         {{ partial "registry/left-nav.html" . }}
                     </div>
                     <div>


### PR DESCRIPTION
Accompanies https://github.com/pulumi/theme/pull/28. This just removes the teeny bit of additional space above the API Navigation heading that was keeping it out of alignment with the other two columns.

Here's how this looks with the changes in https://github.com/pulumi/theme/pull/28:

https://user-images.githubusercontent.com/274700/137186133-80e5d2ec-b5da-49c2-9b60-7819ae413ee2.mov



