### PR TITLE
Use the release branch of theme

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Fetch the latest sibling modules
         run: |
-          hugo mod get github.com/pulumi/theme
+          hugo mod get github.com/pulumi/theme@release
           hugo mod get github.com/pulumi/pulumi-hugo
           hugo mod tidy
 


### PR DESCRIPTION
Oversight on my part; we want to use the `release` branch of pulumi/theme, just to be sure the assets we expose for local development are correct.