### PR TITLE
Add OIDC instructions for pulumi-azuread

### DIFF
--- a/themes/default/content/registry/packages/azuread/installation-configuration.md
+++ b/themes/default/content/registry/packages/azuread/installation-configuration.md
@@ -93,9 +93,10 @@ the service your program will run on.
 via the environment variable `GITLAB_OIDC_TOKEN`. Configure the Pulumi provider to use this token by setting the Pulumi
 configuration `azuread:oidcToken` or the environment variable `ARM_OIDC_TOKEN`.
 
-- In case your provider does not offer an ID token directly but instead a way to exchange a local bearer token for an ID
-token, you can configure this as well via the pair of `azuread:oidcRequestToken` or environment variable
-`ARM_OIDC_REQUEST_TOKEN` and `azuread:oidcRequestUrl` or environment variable `ARM_OIDC_REQUEST_URL`
+- If your identity provider does not offer an ID token directly but it does offer a way to exchange a local bearer token for an ID
+token, you can configure the retrieval of the ID token by setting one of the following pairs:
+  - both the `azuread:oidcRequestToken` and `azuread:oidcRequestUrl` Pulumi configuration values, **or**
+  - both the `ARM_OIDC_REQUEST_TOKEN` and `ARM_OIDC_REQUEST_TOKEN` environment variables.
 
 Finally, configure the client and tenant IDs of your Azure Active Directory application. Refer to the
 [above Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/workload-identities/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp)


### PR DESCRIPTION
The azuread provider recently got support for OIDC authentication (pulumi/pulumi-azuread#580). This PR adds the relevant documentation.

__TODO tkappler only merge this PR after #580__

It's based on the existing OIDC docs for the Azure Classic provider, but rewritten significantly, mainly to address some omissions and inaccuracies around the `oidcToken` configuration. Once this PR is approved, I plan to backport the improved OIDC section to the other Azure providers as well.

Note on the removed line about Azure CLI 2.0: that CLI has been standard for many years now and is typically assumed when talking about the Azure CLI.