### PR TITLE
Add publisher mapping for Statsig

### DIFF
--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -133,6 +133,7 @@
     "selectel": "selectel",
     "spectrocloud": "spectrocloud",
     "splightplatform": "splightplatform",
+    "Statsig": "statsig",
     "supabase": "supabase",
     "sysdiglabs": "sysdiglabs",
     "temporalio": "temporalio",


### PR DESCRIPTION
The statsig provider was added here https://github.com/pulumi/registry/pull/7808, but it's missing a publisher mapping. This fixes that.

Unblocks https://github.com/pulumi/registry/pull/7833