### PR TITLE
Update overview and installation layouts for manual Swiftype content inclusion

### DIFF
--- a/themes/default/layouts/registry/installation.html
+++ b/themes/default/layouts/registry/installation.html
@@ -4,7 +4,9 @@
 
         <div class="lg:flex">
             <div class="lg:w-8/12">
-                {{ .Content }}
+                <section data-swiftype-index="true">
+                    {{ .Content }}
+                </section>
             </div>
             <div class="lg:w-1/12"></div>
             <div class="lg:w-3/12 lg:pl-8">

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -11,7 +11,9 @@
                     <h1 class="text-3xl mt-5">{{ .Params.title }}</h1>
                 {{ end }}
 
-                {{ .Content }}
+                <section data-swiftype-index="true">
+                    {{ .Content }}
+                </section>
             </div>
             <div class="lg:w-1/12"></div>
             <div class="lg:w-3/12 lg:pl-8">


### PR DESCRIPTION
We already have a crawl rule for `/registry` which allows the crawler to index all pages in that path. The [`data-swiftype-index`](https://swiftype.com/documentation/site-search/crawler-configuration/content-inclusion-exclusion#content_inclusion) data attribute controls which parts of a page Swiftype will include in the index for searching.