### PR TITLE
Run "Scheduled jobs: Check links" one day a week

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,8 +9,8 @@ name: "Scheduled jobs: Check links"
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string.
-    # Run every day at 3:00PM UTC.
-    - cron: "0 15 * * *"
+    # Run every Monday at 3:00PM UTC.
+    - cron: "0 15 * * MON"
   workflow_dispatch: null
 jobs:
   all:


### PR DESCRIPTION
Right now, this job runs daily. It generates a slack message in #registry-ops every day with ~70 links (they change run to run, since we also get rate limited). Real errors are flagged, but also URLs such as `server.com/example/name` and `your.url.here`. We also flag URLs from generated and user submitted content, so most errors are not addressable.

To keep this job a useful part of maintaining the registry, we need to invest in limiting the flagged links to pages Pulumi writes and then fixing the links. For now, we can at least make it less annoying.