### PR TITLE
Add CAST AI package metadata to package list

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -1,6 +1,10 @@
 {
   "include": [
     {
+      "repoSlug": "castai/pulumi-castai",
+      "schemaFile": "provider/sdk/schema/schema.json"
+    },
+    {
       "repoSlug": "koyeb/pulumi-koyeb",
       "schemaFile": "provider/cmd/pulumi-resource-koyeb/schema.json"
     },


### PR DESCRIPTION
### Checklist
Please make sure that you have:
- [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The part after the leading `v` must be valid semver 2.0.
- [ ] Published an SDK for your provider in:
    - [ ] Typescript
    - [ ] Python
    - [ ] Go
    - [ ] C#
    - [ ] Java (optional)
- [ ] Have checked in a schema.json that matches the location of the `schemaFile`
      specified in `/community-packages/package-list.json`.
- [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
      out in your repo.
- [ ] `/docs/installation-configuration.md` links to all published SDKs.
- [ ] `/docs/index.md` shows an example of using your provider in each language.