### PR TITLE
Improve bucket cleanup with lifecycle rules

### DIFF
--- a/scripts/ci/remove-buckets.sh
+++ b/scripts/ci/remove-buckets.sh
@@ -26,11 +26,85 @@ echo "Buckets to remove:"
 echo "$buckets_to_remove"
 echo
 
+
+# This is a lifecycle policy that deletes all objects and delete markers after 1 day (minimum).
+# After ~48 hours, the bucket will be empty and can be deleted.
+lifecycle_file=$(mktemp)
+printf '{
+  "Rules": [
+    {
+      "Expiration": {
+        "Days": 1
+      },
+      "ID": "FullDelete",
+      "Filter": {
+        "Prefix": ""
+      },
+      "Status": "Enabled",
+      "NoncurrentVersionExpiration": {
+        "NoncurrentDays": 1
+      },
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 1
+      }
+    },
+    {
+      "Expiration": {
+        "ExpiredObjectDeleteMarker": true
+      },
+      "ID": "DeleteMarkers",
+      "Filter": {
+        "Prefix": ""
+      },
+      "Status": "Enabled"
+    }
+  ]
+}' > "$lifecycle_file"
+
 for bucket in $buckets_to_remove; do
     echo "Removing ${bucket}..."
-    aws s3 rb "s3://${bucket}" --force
-    remove_param_for_commit "$(git_sha)" "$(aws_region)"
+    echo "Upserting lifecycle policy for ${bucket}..."
+    aws s3api put-bucket-lifecycle-configuration --bucket "${bucket}" --lifecycle-configuration "file://${lifecycle_file}"
+
+    # Check if bucket already has cleanup timestamp
+    existing_tags=$(aws s3api get-bucket-tagging --bucket "${bucket}" 2>/dev/null || echo '{"TagSet":[]}')
+    cleanup_started=$(echo "$existing_tags" | jq -r '.TagSet[] | select(.Key=="CleanupStarted") | .Value // empty')
+    
+    if [ -z "$cleanup_started" ]; then
+        # No cleanup tag exists, add it while preserving existing tags
+        timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        # Create new tag set by combining existing tags with the new cleanup tag
+        new_tags=$(echo "$existing_tags" | jq --arg ts "$timestamp" '.TagSet += [{"Key": "CleanupStarted", "Value": $ts}]')
+        aws s3api put-bucket-tagging --bucket "${bucket}" --tagging "$new_tags"
+        echo "Added cleanup timestamp tag to ${bucket}. It should be safe to delete within ~48 hours."
+    else
+        # Calculate time difference
+        current_time=$(date -u +%s)
+        # Parse the cleanup timestamp to Unix time, handling both Linux (-d) and macOS (-j) date syntax
+        cleanup_time=$(date -u -d "$cleanup_started" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$cleanup_started" +%s)
+        # Calculate seconds elapsed since cleanup started
+        time_diff=$((current_time - cleanup_time))
+
+        if [ $time_diff -gt 172800 ]; then  # 48 hours = 172800 seconds
+            echo "Attempting to delete bucket ${bucket} after 48+ hours of cleanup..."
+            if ! aws s3 rb "s3://${bucket}"; then
+                if [ $time_diff -gt 604800 ]; then  # 7 days = 604800 seconds
+                    echo "Error: Bucket ${bucket} has been in cleanup state for more than 7 days. Please resolve the issue and try again."
+                    exit 1
+                fi
+                echo "Warning: Failed to delete bucket ${bucket}, cleanup might still be in progress"
+            else
+                remove_param_for_commit "$(git_sha)" "$(aws_region)"
+            fi
+        else
+            echo "Bucket ${bucket} is still in cleanup idle period (${time_diff} seconds elapsed)"
+        fi
+    fi
+
     echo
 done
+
+# Clean up the temporary lifecycle policy file
+rm "$lifecycle_file"
 
 echo "Done!"

--- a/scripts/ci/remove-buckets.sh
+++ b/scripts/ci/remove-buckets.sh
@@ -30,6 +30,8 @@ echo
 # This is a lifecycle policy that deletes all objects and delete markers after 1 day (minimum).
 # After ~48 hours, the bucket will be empty and can be deleted.
 lifecycle_file=$(mktemp)
+trap 'rm -f "$lifecycle_file"' EXIT
+
 printf '{
   "Rules": [
     {
@@ -103,8 +105,5 @@ for bucket in $buckets_to_remove; do
 
     echo
 done
-
-# Clean up the temporary lifecycle policy file
-rm "$lifecycle_file"
 
 echo "Done!"


### PR DESCRIPTION
The S3 bucket cleanup has been consistently flaky because it has to delete all files in a bucket before being able to delete a bucket (S3 doesn't let you delete non-empty buckets). That's a looot of API requests we're firing off towards S3, ultimately making the cleanup job regularly take 2+ hours.

Instead of cleaning out the bucket ourselves, we can use lifecycle policies to make AWS to the heavy lifting in the background. We also don't have to pay for the API requests that way (💵).

The overall flow is to upsert the lifecycle policy when a bucket needs to be cleaned up and add a tag indicating when this was done. Once 48 hours have passed, the bucket should've been cleaned out by AWS (lifecycle rules run once a day afaik) and we can try deleting it if it's empty.

### Testing
I tested this by running it against a set of prepared test buckets:
```
# Create three test buckets
aws s3 mb s3://flo-test-bucket-fresh
aws s3 mb s3://flo-test-bucket-48h
aws s3 mb s3://flo-test-bucket-7d
aws s3 mb s3://flo-test-bucket-untagged

# Add some test content to each bucket
echo "test content" > test1.txt
echo "test content" > test2.txt
echo "test content" > test3.txt
echo "test content" > test4.txt

# Upload files to each bucket
aws s3 cp test1.txt s3://flo-test-bucket-fresh/
aws s3 cp test2.txt s3://flo-test-bucket-48h/
aws s3 cp test3.txt s3://flo-test-bucket-7d/
aws s3 cp test4.txt s3://flo-test-bucket-untagged/

# Add versioning to test lifecycle rules
aws s3api put-bucket-versioning --bucket flo-test-bucket-fresh --versioning-configuration Status=Enabled
aws s3api put-bucket-versioning --bucket flo-test-bucket-48h --versioning-configuration Status=Enabled
aws s3api put-bucket-versioning --bucket flo-test-bucket-7d --versioning-configuration Status=Enabled
aws s3api put-bucket-versioning --bucket flo-test-bucket-untagged --versioning-configuration Status=Enabled

# Create a second version of files to test version cleanup
echo "updated content" > test1.txt
echo "updated content" > test2.txt
echo "updated content" > test3.txt
echo "updated content" > test4.txt
aws s3 cp test1.txt s3://flo-test-bucket-fresh/
aws s3 cp test2.txt s3://flo-test-bucket-48h/
aws s3 cp test3.txt s3://flo-test-bucket-7d/
aws s3 cp test4.txt s3://flo-test-bucket-untagged/

# Add cleanup tags with different timestamps and additional tags
# Fresh bucket (current time)
aws s3api put-bucket-tagging --bucket flo-test-bucket-fresh --tagging 'TagSet=[{Key=CleanupStarted,Value='$(date -u +"%Y-%m-%dT%H:%M:%SZ")'},{Key=Environment,Value=test},{Key=Owner,Value=flo}]'

# 48h bucket (48 hours ago)
aws s3api put-bucket-tagging --bucket flo-test-bucket-48h --tagging 'TagSet=[{Key=CleanupStarted,Value='$(date -u -d "48 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-48H +"%Y-%m-%dT%H:%M:%SZ")'},{Key=Environment,Value=test},{Key=Owner,Value=flo}]'

# 7d bucket (7 days ago)
aws s3api put-bucket-tagging --bucket flo-test-bucket-7d --tagging 'TagSet=[{Key=CleanupStarted,Value='$(date -u -d "7 days ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-7d +"%Y-%m-%dT%H:%M:%SZ")'},{Key=Environment,Value=test},{Key=Owner,Value=flo}]'

# Add some tags to the untagged bucket (but not the cleanup tag)
aws s3api put-bucket-tagging --bucket flo-test-bucket-untagged --tagging 'TagSet=[{Key=Environment,Value=test},{Key=Owner,Value=flo}]'

# Clean up local test files
rm test1.txt test2.txt test3.txt test4.txt
```

Result:
```
AWS_PAGER="" ./scripts/ci/remove-buckets.sh
Finding deletable  buckets...
origin bucket prefix: registry--origin

Buckets to remove:
flo-test-bucket-fresh
flo-test-bucket-48h
flo-test-bucket-7d
flo-test-bucket-untagged

/var/folders/qb/q9rbqmxn1jqdfps720v2s9h80000gn/T/tmp.7sLn15AO2O
Removing flo-test-bucket-fresh...
Upserting lifecycle policy for flo-test-bucket-fresh...
{
    "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"
}
Bucket flo-test-bucket-fresh is still in cleanup idle period (732 seconds elapsed)

Removing flo-test-bucket-48h...
Upserting lifecycle policy for flo-test-bucket-48h...
{
    "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"
}
Attempting to delete bucket flo-test-bucket-48h after 48+ hours of cleanup...
remove_bucket: flo-test-bucket-48h

Removing flo-test-bucket-7d...
Upserting lifecycle policy for flo-test-bucket-7d...
{
    "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"
}
Attempting to delete bucket flo-test-bucket-7d after 48+ hours of cleanup...
remove_bucket: flo-test-bucket-7d

Removing flo-test-bucket-untagged...
Upserting lifecycle policy for flo-test-bucket-untagged...
{
    "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K"
}
Added cleanup timestamp tag to flo-test-bucket-untagged. It should be safe to delete within ~48 hours.

Done!
```

Fixes https://github.com/pulumi/registry/issues/7511