### PR TITLE
Update pulumi/vercel to pulumiverse/vercel

### DIFF
--- a/themes/default/content/registry/packages/vercel/_index.md
+++ b/themes/default/content/registry/packages/vercel/_index.md
@@ -10,11 +10,10 @@ layout: package
 
 The Vercel provider is available as a package in all Pulumi languages:
 
-* JavaScript/TypeScript: [`@pulumi/vercel`](https://www.npmjs.com/package/@pulumi/vercel)
-* Python: [`pulumi-vercel`](https://pypi.org/project/pulumi-vercel/)
-* Go: [`github.com/pulumiverse/pulumi-vercel/sdk/v3/go/vercel`](https://github.com/pulumi/pulumi-vercel)
-* .NET: [`Pulumi.Vercel`](https://www.nuget.org/packages/Pulumi.Vercel)
-* Java: [`com.pulumi/vercel`](https://central.sonatype.com/artifact/com.pulumi/vercel)
+* JavaScript/TypeScript: [`@pulumiverse/vercel`](https://www.npmjs.com/package/@pulumiverse/vercel)
+* Python: [`pulumiverse-vercel`](https://pypi.org/project/pulumiverse-vercel/)
+* Go: [`github.com/pulumiverse/pulumi-vercel/sdk`](https://pkg.go.dev/github.com/pulumiverse/pulumi-vercel/sdk)
+* .NET: [`Pulumiverse.vercel`](https://www.nuget.org/packages/Pulumiverse.vercel)
 ## Overview
 
 The Vercel provider is used to interact with resources supported by Vercel.


### PR DESCRIPTION
Change the sdk urls to the correct ones. Also the Java sdk doesn't seem to exists.

<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [ ] Typescript
                - [ ] Python
                - [ ] Go
                - [ ] C#
                - [ ] Java (optional)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [ ] `/docs/installation-configuration.md` links to all published SDKs.

            - [ ] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
