### PR TITLE
Add pulumi-duplocloud community package.

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -379,6 +379,10 @@
     {
       "repoSlug": "vatesfr/pulumi-xenorchestra",
       "schemaFile": "provider/cmd/pulumi-resource-xenorchestra/schema.json"
+    },
+    {
+      "repoSlug": "duplocloud/pulumi-duplocloud",
+      "schemaFile": "provider/cmd/pulumi-resource-duplocloud/schema.json"
     }
   ]
 }


### PR DESCRIPTION
# Description

Added [pulumi-duplocloud](https://github.com/duplocloud/pulumi-duplocloud) resource provider.


- [x] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
      part after the leading `v` must be valid semver 2.0.

    - Published an SDK for your provider in:
        - [x] Typescript
        - [x] Python
        - [x] Go
        - [x] C#
        - [ ] Java (optional)

- [x] Have checked in a schema.json that matches the location of the `schemaFile`
      specified in `/community-packages/package-list.json`.

- [x] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
      out in your repo.

    - [x] `/docs/installation-configuration.md` links to all published SDKs.

    - [x] `/docs/index.md` shows an example of using your provider in each language.
    
# DuploCloud Provider

Repository: https://github.com/duplocloud/pulumi-duplocloud

The DuploCloud provider is available as a package in all Pulumi languages:

* JavaScript/TypeScript: [`@duplocloud/pulumi`](https://www.npmjs.com/package/@duplocloud/pulumi)
* Python: [`pulumi-duplocloud`](https://pypi.org/project/pulumi-duplocloud/)
* Go: [`github.com/duplocloud/pulumi-duplocloud/sdk/go/duplocloud`](https://github.com/duplocloud/pulumi-duplocloud)
* .NET: [`DuploCloud.Pulumi`](https://www.nuget.org/packages/DuploCloud.Pulumi/)