### PR TITLE
Add auth tokens for all GitHub requests

### DIFF
--- a/tools/resourcedocsgen/cmd/docs/registry.go
+++ b/tools/resourcedocsgen/cmd/docs/registry.go
@@ -48,17 +48,6 @@ func getRepoSlug(repoURL string) (string, error) {
 	return u.Path, nil
 }
 
-func addGitHubAuthHeaders(req *http.Request) {
-	// Check if the request is for GitHub domains
-	host := req.URL.Host
-	if host == "github.com" || host == "api.github.com" || host == "raw.githubusercontent.com" {
-		// Add GitHub token from environment variable if available
-		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-			req.Header.Add("Authorization", "Bearer "+token)
-		}
-	}
-}
-
 func genResourceDocsForPackageFromRegistryMetadata(
 	metadata pkg.PackageMeta, docsOutDir, packageTreeJSONOutDir string,
 ) error {
@@ -72,10 +61,10 @@ func genResourceDocsForPackageFromRegistryMetadata(
 
 	req, err := http.NewRequest("GET", schemaFileURL, nil)
 	if err != nil {
-		return errors.Wrapf(err, "creating request for %s", schemaFileURL)
+		return errors.Wrapf(err, "creating request for %q", schemaFileURL)
 	}
 
-	addGitHubAuthHeaders(req)
+	pkg.AddGitHubAuthHeaders(req)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "reading schema file from VCS %s", schemaFileURL)

--- a/tools/resourcedocsgen/cmd/pkgversion.go
+++ b/tools/resourcedocsgen/cmd/pkgversion.go
@@ -104,7 +104,13 @@ func getLatestVersion(repoSlug string) (string, error) {
 }
 
 func getRegistryVersion(url string) (string, error) {
-	resp, err := http.Get(url) //nolint:gosec
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request for %q: %w", url, err)
+	}
+
+	pkg.AddGitHubAuthHeaders(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("getting latest version from %s: %w", url, err)
 	}

--- a/tools/resourcedocsgen/pkg/githubInfo.go
+++ b/tools/resourcedocsgen/pkg/githubInfo.go
@@ -43,6 +43,19 @@ func GetGitHubAPI(path string) (*http.Response, error) {
 	return client.Do(req)
 }
 
+// AddGitHubAuthHeaders adds GitHub authentication headers to the request if the request is for GitHub domains
+// and the GITHUB_TOKEN environment variable is set.
+func AddGitHubAuthHeaders(req *http.Request) {
+	// Check if the request is for GitHub domains
+	host := req.URL.Host
+	if host == "github.com" || host == "api.github.com" || host == "raw.githubusercontent.com" {
+		// Add GitHub token from environment variable if available
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			req.Header.Add("Authorization", "Bearer "+token)
+		}
+	}
+}
+
 type GitHubTag struct {
 	Name       string `json:"name"`
 	ZipballURL string `json:"zipball_url"`


### PR DESCRIPTION
Not all places sending requests to GitHub were using a GitHub auth token. We're seeing more and more CI runs fail due to rate limiting.

Fixes #7598 
Fixes #7605
Fixes #7617 