### PR TITLE
Address breaking changes in AWS v7

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -147,7 +147,7 @@ const logsBucketOwnershipControls = new aws.s3.BucketOwnershipControls("logs-buc
 
 const logsBucketACL = new aws.s3.BucketAclV2("logs-bucket-acl", {
     bucket: websiteLogsBucket.id,
-    acl: aws.s3.PrivateAcl,
+    acl: aws.s3.CannedAcl.Private,
 }, {
     dependsOn: [logsBucketOwnershipControls],
 });


### PR DESCRIPTION
`PrivateAcl` got removed in AWS v7. It got replaced by `CannedAcl.Private`.

Fixes https://github.com/pulumi/registry/issues/8157