### PR TITLE
Clean up SSM parameter when deleting bucket

### DIFF
--- a/scripts/ci/remove-buckets.sh
+++ b/scripts/ci/remove-buckets.sh
@@ -29,6 +29,7 @@ echo
 for bucket in $buckets_to_remove; do
     echo "Removing ${bucket}..."
     aws s3 rb "s3://${bucket}" --force
+    remove_param_for_commit "$(git_sha)" "$(aws_region)"
     echo
 done
 


### PR DESCRIPTION
## Description

<!-- A brief description of the PR here. -->
When cleaning up old buckets, we should also remove the associated SSM parameter, otherwise we can run into account level quotas.