### PR TITLE
Mark gcp as featured; not google-native

### DIFF
--- a/themes/default/data/registry/packages/gcp.yaml
+++ b/themes/default/data/registry/packages/gcp.yaml
@@ -7,6 +7,6 @@ publisher: Pulumi
 category: Cloud
 package_status: ga
 version: v5.24.0
-featured: false
+featured: true
 native: false
 component: false

--- a/themes/default/data/registry/packages/google-native.yaml
+++ b/themes/default/data/registry/packages/google-native.yaml
@@ -7,6 +7,6 @@ publisher: Pulumi
 category: Cloud
 package_status: public_preview
 version: v0.8.0
-featured: true
+featured: false
 native: true
 component: false


### PR DESCRIPTION
It appears that a change I made to the script that generates these files in `docs@master` seems to have been reverted perhaps during a merge conflict(?) when merging `master` into `reg-staging`.

Here's the change in `master`: https://github.com/pulumi/docs/commit/a3a1a0780a8100cdff6c4787f237f417a825be78

When I look at the [changes for 10/5](https://github.com/pulumi/docs/commits/reg-staging?after=4a7f52b8158ec0442dc484d45a859db8ef8dfe35+34&branch=reg-staging) in the `reg-staging` branch I see that the commit is there but somehow when I look at the file's history itself it doesn't show up 🤷‍♂️ 

![image](https://user-images.githubusercontent.com/1466314/137227110-0c182168-ff31-4d38-8684-f0a5e6b6dad6.png)