### PR TITLE
Add a MutationObserver to remove search results that are not from the registry

### DIFF
--- a/themes/default/layouts/partials/registry/header.html
+++ b/themes/default/layouts/partials/registry/header.html
@@ -116,9 +116,16 @@
             </div>
         </div>
         <script>
+            // We want to restrict the results to just the ones from the registry.
+            // Create a MutationObserver and attach it to the #search-results container above.
+            // The `subtree` modifications property will allow our callback to be called
+            // whenever search result nodes (the `<a>` tag elements) will be added to the
+            // container.
             const observer = new MutationObserver((mutations, observer) => {
                 mutations.forEach(mutation => {
                     mutation.addedNodes.forEach(n => {
+                        // Remove the result if its URL does not contain `registry`.
+                        // We can make this a bit more restrictive if we need to later.
                         if (n.classList.contains("st-ui-result") && !n.href.includes("registry")) {
                             n.remove();
                         }


### PR DESCRIPTION
In #145 I proposed adding a new search "engine" in Swiftype that would be restricted to just the `/registry` path. However, I found another way to limit the results with a single engine. I think this is working quite well. If we are good with this then I'll close out #145.

You should be able to try out the search in the PR preview and compare that with the live site.

### Screenshots
<details>
<summary>Expand me!</summary>

#### Searching for Miniflux with this change vs. the live site

<img width="774" alt="Screen Shot 2021-10-20 at 11 30 11" src="https://user-images.githubusercontent.com/1466314/138151053-00b06ed8-1529-406b-a359-9dbb0819f913.png">

Live site:
<img width="774" alt="Screen Shot 2021-10-20 at 11 29 33" src="https://user-images.githubusercontent.com/1466314/138151061-145cd35a-39c0-4cf7-a4f8-54d81105ac09.png">

#### Searching for Lambda

<img width="773" alt="Screen Shot 2021-10-20 at 11 31 13" src="https://user-images.githubusercontent.com/1466314/138151323-da74f40e-bdc9-4deb-b5f0-13a1de551b59.png">

Live site (notice how there are links to blog posts):
<img width="779" alt="Screen Shot 2021-10-20 at 11 30 59" src="https://user-images.githubusercontent.com/1466314/138151171-ff6a2cd0-1831-4c3f-8bc7-0852e598e923.png">
</details>

### Potential downside

Because the results are removed client-side when you open up the overlay by pressing Enter or clicking Search, there is a chance for the page to have fewer results but as you navigate to the other pages you'll see more results. It's odd for sure. But also I believe this is happening because the Swiftype engine is currently going through and recrawling the site so I expect some pages to not be there at all in the results which would reduce the chances of this happening.

<img width="659" alt="Screen Shot 2021-10-20 at 11 35 40" src="https://user-images.githubusercontent.com/1466314/138151623-882db239-e8de-4f64-8cbe-e2b2dba54919.png">


