### PR TITLE
Remove `lbrlabs/pulumi-vantage` from the list of community providers

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -213,10 +213,6 @@
       "schemaFile": "provider/cmd/pulumi-resource-mssql/schema.json"
     },
     {
-      "repoSlug": "lbrlabs/pulumi-vantage",
-      "schemaFile": "provider/cmd/pulumi-resource-vantage/schema.json"
-    },
-    {
       "repoSlug": "pulumiverse/pulumi-matchbox",
       "schemaFile": "provider/cmd/pulumi-resource-matchbox/schema.json"
     },


### PR DESCRIPTION
Part of <https://github.com/pulumi/registry/issues/5945>.

<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [ ] Typescript
                - [ ] Python
                - [ ] Go
                - [ ] C#
                - [ ] Java (optional)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [ ] `/docs/installation-configuration.md` links to all published SDKs.

            - [ ] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
