### PR TITLE
Widen the space between tabs on the package page

### DIFF
--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -42,27 +42,29 @@
 
     {{ with .GetPage (path.Join "registry/packages" $packageName) }}
         <div class="flex mb-8 font-display text-base md:text-lg">
-            <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 md:mr-4 lg:mr-6">
+            <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mr-2 md:mr-4 lg:mr-6">
                 <a class="flex items-center" href="{{ relref . .File.Dir }}">Overview</a>
             </div>
-            <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 md:mx-4 lg:mx-6">
+            <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mx-2 md:mx-4 lg:mx-6">
                 <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">
                     <span class="md:hidden">Install</span>
                     <span class="hidden md:block">Installation &amp; Configuration</span>
                 </a>
             </div>
-            <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 md:mx-4 lg:mx-6">
+            <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mx-2 md:mx-4 lg:mx-6">
                 <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "api-docs") }}">
                     <span class="md:hidden">API</span>
                     <span class="hidden md:block">API Docs</span>
                 </a>
             </div>
-            <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 md:ml-4 lg:ml-6">
+            <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 ml-2 md:ml-4 lg:ml-6">
                 <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
                     <span class="md:hidden">Guides</span>
                     <span class="hidden md:block">How-to Guides</span>
                     {{ if gt $guidesCount 0 }}
-                        {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
+                        <span class="hidden md:inline">
+                            {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
+                        </span>
                     {{ end }}
                 </a>
             </div>


### PR DESCRIPTION
This change makes the space between the tabs 3rem on desktop and 2rem on tablet (the latter to leave enough room to prevent the tab labels themselves from wrapping, which they do at 3).

https://user-images.githubusercontent.com/274700/137385053-3b807b16-febe-42d4-9baa-a6a0b0156c31.mov

Fixes #158.


