### PR TITLE
Fix nav hidden for mobile

### DIFF
--- a/themes/default/layouts/registry/api.html
+++ b/themes/default/layouts/registry/api.html
@@ -33,7 +33,7 @@
 
             <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:pt-0 lg:mt-0">
                 <div class="sticky-sidebar left-nav">
-                    <div class="sm:hidden lg:block mb-6">
+                    <div class="hidden lg:block mb-6">
                         {{ partial "registry/left-nav.html" . }}
                     </div>
                     <div>


### PR DESCRIPTION
This was fixed yesterday, but got mixed up/regressed somehow.  Below screen widths of 1024, api docs nav is hidden.  See screenshots below w/ screen sizes.

<img width="623" alt="Screen Shot 2021-10-14 at 10 28 57 AM" src="https://user-images.githubusercontent.com/25756367/137367152-93d8f992-3e17-424e-b6fd-1848949c4ef7.png">

<img width="767" alt="Screen Shot 2021-10-14 at 10 28 46 AM" src="https://user-images.githubusercontent.com/25756367/137367141-86fcf736-18f2-445e-a279-d35561ec1749.png">
