### PR TITLE
Revert the link for the banner until the blog post is published

### DIFF
--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -66,7 +66,7 @@
         <div class="content font-display text-lg px-4 md:px-8">
             <span>Welcome to Pulumi Registry, your window into the cloud.</span>
             <span class="whitespace-nowrap">
-            <a href="{{ relref . "/blog/introducing-pulumi-registry" }}" class="ml-2 underline">Read the announcement</a>.<span>
+            <a href="{{ relref . "/blog" }}" class="ml-2 underline">Read the announcement</a>.<span>
         </div>
     </pulumi-banner>
 </div>


### PR DESCRIPTION
The blog post is not published until 10/18. The PR previews will work fine because we specifically build future posts.