### PR TITLE
Add featured guides section for handwritten guides coming from Hugo

### DIFF
--- a/themes/default/layouts/registry/how-to.html
+++ b/themes/default/layouts/registry/how-to.html
@@ -8,13 +8,15 @@
                     There are no guides yet for this package.
                 {{ else }}
                     {{ if not (eq (len (where .Pages "Params.language" "==" nil)) 0) }}
-                        <h2>Featured Guides</h2>
+                        <h3>Featured Guides</h3>
 
                         {{ range where .Pages "Params.language" "==" nil }}
                             <div class="pb-4">
                                 <a class="text-blue-600 underline" href="{{ relref . .Path }}">{{ .Title }}</a>
                             </div>
                         {{ end }}
+
+                        <h3>How-to Guides by Language</h3>
                     {{ end }}
 
                     <div><pulumi-chooser type="language" options="typescript,javascript,python,go,csharp"></pulumi-chooser></div>


### PR DESCRIPTION
Added a section to the how-to guides layout which will include hand-written docs that are language agnostic.

I've created a follow-up issue to make these into cards [here](https://github.com/pulumi/registry/issues/173)

## Issue
Fixes #99 