### PR TITLE
Update the instructions for adding a new package to the registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 CODEOWNERS @sean1588 @mjeffryes @iwahbe
 
 # Community packages.
-/community-packages/ @sean1588 @pulumi/providers
+/community-packages/ @pulumi/iac-cloud

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,39 @@
-## Description
+<!--
 
-<!-- A brief description of the PR here. -->
+        +--------------------------------------------------------+
+        | If you are adding a new package to the Pulumi Registry |
+        +--------------------------------------------------------+
 
-## Adding a new package?
+        Please make sure that you have:
 
-If this pull request adds a new package, please verify/document:
+        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
+              part after the leading `v` must be valid semver 2.0.
 
-- [ ] The primary maintainer contact for this package (please indicate if the provider is sponsored by a company or community maintained)
-- [ ] The package's schema URL in this PR is correct.
-- [ ] The package metadata file, if present, contains:
-  - [ ] a supported category (one of `Cloud`, `Infrastructure`, `Network`, `Database`, `Monitoring`, or `Utility`).
-  - [ ] a valid plugin download URL. See [Publish Your Package](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/how-to-author/#publish-your-package).
-  - [ ] a description that explains what the package does.
-  - [ ] a valid logo URL that points to a PNG whose dimensions conform to the others in this repo (e.g., 100x100).
-- [ ] The package repo contains an Overview doc (`/docs/_index.md`) that includes:
-  - [ ] a brief explanation of what the package is and what it does.
-  - [ ] at least one representative example in all supported languages (i.e. TypeScript, Python, Go and C#).
-  - [ ] a front-matter property for the `layout` set to `package`.
-- [ ] The package repo contains an Installation and Configuration doc (`/docs/installation-configuration.md`) that includes:
-  - [ ] links to SDKs in all supported languages (i.e. should link to published SDKs in NPM, PyPi and NuGet).
-  - [ ] a copyable command for installing the resource plugin if necessary.
-  - [ ] an example of configuring the provider with `pulumi config set`.
-  - [ ] an example of configuring the provider with environment variables.
-- [ ] The repository has:
-  - [ ] a version tag prefixed with `v` that corresponds with a valid GitHub release and published package SDKs (in NPM, PyPi, and NuGet)
-- [ ] A CODEOWNER has reviewed the PR.
-- [ ] A member of the @pulumi/docs team has reviewed all documentation.
+            - Published an SDK for your provider in:
+                - [ ] Typescript
+                - [ ] Python
+                - [ ] Go
+                - [ ] C#
+                - [ ] Java (optional)
+
+        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
+              specified in `/community-packages/package-list.json`.
+
+        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
+              out in your repo.
+
+            - [ ] `/docs/installation-configuration.md` links to all published SDKs.
+
+            - [ ] `/docs/index.md` shows an example of using your provider in each language.
+
+        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
+        review your PR.
+
+        Thanks for contributing to the Pulumi Registry!
+
+        ---
+
+        For maintainers, see the full checklist for adding a new provider at
+        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.
+
+-->

--- a/docs/adding-a-new-package.md
+++ b/docs/adding-a-new-package.md
@@ -1,0 +1,54 @@
+# Adding a new package
+
+## For maintainers
+
+To keep quality in the Pulumi Registry high, we have a check-list before merging a new provider into the registry. Please post a copy of this checklist in the PR under review and check off each item as verified.
+
+- [ ] Pulumi has appropriate contact information from the provider maintainer
+
+  If the provider is community maintained (maintained by a person, not a company), then a GitHub handle is sufficient
+
+  If the provider is maintained by a company, Pulumi needs a contact person at the maintaining company.
+
+- [ ] The package will generate accurate documentation:
+
+  1. Check out the PR under review and run:
+
+  ```sh
+  $ make bin/resourcedocsgen
+  $ ./bin/resourcedocsgen metadata from-github \
+          --repoSlug '<repoSlug>' \
+          --schemaFile '<schemaFile>' \
+          --version '<version>'
+  ```
+
+  Here `<repoSlug>` and `<schemaFile>` should match exactly the values added to `/community-packages/package-list.json`.
+
+  This will generate metadata for the provider locally.
+
+  1. Push the metadata files into a PR (either back to the PR under review or a new PR).
+
+  After pushing the provider to CI and waiting for a preview site:
+
+  - [ ] Confirm that that CI passes **for the PR with the metadata files**.
+
+  - [ ] Click through the site preview and confirm that the docs (for the new provider) render as expected.
+
+  - [ ] The registry renders a valid logo for the new provider.
+
+- [ ] Hand-written docs are complete and accurate:
+
+  - [ ] Validate that you can install the new provider with the instructions found in `/docs/installation-configuration.md`.
+
+  Maintainers should run the `pulumi plugin install resource <name> <version> --server <pluginDownloadURL>` command specified in the `/docs/installation-configuration.md` and see a provider be downloaded.
+
+  - [ ] `/docs/installation-configuration.md` contains a link to the published SDK in each language (i.e. TypeScript, Python, Go and C#).
+
+  - [ ] `/docs/_index.md` contains a minimal example in every supported language.
+  - [ ] `/docs/_index.md` contains a brief explanation of what the package does.
+
+- [ ] There is a published version:
+  - [ ] The repository has a version tag prefixed with `v` that corresponds with a valid GitHub release
+  - [ ] Each published SDK has a matching release
+
+- [ ] A CODEOWNER has approved the PR.


### PR DESCRIPTION
<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registgry/blob/main/docs/adding-a-new-pacakge.md>.

-->

The new instructions render like this in "Write" mode, but don't get rendered in the display mode (which we don't want 95% of the time):

<img width="1259" alt="Screenshot 2025-02-20 at 10 43 33 PM" src="https://github.com/user-attachments/assets/fe985457-345c-4f4b-8136-f866e1c4d6ed" />

---

I have also added new instructions for maintainers, which should be more actionable and clearer. I'm always happy to have suggestions here.