### PR TITLE
Add Docs menu item and aliases

### DIFF
--- a/themes/default/content/registry/_index.md
+++ b/themes/default/content/registry/_index.md
@@ -11,6 +11,12 @@ menu:
         identifier: cloud-providers
         name: Cloud Providers
         weight: 6
+    userguides:
+        identifier: tutorials
+        name: Tutorials
+        weight: 1
 aliases:
     - /registry/packages
+    - /docs/tutorials
+    - /docs/reference/tutorials/
 ---


### PR DESCRIPTION
This change adds a couple of frontmatter params to the registry index page:

* A menu item that makes the Tutorials link continue showing up under Intro, but now linking to the registry index.
* Aliases for that page, as it's being deleted in https://github.com/pulumi/pulumi-hugo/pull/728. 

Part of https://github.com/pulumi/registry/issues/161.