### PR TITLE
Add publisher mapping for sumologic

### DIFF
--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -134,6 +134,7 @@
     "spectrocloud": "spectrocloud",
     "splightplatform": "splightplatform",
     "Statsig": "statsig",
+    "sumologic": "sumologic",
     "supabase": "supabase",
     "sysdiglabs": "sysdiglabs",
     "temporalio": "temporalio",


### PR DESCRIPTION
Sumologic was turned into a dynamically bridged provider, but it's missing a publisher mapping. This adds that.

Relates to https://github.com/pulumi/pulumi-sumologic/issues/653