### PR TITLE
bump theme to include api nav perf improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211018100029-efdf68be2623 // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20211011171710-45eb4e243ab7 // indirect
-	github.com/pulumi/theme v0.0.0-20211015193555-271ef1f67093 // indirect
+	github.com/pulumi/theme v0.0.0-20211025172707-d60f9ad59328 // indirect
 )
 
 // The override is needed because this repo is currently private and module at themes/default


### PR DESCRIPTION
Bumping theme to include api nav perf improvements from https://github.com/pulumi/theme/pull/40

Is this the right process?

1. bump go.mod in pulumi/registry (I had to run `git update-index --no-skip-worktree go.mod` which was surprising and a little annoying https://github.com/pulumi/registry/blob/8922d0abe14d252cd99ef2f0edfc7abe55ebe27f/scripts/ensure.sh#L41)
2. wait for automation to merge to pulumi/pulumi-hugo
3. wait for automation to merge to pulumi/docs

It would be great to have this documented somewhere if it isn't already. 