### PR TITLE
Refine contribution process

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yml
+++ b/.github/ISSUE_TEMPLATE/new-package.yml
@@ -1,5 +1,5 @@
-name: New Provider
-description: Request to add a new provider to the registry.
+name: New Package
+description: Request to add a new package to the registry.
 type: Task
 labels:
   - needs-triage
@@ -8,9 +8,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for your interest in adding a new provider to the Pulumi Registry! Please fill out the following information to help us understand your request.
+        Thank you for your interest in adding a new package to the Pulumi Registry! Please fill out the following information to help us understand your request.
 
-        If you are the maintainer of the provider, please also complete the [Pulumi Registry Onboarding form](https://docs.google.com/forms/d/e/1FAIpQLSe8ohRL1PP00KTXEGPYawjY-PgrbxCH6Z88wBqxEDMa4hw2qw/viewform).
+        If you are the maintainer of the package, please also complete the [Pulumi Registry Onboarding form](https://docs.google.com/forms/d/e/1FAIpQLSe8ohRL1PP00KTXEGPYawjY-PgrbxCH6Z88wBqxEDMa4hw2qw/viewform).
   - type: dropdown
     id: PackageType
     attributes:
@@ -18,7 +18,7 @@ body:
       description: Type of the package (see https://www.pulumi.com/docs/iac/concepts/packages/).
       options:
         - Native Pulumi Provider
-        - Terraform/OpenTofu provider
+        - Terraform/OpenTofu Provider
         - Component
         - Other/Not sure
   - type: input

--- a/.github/ISSUE_TEMPLATE/new-provider.yml
+++ b/.github/ISSUE_TEMPLATE/new-provider.yml
@@ -5,15 +5,22 @@ labels:
   - needs-triage
   - kind/package
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your interest in adding a new provider to the Pulumi Registry! Please fill out the following information to help us understand your request.
+
+        If you are the maintainer of the provider, please also complete the [Pulumi Registry Onboarding form](https://docs.google.com/forms/d/e/1FAIpQLSe8ohRL1PP00KTXEGPYawjY-PgrbxCH6Z88wBqxEDMa4hw2qw/viewform).
   - type: dropdown
     id: PackageType
     attributes:
       label: Package Type
-      description: Type of the package (e.g., Terraform, Native, Component).
+      description: Type of the package (see https://www.pulumi.com/docs/iac/concepts/packages/).
       options:
-        - Pulumi Provider (bridged or native)
+        - Native Pulumi Provider
         - Terraform/OpenTofu provider
         - Component
+        - Other/Not sure
   - type: input
     id: PackageName
     attributes:
@@ -26,7 +33,15 @@ body:
       label: Repository URL
       description: URL of the repository where the package can be found.
       placeholder: https://github.com/pulumi/pulumi-xyz
-  - type: markdown
+  - type: input
+    id: Connection
     attributes:
+      label: Connection to the Package
+      description: How are you connected to the package? (e.g., maintainer, user, etc.)
+      placeholder: I am a [maintainer/user/etc.] of the package.
+  - type: textarea
+    id: OtherInfo
+    attributes:
+      label: Other Information
       value: |
         Please provide any additional information or context that may be helpful in reviewing this request.

--- a/.github/ISSUE_TEMPLATE/new-provider.yml
+++ b/.github/ISSUE_TEMPLATE/new-provider.yml
@@ -1,0 +1,32 @@
+name: New Provider
+description: Request to add a new provider to the registry.
+type: Task
+labels:
+  - needs-triage
+  - kind/package
+body:
+  - type: dropdown
+    id: PackageType
+    attributes:
+      label: Package Type
+      description: Type of the package (e.g., Terraform, Ansible).
+      options:
+        - Pulumi Provider (bridged or native)
+        - Terraform/OpenTofu provider
+        - Component
+  - type: input
+    id: PackageName
+    attributes:
+      label: Package Name
+      description: Name of the package from the source.
+      placeholder: Your package name
+  - type: input
+    id: RepositoryUrl
+    attributes:
+      label: Repository URL
+      description: URL of the repository where the package can be found.
+      placeholder: https://github.com/pulumi/pulumi-xyz
+  - type: markdown
+    attributes:
+      value: |
+        Please provide any additional information or context that may be helpful in reviewing this request.

--- a/.github/ISSUE_TEMPLATE/new-provider.yml
+++ b/.github/ISSUE_TEMPLATE/new-provider.yml
@@ -9,7 +9,7 @@ body:
     id: PackageType
     attributes:
       label: Package Type
-      description: Type of the package (e.g., Terraform, Ansible).
+      description: Type of the package (e.g., Terraform, Native, Component).
       options:
         - Pulumi Provider (bridged or native)
         - Terraform/OpenTofu provider

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Adding a Package
 
-If you want to see a new package to the Pulumi Registry, open an issue requesting the addition using the ["New Provider"](https://github.com/pulumi/registry/issues/new?template=new-provider.yml) issue template. You can request either a [Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/) (Native, Bridged or Component) that you have written or any Terraform Provider present in the [opentofu package registry](https://search.opentofu.org).
+If you want to see a new package to the Pulumi Registry, open an issue requesting the addition using the ["New Package"](https://github.com/pulumi/registry/issues/new?template=new-package.yml) issue template. You can request either a [Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/) (Native, Bridged or Component) that you have written or any Terraform/OpenTofu provider present in the [opentofu package registry](https://search.opentofu.org).
 
 For assistance, please reach out on the [Pulumi community slack](https://slack.pulumi.com/) or get in touch with us via this [contact form](https://pulumi.com/contact/?form=registry).
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ To publish a community-maintained package on the Pulumi Registry as a community 
 
 ## Internal Process
 
-When a community member requests adding a provider to the registry, a Pulumi staff member should perform the following steps:
-
-1. Add the package to the [community packages list](./community-packages/package-list.json) via pull request to this repository.
-1. Follow the instructions outlined in [docs/adding-a-new-package.md](./docs/adding-a-new-package.md) to validate the PR, requesting updates as necessary.
-1. Merge the PR.
+Pulumi maintainers should follow the [adding a new package guide](./docs/adding-a-new-package.md).
 
 ## About this repository
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Registry
 
-[Pulumi Registry](https://pulumi.com/registry) is the global index of everything you can do with Pulumi. The home of pulumi.com/registry.
+[Pulumi Registry](https://pulumi.com/registry) is the public index of Pulumi extensions and integrations.
 
-## Authoring a Pulumi Package
+## Adding a Package
 
-We’re always eager to expand that index with new [Pulumi Packages](https://www.pulumi.com/docs/guides/pulumi-packages/). Whether you want to author a new native provider, bridge a provider from the Terraform ecosystem, or create a cloud component with best practices and sensible defaults built in, we’d like to work with you to list it on Pulumi Registry.
-To get started, use our [guide on authoring a Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/) of your own.
+To add a package to the Pulumi Registry, open an issue requesting the addition using the ["New Provider"](https://github.com/pulumi/registry/issues/new?template=new-provider.yml) issue template.
 
-### Publishing a Community Package on the Registry
+For assistance, please reach out on the [Pulumi community slack](https://slack.pulumi.com/) or get in touch with us via this [contact form](https://pulumi.com/contact/?form=registry).
 
-#### Community Steps
+### Preparing a Pulumi Provider Package
+
+We’re always eager to expand that index with new [Pulumi Packages](https://www.pulumi.com/docs/guides/pulumi-packages/). To get started, use our [guide on authoring a Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/) of your own.
 
 To publish a community-maintained package on the Pulumi Registry as a community member:
 
@@ -17,14 +18,18 @@ To publish a community-maintained package on the Pulumi Registry as a community 
     * `docs/_index.md`, which should contain a summary of the provider's purpose (required) along with a code sample (preferred). This file will render as the index page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/)).
     * `docs/installation-configuration.md`, which should contain links to SDK packages in each language along with instructions for configuring the provider (e.g., required credentials and/or environment variables). This file will render as the Installation & Configuration page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/installation-configuration/)).
 1. Create a release of your provider in GitHub.
-1. Add your package to the [community packages list](./community-packages/package-list.json) via pull request to this repository.
 
-For assistance, please reach out on the [Pulumi community slack](https://slack.pulumi.com/) or get in touch with us via this [contact form](https://pulumi.com/contact/?form=registry).
+### Other Package Types
 
-#### Pulumi Steps
+Terraform/OpenTofu providers which have not yet been bridged can be requested through the ["Any Terraform Provider" wrapper](https://www.pulumi.com/registry/packages/terraform-provider/), though we recommend following the [authoring guide](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/) to create published SDKs & refine resource configurations.
 
-Once the community member has submitted the PR to add the provider to the registry, a Pulumi staff member should perform the following steps:
+[Components can also created and shared](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/build-a-component/) via the registry, combining one or more resources into a reusable abstraction.
 
+## Internal Process
+
+When a community member requests adding a provider to the registry, a Pulumi staff member should perform the following steps:
+
+1. Add the package to the [community packages list](./community-packages/package-list.json) via pull request to this repository.
 1. Review the PR. Ensure that the PR has been rebased if necessary before merging. If ok, merge.
 1. Once the PR is merged, a [scheduled task](https://github.com/pulumi/registry/actions/workflows/generate-package-metadata.yml) will pick up the changes and create a PR to add the package metadata to the registry. A correct metadata PR ([example](https://github.com/pulumi/registry/pull/1606/files)) will include the following files, at a minimum:
    * `data/registry/${PROVIDER}.yaml` which includes structured metadata about the provider. This file is always included with every PR that gets generated for a new release.
@@ -40,10 +45,9 @@ Once the community member has submitted the PR to add the provider to the regist
 
 ## About this repository
 
-This repository is a [Hugo module](https://gohugo.io/hugo-modules/) that doubles as a development server to make it easier to work on the pages that make up Pulumi Registry. It contains all of the Hugo `content` and `layouts` files, JavaScript, CSS, and web components. comprising what you see at https://pulumi.com/registry
+This repository is a [Hugo module](https://gohugo.io/hugo-modules/) that doubles as a development server to make it easier to work on the pages that make up Pulumi Registry. It contains all of the Hugo `content` and `layouts` files, JavaScript, CSS, and web components. comprising what you see at <https://pulumi.com/registry>
 
 We build the JavaScript and CSS bundles that power the Pulumi Registry here, under the `themes/default/theme` directory. If you are making styling changes along-side content changes, use `make serve-all` to enable hot reloading of both the pages and CSS/JS assets.
-
 
 ## Using this repository
 
@@ -59,17 +63,18 @@ We build the Pulumi website statically with Hugo, manage our Node.js dependencie
 ### Installing dependencies
 
 The prerequisites listed above need to be installed on your machine in order to serve the site.
+
 1. Run `make ensure` to check for the appropriate tools and versions, and install any dependencies. The script will let you know if you're missing anything important.
   
-	```
-	make ensure
-	```
+ ```
+ make ensure
+ ```
 
 1. Once that succeeds, run `make build_assets` to build the assets the site depends on. This needs to be done before the first time you serve this repo so the assets exist on your local machine.
 
-	```
-	make build-assets
-	```
+ ```
+ make build-assets
+ ```
 
 ### Running Hugo locally
 
@@ -103,8 +108,7 @@ make lint
 
 When you're ready to submit a pull request, make sure you've removed anything that doesn't seem to belong (`go.mod`/`go.sum` changes, etc.) and submit the PR in the usual way.
 
-
 > [!NOTE]
-> It currently requires a machine with a minimum of 32 GB of memory (64 GB preferred) to build the registry in its entirety including _all_ pacakges.
+> It currently requires a machine with a minimum of 32 GB of memory (64 GB preferred) to build the registry in its entirety including *all* pacakges.
 
-Once your PR is approved and merged into the default branch of this repository, it will be deployed to the registry site (https://pulumi.com/registry).
+Once your PR is approved and merged into the default branch of this repository, it will be deployed to the registry site (<https://pulumi.com/registry>).

--- a/README.md
+++ b/README.md
@@ -4,44 +4,28 @@
 
 ## Adding a Package
 
-To add a package to the Pulumi Registry, open an issue requesting the addition using the ["New Provider"](https://github.com/pulumi/registry/issues/new?template=new-provider.yml) issue template.
+If you want to see a new package to the Pulumi Registry, open an issue requesting the addition using the ["New Provider"](https://github.com/pulumi/registry/issues/new?template=new-provider.yml) issue template. You can request either a [Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/) (Native, Bridged or Component) that you have written or any Terraform Provider present in the [opentofu package registry](https://search.opentofu.org).
 
 For assistance, please reach out on the [Pulumi community slack](https://slack.pulumi.com/) or get in touch with us via this [contact form](https://pulumi.com/contact/?form=registry).
 
-### Preparing a Pulumi Provider Package
+### Adding a Pulumi Package that you have authored
 
 We’re always eager to expand that index with new [Pulumi Packages](https://www.pulumi.com/docs/guides/pulumi-packages/). To get started, use our [guide on authoring a Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/) of your own.
 
 To publish a community-maintained package on the Pulumi Registry as a community member:
 
 1. Ensure your provider repo has the following files:
-    * `docs/_index.md`, which should contain a summary of the provider's purpose (required) along with a code sample (preferred). This file will render as the index page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/)).
-    * `docs/installation-configuration.md`, which should contain links to SDK packages in each language along with instructions for configuring the provider (e.g., required credentials and/or environment variables). This file will render as the Installation & Configuration page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/installation-configuration/)).
-1. Create a release of your provider in GitHub.
-
-### Other Package Types
-
-Terraform/OpenTofu providers which have not yet been bridged can be requested through the ["Any Terraform Provider" wrapper](https://www.pulumi.com/registry/packages/terraform-provider/), though we recommend following the [authoring guide](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/) to create published SDKs & refine resource configurations.
-
-[Components can also created and shared](https://www.pulumi.com/docs/iac/using-pulumi/extending-pulumi/build-a-component/) via the registry, combining one or more resources into a reusable abstraction.
+    * `docs/_index.md`, which should contain a summary of the provider's purpose (required) along with a code sample in each language (required). This file will render as the index page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/)).
+    * `docs/installation-configuration.md`, which should contain links to published SDKs in (Go, Typescript, C#, Python; required) along with instructions for configuring the provider (e.g., required credentials and/or environment variables). This file will render as the Installation & Configuration page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/installation-configuration/)).
+1. Create a release of your provider in GitHub with a "v" + [Semver 2.0](https://semver.org) compliant tag (`vX.Y.Z`).
 
 ## Internal Process
 
 When a community member requests adding a provider to the registry, a Pulumi staff member should perform the following steps:
 
 1. Add the package to the [community packages list](./community-packages/package-list.json) via pull request to this repository.
-1. Review the PR. Ensure that the PR has been rebased if necessary before merging. If ok, merge.
-1. Once the PR is merged, a [scheduled task](https://github.com/pulumi/registry/actions/workflows/generate-package-metadata.yml) will pick up the changes and create a PR to add the package metadata to the registry. A correct metadata PR ([example](https://github.com/pulumi/registry/pull/1606/files)) will include the following files, at a minimum:
-   * `data/registry/${PROVIDER}.yaml` which includes structured metadata about the provider. This file is always included with every PR that gets generated for a new release.
-   * `themes/default/content/registry/packages/${PROVIDER}/installation-configuration.md`, as described above. This file *must* be included in the first release, but will only be included in subsequent PRs if the content has changed.
-   * `themes/default/content/registry/packages/exoscale/_index.md`, as described above. This file *must* be included in the first release, but will only be included in subsequent PRs if the content has changed.
-
-   Optionally, the PR may include additional content files like How-To Guides if they are present in the upstream repo.
-
-1. Merge the PR if it looks ok.
-1. In pulumi/docs, a [scheduled task](https://github.com/pulumi/docs/actions/workflows/update-theme.yml) runs hourly and will pick up any changes in this repo, generate files from the provider schema and `data/registry/${PROVIDER}.yaml`, and publish to pulumi.com.
-
-  This scheduled task currently lacks adequate monitoring, and **should be watched to ensure that it runs correctly to completion**. (If it fails, it will block all updates to pulumi.com, including marketing and manually maintained docs pages.)
+1. Follow the instructions outlined in [docs/adding-a-new-package.md](./docs/adding-a-new-package.md) to validate the PR, requesting updates as necessary.
+1. Merge the PR.
 
 ## About this repository
 

--- a/docs/adding-a-new-package.md
+++ b/docs/adding-a-new-package.md
@@ -52,3 +52,15 @@ To keep quality in the Pulumi Registry high, we have a check-list before merging
   - [ ] Each published SDK has a matching release
 
 - [ ] A CODEOWNER has approved the PR.
+
+## Adding the package
+
+When a community member requests adding a provider to the registry, a Pulumi staff member should perform the following steps:
+
+1. Add the package to the [community packages list](./community-packages/package-list.json) via pull request to this repository.
+1. Follow the instructions outlined in [docs/adding-a-new-package.md](./docs/adding-a-new-package.md) to validate the PR, requesting updates as necessary.
+1. Merge the PR.
+
+In pulumi/docs, a [scheduled task](https://github.com/pulumi/docs/actions/workflows/update-theme.yml) runs hourly and will pick up any changes in this repo, generate files from the provider schema and `data/registry/${PROVIDER}.yaml`, and publish to pulumi.com.
+
+  This scheduled task currently lacks adequate monitoring, and **should be watched to ensure that it runs correctly to completion**. (If it fails, it will block all updates to pulumi.com, including marketing and manually maintained docs pages.)


### PR DESCRIPTION
Use issues rather than PRs as the main mechanism for adding packages as this allows requesting a dynamically bridged provider or component to be listed as well as native or statically bridged providers.

This deficiency was found while trying to show a customer how to add their Terraform provider to the registry via dynamic bridging and realising it's not currently possible.