### PR TITLE
Make the headings right

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211011201142-d6a7ace2bc4a // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20211011171710-45eb4e243ab7 // indirect
-	github.com/pulumi/theme v0.0.0-20211014212717-5bb2ea3e5bf1 // indirect
+	github.com/pulumi/theme v0.0.0-20211014235548-99b241043932 // indirect
 )
 
 // The override is needed because this repo is currently private and module at themes/default

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211011201142-d6a7ace2bc4a 
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211011201142-d6a7ace2bc4a/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
 github.com/pulumi/theme v0.0.0-20211014212717-5bb2ea3e5bf1 h1:mQpfh/eua5VKtXeQTL8Fdxoj211Enwta3yh7mXzosIY=
 github.com/pulumi/theme v0.0.0-20211014212717-5bb2ea3e5bf1/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211014235548-99b241043932 h1:vTlnrflMY6w80N2BLiLyHuxuVYrVZ/tWSEs4v2ZMd0I=
+github.com/pulumi/theme v0.0.0-20211014235548-99b241043932/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=

--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -77,12 +77,19 @@
     </div>
     <div class="dot-overlay"></div>
     <div class="registry-hero-title container mx-auto w-full px-4">
-        <a href="{{ relref . "/registry" }}">
-            <i class="fas fa-archive title-icon"></i>
-        </a>
-        <a href="{{ relref . "/registry" }}">
-            <h1 class="title-text-content">Pulumi Registry</h1>
-        </a>
+        <div class="flex items-center">
+            <a href="{{ relref . "/registry" }}">
+                <i class="fas fa-archive title-icon"></i>
+            </a>
+            <a href="{{ relref . "/registry" }}">
+                {{/* Only use an h1 on the index page. */}}
+                {{ if eq .Title "Pulumi Registry"}}
+                    <h1 class="title-text-content">Pulumi Registry</h1>
+                {{ else }}
+                    <span class="title-text-content">Pulumi Registry</span>
+                {{ end }}
+            </a>
+        </div>
         <div class="flex-1"></div>
         <script>
             (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){

--- a/themes/default/layouts/partials/registry/package/header.html
+++ b/themes/default/layouts/partials/registry/package/header.html
@@ -23,7 +23,7 @@
     {{ end }}
 
     <div class="lg:flex mb-2">
-        <h2 class="text-4xl">{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}</h2>
+        <h1 class="text-4xl">{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}</h1>
     </div>
 
     {{ with (index $.Site.Data.registry.packages ($packageName)) }}
@@ -41,33 +41,35 @@
     </div>
 
     {{ with .GetPage (path.Join "registry/packages" $packageName) }}
-        <div class="flex mb-8 font-display text-base md:text-lg">
-            <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mr-2 md:mr-4 lg:mr-6">
-                <a class="flex items-center" href="{{ relref . .File.Dir }}">Overview</a>
+        <nav>
+            <div class="flex mb-8 font-display text-base md:text-lg">
+                <div class="{{ if (eq $packageSection "_index") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mr-2 md:mr-4 lg:mr-6">
+                    <a class="flex items-center" href="{{ relref . .File.Dir }}">Overview</a>
+                </div>
+                <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mx-2 md:mx-4 lg:mx-6">
+                    <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">
+                        <span class="md:hidden">Install</span>
+                        <span class="hidden md:block">Installation &amp; Configuration</span>
+                    </a>
+                </div>
+                <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mx-2 md:mx-4 lg:mx-6">
+                    <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "api-docs") }}">
+                        <span class="md:hidden">API</span>
+                        <span class="hidden md:block">API Docs</span>
+                    </a>
+                </div>
+                <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 ml-2 md:ml-4 lg:ml-6">
+                    <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
+                        <span class="md:hidden">Guides</span>
+                        <span class="hidden md:block">How-to Guides</span>
+                        {{ if gt $guidesCount 0 }}
+                            <span class="hidden md:inline">
+                                {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
+                            </span>
+                        {{ end }}
+                    </a>
+                </div>
             </div>
-            <div class="{{ if (eq $packageSection "installation-configuration") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mx-2 md:mx-4 lg:mx-6">
-                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "installation-configuration") }}">
-                    <span class="md:hidden">Install</span>
-                    <span class="hidden md:block">Installation &amp; Configuration</span>
-                </a>
-            </div>
-            <div class="{{ if (eq $packageSection "api-docs") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 mx-2 md:mx-4 lg:mx-6">
-                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "api-docs") }}">
-                    <span class="md:hidden">API</span>
-                    <span class="hidden md:block">API Docs</span>
-                </a>
-            </div>
-            <div class="{{ if (eq $packageSection "how-to-guides") }} border-b-2 border-blue-600 {{ end }} pb-2 px-2 ml-2 md:ml-4 lg:ml-6">
-                <a class="flex items-center" href="{{ relref . (path.Join .File.Dir "how-to-guides") }}">
-                    <span class="md:hidden">Guides</span>
-                    <span class="hidden md:block">How-to Guides</span>
-                    {{ if gt $guidesCount 0 }}
-                        <span class="hidden md:inline">
-                            {{ partial "count-pill" (dict "count" $guidesCount "selected" (eq $packageSection "how-to-guides")) }}
-                        </span>
-                    {{ end }}
-                </a>
-            </div>
-        </div>
+        </nav>
     {{ end }}
 </div>


### PR DESCRIPTION
Along with https://github.com/pulumi/theme/pull/35, makes the headings on the index and package pages more correct.

Most of the items in the issue were already done; this just fixes up the last few of them.

Fixes #133.