### PR TITLE
Add legacy publisher handling for resource metadata generation

### DIFF
--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -244,7 +244,7 @@ func packageMetadataFromGitHubCmd(metadataDir, packageDocsDir *string) *cobra.Co
 			mainSpec.Publisher = publisher
 		}
 
-		err = writePackageMetadata(mainSpec, providerName, schemaURL, metadataDir, publishedDate, repoSlug)
+		err = writePackageMetadata(mainSpec, providerName, schemaURL, metadataDir, publishedDate, &repoSlug)
 		if err != nil {
 			return errors.Wrap(err, "generating package metadata")
 		}

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -382,6 +383,15 @@ func legacyNameRuleException(schemaName, providerName string) bool {
 	return schemaName == "runpod" && providerName == "runpod-native"
 }
 
+// legacyPublisherExceptions is a set of repository slugs that are exceptions to the
+// rule of requiring a publisher field in the schema.
+var legacyPublisherExceptions = codegen.NewStringSet(
+	"genesiscloud/pulumi-genesiscloud",
+	"nuage-studio/pulumi-nuage",
+	"wttech/pulumi-aem",
+	"pulumi/pulumi-tls-self-signed-cert",
+)
+
 // legacyPublisherRuleException checks if the repository slug is an exception to the
 // standard publisher naming rules. This allows certain repositories to maintain
 // backward compatibility with the previous behavior of not requiring a publisher field
@@ -391,7 +401,7 @@ func legacyNameRuleException(schemaName, providerName string) bool {
 // the repository owner. New providers should not be added to this exception list and
 // should explicitly specify their publisher in the schema.
 func legacyPublisherRuleException(repoSlug repoSlug) bool {
-	return repoSlug.String() == "genesiscloud/pulumi-genesiscloud"
+	return legacyPublisherExceptions.Has(repoSlug.String())
 }
 
 // getLegacyPublisher returns the publisher name for repositories that are exceptions

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -399,6 +399,7 @@ func legacyPublisherRuleException(repoSlug repoSlug) bool {
 // to derive a publisher name when one is not explicitly specified in the schema.
 // This maintains backward compatibility with previously established publisher names.
 func getLegacyPublisher(repoSlug repoSlug) string {
+	contract.Assertf(repoSlug.owner != "", "repoSlug.owner is non-empty by construction")
 	return cases.Title(language.Und, cases.NoLower).String(repoSlug.owner)
 }
 

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -34,6 +34,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/registry/tools/resourcedocsgen/pkg"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const defaultPackageCategory = pkg.PackageCategoryCloud
@@ -120,7 +122,7 @@ func packageMetadataFromURLsCmd(metadataDir, packageDocsDir *string) *cobra.Comm
 			return errors.WithMessage(err, "unable to read remote schema file")
 		}
 
-		err = writePackageMetadata(mainSpec, providerName, schemaFileURL, metadataDir, time.Now())
+		err = writePackageMetadata(mainSpec, providerName, schemaFileURL, metadataDir, time.Now(), nil)
 		if err != nil {
 			return err
 		}
@@ -242,7 +244,7 @@ func packageMetadataFromGitHubCmd(metadataDir, packageDocsDir *string) *cobra.Co
 			mainSpec.Publisher = publisher
 		}
 
-		err = writePackageMetadata(mainSpec, providerName, schemaURL, metadataDir, publishedDate)
+		err = writePackageMetadata(mainSpec, providerName, schemaURL, metadataDir, publishedDate, repoSlug)
 		if err != nil {
 			return errors.Wrap(err, "generating package metadata")
 		}
@@ -296,7 +298,7 @@ func packageMetadataFromGitHubCmd(metadataDir, packageDocsDir *string) *cobra.Co
 }
 
 func writePackageMetadata(
-	spec *schema.PackageSpec, providerName, schemaURL, metadataDir string, updatedOn time.Time,
+	spec *schema.PackageSpec, providerName, schemaURL, metadataDir string, updatedOn time.Time, repoSlug *repoSlug,
 ) error {
 	// Validate the schema for usage.
 	//
@@ -326,7 +328,11 @@ func writePackageMetadata(
 	}
 
 	if spec.Publisher == "" {
-		validationErrors = append(validationErrors, stderrors.New("Publisher is a required field on the schema"))
+		if repoSlug != nil && legacyPublisherRuleException(*repoSlug) {
+			spec.Publisher = getLegacyPublisher(*repoSlug)
+		} else {
+			validationErrors = append(validationErrors, stderrors.New("Publisher is a required field on the schema"))
+		}
 	}
 
 	// Check if the schema failed to validate.
@@ -374,6 +380,26 @@ func legacyNameRuleException(schemaName, providerName string) bool {
 	// The repo name is "runpod/pulumi-runpod-native" but the name of the provider is
 	// "runpod" (not the inferred "runpod-native").
 	return schemaName == "runpod" && providerName == "runpod-native"
+}
+
+// legacyPublisherRuleException checks if the repository slug is an exception to the
+// standard publisher naming rules. This allows certain repositories to maintain
+// backward compatibility with the previous behavior of not requiring a publisher field
+// in the schema.
+//
+// For existing providers, we allow the publisher field to be empty and derive it from
+// the repository owner. New providers should not be added to this exception list and
+// should explicitly specify their publisher in the schema.
+func legacyPublisherRuleException(repoSlug repoSlug) bool {
+	return repoSlug.String() == "genesiscloud/pulumi-genesiscloud"
+}
+
+// getLegacyPublisher returns the publisher name for repositories that are exceptions
+// to the standard publisher naming rules. It converts the repository owner to title case
+// to derive a publisher name when one is not explicitly specified in the schema.
+// This maintains backward compatibility with previously established publisher names.
+func getLegacyPublisher(repoSlug repoSlug) string {
+	return cases.Title(language.Und, cases.NoLower).String(repoSlug.owner)
 }
 
 func readRemoteFile(url, repoOwner string) ([]byte, error) {


### PR DESCRIPTION
## Description

This change removed the code for defaulting the publisher name if it's not specified: https://github.com/pulumi/registry/pull/6246.

We do want to require a publisher, but in order to not break existing providers this change adds an allow list for using the old mechanism of inferring the publisher name based on the github org.

Test by running the metadata generation on all third party packages:
```
~ go build -C ./tools/resourcedocsgen . && cat community-packages/package-list.json | jq -c '.include[]' | while read -r package; do
    repoSlug=$(echo "$package" | jq -r '.repoSlug')
    schemaFile=$(echo "$package" | jq -r '.schemaFile')
    repoName=$(echo "$repoSlug" | cut -d'/' -f2 | sed 's/^pulumi-//')

    # Special case for runpod-native
    if [ "$repoName" = "runpod-native" ]; then
        repoName="runpod"
    fi

    version=$(cat "themes/default/data/registry/packages/$repoName.yaml" | yq -r '.version')

    GITHUB_TOKEN=$(gh auth token) ./tools/resourcedocsgen/resourcedocsgen metadata from-github \
            --repoSlug "$repoSlug" \
            --version "$version" \
            --schemaFile "$schemaFile" 2>&1 | grep -q "Publisher is a required field on the schema" && echo "$repoSlug"
done
~
```

Fixes https://github.com/pulumi/registry/issues/6739