### PR TITLE
Workaround https://github.com/pulumi/pulumi-aws/issues/5229

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -293,6 +293,10 @@ const cdn = new aws.cloudfront.Distribution(
     {
         protect: true,
         dependsOn: [ websiteLogsBucket ],
+        // Work-around https://github.com/pulumi/pulumi-aws/issues/5229 to allow upgrading the version of pulumi-aws used.
+        //
+        // Before upgrading to v6, this has no effect.
+        ignoreChanges: ["staging"],
     },
 );
 


### PR DESCRIPTION
This is a necessary step to upgrade pulumi-aws to v6. It has been recommended and vetted by Keith:

https://github.com/pulumi/pulumi-aws/issues/5229#issuecomment-2707734229

<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [ ] Typescript
                - [ ] Python
                - [ ] Go
                - [ ] C#
                - [ ] Java (optional)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [ ] `/docs/installation-configuration.md` links to all published SDKs.

            - [ ] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
