### PR TITLE
Handle "Cloud provider detected" error in cypress tests

### DIFF
--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -1,3 +1,20 @@
+/**
+ * Handle uncaught exceptions from third-party scripts.
+ * 
+ * The vector.co pixel.js script throws an uncaught exception when it detects a cloud provider environment.
+ * This happens in the GitHub Actions runner but not locally, causing tests to fail in CI.
+ * 
+ * We catch and ignore this specific error while still allowing other legitimate errors to fail the tests.
+ */
+Cypress.on('uncaught:exception', (err) => {
+    // Return false to prevent the error from failing the test
+    if (err.message.includes('Cloud provider detected')) {
+        return false;
+    }
+    // Return true for other errors to fail the test
+    return true;
+});
+
 describe("www.pulumi.com", () => {
 
     // This should probably be testing the Registry home page and not the home-home page.


### PR DESCRIPTION
Ignores "Cloud provider detected" error being thrown by vector.co/pixel.js script.
These analytics scripts try to detect and block traffic from cloud hosted
environments, which a GH runner technically is, in order to prevent abuse and filter
out "non-human" traffic. So this handles that error so we do not fail the tests on
that specific error.

This replicates a similar fix applied to the docs page:
https://github.com/pulumi/docs/pull/14702

Fixes https://github.com/pulumi/registry/issues/7069