### PR TITLE
Auto-merge tutorial update PRs

### DIFF
--- a/.github/workflows/update-tutorials.yml
+++ b/.github/workflows/update-tutorials.yml
@@ -18,22 +18,37 @@ jobs:
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
+      - name: Checkout examples repo
+        id: checkout-examples
+        uses: actions/checkout@v4
+        with:
+          repository: pulumi/examples
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          path: "examples"
+
       - name: Run mktutorial
         run: |
-          ./scripts/ci/mktutorial.sh
+          ./scripts/ci/mktutorial.sh $GITHUB_WORKSPACE/examples
 
       - name: Create a pull request
-        uses: peter-evans/create-pull-request@v3
+        id: ensure-pr
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: tutorials/refresh
           author: Pulumi Bot <bot@pulumi.com>
           committer: Pulumi Bot <bot@pulumi.com>
           title: Update tutorials
-          labels: "automation/merge"
-          commit-message: Update tutorials
+          commit-message: "Update tutorials from ${{ steps.checkout-examples.outputs.commit }}"
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          delete-branch: true
           body: |
             Regenerate all tutorials based on the latest available content at https://github.com/pulumi/examples.
+      - name: Auto-merge PR
+        # If the pull request was created, then we need to mark it as auto-merge.
+        if: ${{ steps.ensure-pr.outputs.pull-request-operation == 'created' }}
+        run: gh pr merge --auto --rebase "${{ steps.ensure-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   notify:
     if: failure()
     name: Send slack notification

--- a/scripts/ci/mktutorial.sh
+++ b/scripts/ci/mktutorial.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -e
 TUTORIAL_OUT=$(mktemp -d)
-pushd ./tools/mktutorial
-go run ./*.go https://github.com/pulumi/examples "$TUTORIAL_OUT"
-popd
+make bin/mktutorial
+bin/mktutorial "$1" "$TUTORIAL_OUT"
 for cloud in "aws-apigateway" "aws" "classic-azure" "azure" "gcp" "kubernetes" ; do
     ## Temporary hack to address mismatched package names in pulumi/examples
     if [[ "$cloud" == "azure" ]]; then

--- a/tools/mktutorial/main.go
+++ b/tools/mktutorial/main.go
@@ -15,10 +15,8 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -41,30 +39,16 @@ var langMap = map[string]string{
 }
 
 func main() {
-	// Parse and validate the args.
-	flag.Parse()
-	args := flag.Args()
-	if len(args) < 2 {
-		exitErr("usage: %s <tutorial-repo> <docs-root-dir>", os.Args[0])
+	if len(os.Args) < 2 {
+		exitErr("usage: %s <examples-repo> <docs-root-dir>", os.Args[0])
 	}
-	repo := os.Args[1]
+	examples := os.Args[1]
 	docsRoot := os.Args[2]
 
-	// Clone the tutorial repo at master/HEAD so the tool isn't dependent on the local filesystem.
-	fmt.Printf("Gathering tutorials from %s...\n", repo)
-	tmp, err := os.MkdirTemp("", "")
-	if err != nil {
-		exitErr("creating temp dir for tutorial repo: %v", err)
-	}
-	defer os.RemoveAll(tmp)
-	cmd := exec.Command("git", "clone", "-b", "master", repo, "--depth=1", tmp)
-	cmd.Stdout = os.Stdout
-	if err = cmd.Run(); err != nil {
-		exitErr("cloning tutorial repo: %v", err)
-	}
+	fmt.Printf("Gathering tutorials from %s...\n", examples)
 
 	// Now, for every directory in the tutorial repo, accumulate metadata.
-	tuts, err := gatherTutorials(tmp)
+	tuts, err := gatherTutorials(examples)
 	if err != nil {
 		exitErr("gathering tutorials: %v", err)
 	}


### PR DESCRIPTION
This PR fixes the auto-merge CI action, moving away from the `automation/merge` label that observably doesn't do anything towards just calling `gh pr merge --auto`.

This commit also moves checkout out `pulumi/examples` into the CI script so the commit associated with the new tutorials change can be included in the commit message.

<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [ ] Typescript
                - [ ] Python
                - [ ] Go
                - [ ] C#
                - [ ] Java (optional)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [ ] `/docs/installation-configuration.md` links to all published SDKs.

            - [ ] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
