### PR TITLE
[providers] add volcenginecc to package list

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -241,6 +241,10 @@
       "schemaFile": "provider/cmd/pulumi-resource-volcengine/schema.json"
     },
     {
+      "repoSlug": "volcengine/pulumi-volcenginecc",
+      "schemaFile": "provider/cmd/pulumi-resource-volcenginecc/schema.json"
+    },
+    {
       "repoSlug": "netascode/pulumi-aci",
       "schemaFile": "provider/cmd/pulumi-resource-aci/schema.json"
     },


### PR DESCRIPTION
Looks like this was dropped during one of the regens on https://github.com/pulumi/registry/pull/8724/files

