### PR TITLE
Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v1.64.8
+        version: v2.1.6
         working-directory: ${{ inputs.path }}
         args: --config $GITHUB_WORKSPACE/.golangci.yml
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,12 @@
-run:
-  timeout: 10m
+version: "2"
 linters:
-  enable-all: false
   enable:
     - durationcheck
-    - errcheck
     - exhaustive
-    - gofumpt
     - goheader
     - goprintffuncname
     - gosec
-    - govet
     - importas
-    - ineffassign
     - lll
     - misspell
     - nakedret
@@ -21,65 +15,64 @@ linters:
     - perfsprint
     - prealloc
     - revive
-    - tenv
     - unconvert
-    - unused
     - wastedassign
     - whitespace
+  settings:
+    goheader:
+      values:
+        regexp:
+          COPYRIGHT_YEARS: (\d{4}-)?\d{4}
+          WHITESPACE: \s*
+      template: |-
+        Copyright {{ COPYRIGHT_YEARS }}, Pulumi Corporation.
 
-linters-settings:
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 60
-  govet:
-    enable:
-      - nilness
-      # Reject comparisons of reflect.Value with DeepEqual or '=='.
-      - reflectvaluecompare
-      # Reject sort.Slice calls with a non-slice argument.
-      - sortslice
-      # Detect write to struct/arrays by-value that aren't read again.
-      - unusedwrite
-  goheader:
-    values:
-      regexp:
-        COPYRIGHT_YEARS: (\d{4}-)?\d{4}
-        WHITESPACE: \s*
-    template: |-
-      Copyright {{ COPYRIGHT_YEARS }}, Pulumi Corporation.
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
 
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
+        {{ WHITESPACE }}http://www.apache.org/licenses/LICENSE-2.0
 
-      {{ WHITESPACE }}http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-
-issues:
-  exclude-rules:
-    # Don't warn on unused parameters.
-    # Parameter names are useful; replacing them with '_' is undesirable.
-    - linters: [revive]
-      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
-
-    # staticcheck already has smarter checks for empty blocks.
-    # revive's empty-block linter has false positives.
-    # For example, as of writing this, the following is not allowed.
-    #   for foo() { }
-    - linters: [revive]
-      text: 'empty-block: this block is empty, you can remove it'
-
-    # We *frequently* use the term 'new' in the context of properties
-    # (new and old properties),
-    # and we rarely use the 'new' built-in function.
-    # It's fine to ignore these cases.
-    - linters: [revive]
-      text: 'redefines-builtin-id: redefinition of the built-in function new'
-
-  exclude-dirs-use-default: true
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      enable:
+        - nilness
+        - reflectvaluecompare
+        - sortslice
+        - unusedwrite
+    nakedret:
+      max-func-lines: 60
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - revive
+        text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+      - linters:
+          - revive
+        text: 'empty-block: this block is empty, you can remove it'
+      - linters:
+          - revive
+        text: 'redefines-builtin-id: redefinition of the built-in function new'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ lint-go: lint-resourcedocsgen lint-mktutorial
 
 .PHONY: lint-resourcedocsgen
 lint-resourcedocsgen:
-	cd tools/resourcedocsgen/ && golangci-lint run --config ../../.golangci.yml --path-prefix tools/resourcedocsgen/
+	cd tools/resourcedocsgen/ && golangci-lint run --config ../../.golangci.yml
 
 .PHONY: lint-mktutorial
 lint-mktutorial:
-	cd tools/mktutorial/ && golangci-lint run --config ../../.golangci.yml --path-prefix tools/mktutorial/
+	cd tools/mktutorial/ && golangci-lint run --config ../../.golangci.yml
 
 .PHONY: test
 test:

--- a/tools/mktutorial/main.go
+++ b/tools/mktutorial/main.go
@@ -108,7 +108,7 @@ func gatherTutorials(root string) ([]tutorial, error) {
 		var h1 string
 		top.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
 			if node.Type == blackfriday.Link && pulumiTemplateURL == "" {
-				destination := string(node.LinkData.Destination)
+				destination := string(node.Destination)
 
 				if destination == "https://app.pulumi.com/new" {
 					pulumiTemplateURL = githubURL
@@ -118,7 +118,7 @@ func gatherTutorials(root string) ([]tutorial, error) {
 					pulumiTemplateURL = strings.ReplaceAll(pulumiTemplateURL, "#gh-light-mode-only", "")
 				}
 			}
-			if (node.Type == blackfriday.Heading && node.HeadingData.Level == 1) && h1 == "" {
+			if (node.Type == blackfriday.Heading && node.Level == 1) && h1 == "" {
 				node.Walk(func(inner *blackfriday.Node, entering bool) blackfriday.WalkStatus {
 					if inner.Type == blackfriday.Text {
 						h1 += string(inner.Literal)

--- a/tools/resourcedocsgen/cmd/pkgversion.go
+++ b/tools/resourcedocsgen/cmd/pkgversion.go
@@ -43,7 +43,7 @@ The version in the registry is defined in the YAML file at:
     https://raw.githubusercontent.com/pulumi/registry/master/themes/default/data/registry/packages/${PKG#pulumi/pulumi-}.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if strings.Contains(repoSlug, "https") || strings.Contains(repoSlug, "github.com") {
-				return fmt.Errorf("Expected repoSlug to be in the format of `owner/repo`"+
+				return fmt.Errorf("expected repoSlug to be in the format of `owner/repo`"+
 					" but got %q", repoSlug)
 			}
 
@@ -91,7 +91,7 @@ func getLatestVersion(repoSlug string) (string, error) {
 
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("Could not find a release at https://api.github.com%s: %w", path, err)
+		return "", fmt.Errorf("could not find a release at https://api.github.com%s: %w", path, err)
 	}
 
 	var tag pkg.GitHubTag

--- a/tools/resourcedocsgen/pkg/docs/constructor_syntax_generator.go
+++ b/tools/resourcedocsgen/pkg/docs/constructor_syntax_generator.go
@@ -51,8 +51,8 @@ func (g *constructorSyntaxGenerator) indent(buffer *bytes.Buffer) {
 	buffer.WriteString(strings.Repeat(" ", g.indentSize))
 }
 
-func (g *constructorSyntaxGenerator) writef(buffer *bytes.Buffer, format string, args ...interface{}) {
-	buffer.WriteString(fmt.Sprintf(format, args...))
+func (g *constructorSyntaxGenerator) writef(buffer *bytes.Buffer, format string, args ...any) {
+	fmt.Fprintf(buffer, format, args...)
 }
 
 func (g *constructorSyntaxGenerator) writeValue(


### PR DESCRIPTION
This upgrades the linter we use from v1.68.8 to v2.1.6. The `.golangci.yml` was migrated with `golangci-lint migrate`.