### PR TITLE
Fix FunctionArgsOutputVersion for Java

### DIFF
--- a/tools/resourcedocsgen/pkg/docs/gen_function.go
+++ b/tools/resourcedocsgen/pkg/docs/gen_function.go
@@ -241,13 +241,11 @@ func (mod *modContext) genFunctionParamsCS(f *schema.Function, funcName string, 
 	return params
 }
 
-func (mod *modContext) genFunctionParamsJava(f *schema.Function, funcName string, outputVersion bool) []formalParam {
+func (mod *modContext) genFunctionParamsJava(f *schema.Function, funcName string) []formalParam {
 	dctx := mod.context
 
+	// java uses the same args type for both the regular and output versions of the function
 	argsTypeSuffix := "Args"
-	if outputVersion {
-		argsTypeSuffix = "InvokeArgs"
-	}
 
 	argsType := title(funcName+argsTypeSuffix, language.Java)
 	docLangHelper := dctx.getLanguageDocHelper(language.Java)
@@ -360,7 +358,7 @@ func (mod *modContext) genFunctionParams(
 	case language.CSharp:
 		return mod.genFunctionParamsCS(f, funcName, outputVersion)
 	case language.Java:
-		return mod.genFunctionParamsJava(f, funcName, outputVersion)
+		return mod.genFunctionParamsJava(f, funcName)
 	case language.Python:
 		return mod.genFunctionParamsPython(f, funcName, outputVersion)
 	case language.YAML: // Left blank

--- a/tools/resourcedocsgen/pkg/docs/gen_function.go
+++ b/tools/resourcedocsgen/pkg/docs/gen_function.go
@@ -399,7 +399,7 @@ func (mod *modContext) genFunctionOutputVersionMap(f *schema.Function) map[langu
 		switch lang {
 		case language.Go:
 			hasOutputVersion = go_gen.NeedsGoOutputVersion(f)
-		case language.Java, language.YAML:
+		case language.YAML:
 			hasOutputVersion = false
 		}
 		result[lang] = hasOutputVersion

--- a/tools/resourcedocsgen/pkg/docs/templates/function.tmpl
+++ b/tools/resourcedocsgen/pkg/docs/templates/function.tmpl
@@ -86,7 +86,7 @@ func </span>{{ index .FunctionName lGo }}Output<span class="p">(</span>{{ htmlSa
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgs lJava) }}<span class="p">)</span>
-<span class="k">public static Output<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgsOutputVersion lJava) }}<span class="p">)</span>
+{{ if (index .HasOutputVersion lJava) }}<span class="k">public static Output<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgsOutputVersion lJava) }}<span class="p">)</span>{{- end }}
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/templates/function.tmpl
+++ b/tools/resourcedocsgen/pkg/docs/templates/function.tmpl
@@ -86,7 +86,7 @@ func </span>{{ index .FunctionName lGo }}Output<span class="p">(</span>{{ htmlSa
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgs lJava) }}<span class="p">)</span>
-<span class="k">public static Output<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgs lJava) }}<span class="p">)</span>
+<span class="k">public static Output<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgsOutputVersion lJava) }}<span class="p">)</span>
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/templates/function.tmpl
+++ b/tools/resourcedocsgen/pkg/docs/templates/function.tmpl
@@ -85,8 +85,8 @@ func </span>{{ index .FunctionName lGo }}Output<span class="p">(</span>{{ htmlSa
 <!-- Java -->
 <div>
 <pulumi-choosable type="language" values="java">
-<div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgs lJava) }}<span class="p">)</span>
-{{ if (index .HasOutputVersion lJava) }}<span class="k">public static Output<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgsOutputVersion lJava) }}<span class="p">)</span>{{- end }}
+<div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgs lJava) }}<span class="p">)</span>{{ if (index .HasOutputVersion lJava) }}
+<span class="k">public static Output<{{ template "linkify_param" (index .FunctionResult lJava) }}> </span>{{ index .FunctionName lJava }}<span class="p">(</span>{{ htmlSafe (index .FunctionArgsOutputVersion lJava) }}<span class="p">)</span>{{ end }}
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithconstinput/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithconstinput/_index.md
@@ -69,7 +69,6 @@ Codegen demo with const inputs
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture&lt;<span class="nx"><a href="#result">FuncWithConstInputResult</a></span>> </span>funcWithConstInput<span class="p">(</span><span class="nx">FuncWithConstInputArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
-
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithconstinput/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithconstinput/_index.md
@@ -69,7 +69,7 @@ Codegen demo with const inputs
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture&lt;<span class="nx"><a href="#result">FuncWithConstInputResult</a></span>> </span>funcWithConstInput<span class="p">(</span><span class="nx">FuncWithConstInputArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
-<span class="k">public static Output&lt;<span class="nx"><a href="#result">FuncWithConstInputResult</a></span>> </span>funcWithConstInput<span class="p">(</span><span class="nx">FuncWithConstInputArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
+
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithemptyoutputs/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithemptyoutputs/_index.md
@@ -69,7 +69,7 @@ n/a
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>> </span>funcWithEmptyOutputs<span class="p">(</span><span class="nx">FuncWithEmptyOutputsArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
-<span class="k">public static Output&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>> </span>funcWithEmptyOutputs<span class="p">(</span><span class="nx">FuncWithEmptyOutputsArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
+
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithemptyoutputs/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/output-funcs/docs/funcwithemptyoutputs/_index.md
@@ -69,7 +69,6 @@ n/a
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>> </span>funcWithEmptyOutputs<span class="p">(</span><span class="nx">FuncWithEmptyOutputsArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
-
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/simple-plain-schema/docs/dofoo/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/simple-plain-schema/docs/dofoo/_index.md
@@ -67,7 +67,6 @@ no_edit_this_page: true
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture&lt;<span class="nx"><a href="#result">DoFooResult</a></span>> </span>doFoo<span class="p">(</span><span class="nx">DoFooArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
-
 </code></pre></div>
 </pulumi-choosable>
 </div>

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/simple-plain-schema/docs/dofoo/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/simple-plain-schema/docs/dofoo/_index.md
@@ -67,7 +67,7 @@ no_edit_this_page: true
 <div>
 <pulumi-choosable type="language" values="java">
 <div class="highlight"><pre class="chroma"><code class="language-java" data-lang="java"><span class="k">public static CompletableFuture&lt;<span class="nx"><a href="#result">DoFooResult</a></span>> </span>doFoo<span class="p">(</span><span class="nx">DoFooArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
-<span class="k">public static Output&lt;<span class="nx"><a href="#result">DoFooResult</a></span>> </span>doFoo<span class="p">(</span><span class="nx">DoFooArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx">InvokeOptions</span><span class="p"> </span><span class="nx">options<span class="p">)</span>
+
 </code></pre></div>
 </pulumi-choosable>
 </div>


### PR DESCRIPTION
## Description

Java uses the same args type for both the regular and output versions of the function. This corrects docsgen to set the correct `FunctionArgsOutputVersion`. Additionally it fixes java emitting broken output versions when no output version should be generated.

Note: The actual docs shouldn't change because we've worked around this issue previously by using the regular `FunctionArgs` even for the output version in Java.

Fixes #6595