### PR TITLE
Add h1 with how-to-guide title to individual how to guide page

### DIFF
--- a/themes/default/layouts/registry/how-to-guide.html
+++ b/themes/default/layouts/registry/how-to-guide.html
@@ -8,7 +8,7 @@
                     <div class="lg:flex">
                         {{ partial "registry/package/how-to-guides/breadcrumb.html" . }}
                     </div>
-                    <h1>{{ .Params.h1 }}</h1>
+                    <h1 class="text-3xl mt-5">{{ .Params.h1 }}</h1>
                 {{ end }}
 
                 {{ .Content }}


### PR DESCRIPTION
Fixes: https://github.com/pulumi/registry/issues/160

Screenshots locally:
<img width="1220" alt="Screen Shot 2021-10-15 at 10 53 22 AM" src="https://user-images.githubusercontent.com/25756367/137531992-4df585c2-e6ed-4546-a7d8-8268dbbe7456.png">
<img width="1077" alt="Screen Shot 2021-10-15 at 10 54 18 AM" src="https://user-images.githubusercontent.com/25756367/137532002-0fcb390d-cd5b-4374-a7e6-3548131290c4.png">

How to index remains unchanged:
<img width="1022" alt="Screen Shot 2021-10-15 at 10 54 34 AM" src="https://user-images.githubusercontent.com/25756367/137532019-c1bfcf99-b6a0-401e-b236-292ffc286552.png">
