### PR TITLE
Update Azure Native metadata

### DIFF
--- a/themes/default/data/registry/packages/azure-native.yaml
+++ b/themes/default/data/registry/packages/azure-native.yaml
@@ -2,11 +2,11 @@ name: azure-native
 title: Azure Native
 description: A native Pulumi package for creating and managing Azure resources.
 logo_url: ""
-updated_on: 1634021423
+updated_on: 1634203337
 publisher: Pulumi
 category: Cloud
 package_status: ga
-version: v1.37.0
+version: v1.38.0
 featured: true
 native: true
 component: false


### PR DESCRIPTION
Regenerated the API for today's staging site payload and the `azure-native` package metadata was updated. So just syncing with the API docs.