### PR TITLE
Set GITHUB_TOKEN for tests to avoid rate limits

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -44,6 +44,8 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
     - name: Run Tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE/${{ inputs.path }}
         go test ./... -v


### PR DESCRIPTION
Example error this should address

```
=== NAME  TestMetadataBridgedProvider
    metadata_test.go:35:
        	Error Trace:	/home/runner/work/registry/registry/tools/resourcedocsgen/cmd/metadata_test.go:286
        	            				/home/runner/work/registry/registry/tools/resourcedocsgen/cmd/metadata_test.go:35
        	Error:      	Received unexpected error:
        	            	getting tags info for pulumi/pulumi-random: {"message":"API rate limit exceeded for 135.119.132.145. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```
