### PR TITLE
remove deprecated set-output commands in workflow files

### DIFF
--- a/.github/workflows/generate-package-metadata.yml
+++ b/.github/workflows/generate-package-metadata.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
-        run: echo "matrix=$(python generate_package_list.py)'" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(python generate_package_list.py)" >> $GITHUB_OUTPUT
         working-directory: community-packages
       - name: List open pull requests
         uses: jkisk/list-open-pulls@v1.0.1


### PR DESCRIPTION
part of: https://github.com/pulumi/registry/issues/2121

`set-output` is being deprecated and will no longer be able to use it by may 31st. This PR removes this from the workflow file. However we are still getting the errors because there is a [custom actionbeing referenced here that set-output is embedded in](https://github.com/jkisk/list-open-pulls/blob/main/index.js#L19) it that is using this still. So I will need to probably fork it and get that addressed elsewhere to get rid of the last deprecation warning.

Here is the run of the workflow i manually kicked off with these changes
https://github.com/pulumi/registry/actions/runs/5006003820