### PR TITLE
Isolate intersight browser tests

### DIFF
--- a/scripts/run-browser-tests.js
+++ b/scripts/run-browser-tests.js
@@ -24,6 +24,7 @@ const singles = [
     "google-native",
     "kubernetes",
     "oci",
+    "intersight",
 ];
 
 const allPkgs = getPackagesMetadata();


### PR DESCRIPTION
The intersight test currently fails with OOM error - so try to run this provider in isolation to avoid this.

Fixes https://github.com/pulumi/registry/issues/7285