### PR TITLE
Render resource description (if present)

### DIFF
--- a/tools/resourcedocsgen/cmd/docs/testdata/TestGenerateDocsAllPackage/registry/docs/aws-apigateway/api-docs/restapi/_index.md.golden
+++ b/tools/resourcedocsgen/cmd/docs/testdata/TestGenerateDocsAllPackage/registry/docs/aws-apigateway/api-docs/restapi/_index.md.golden
@@ -1781,6 +1781,8 @@ APIKey<wbr>Source<pulumi-choosable type="language" values="python,go" class="inl
 <h4 id="authorizer">
 Authorizer<pulumi-choosable type="language" values="python,go" class="inline">, Authorizer<wbr>Args</pulumi-choosable>
 </h4>
+LambdaAuthorizer provides the definition for a custom Authorizer for API Gateway.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -2937,6 +2939,10 @@ Required<wbr>Parameter<pulumi-choosable type="language" values="python,go" class
 <h4 id="route">
 Route<pulumi-choosable type="language" values="python,go" class="inline">, Route<wbr>Args</pulumi-choosable>
 </h4>
+A route that that APIGateway should accept and forward to some type of destination. All routes
+have an incoming path that they match against.  However, destinations are determined by the kind
+of the route.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/cmd/docs/testdata/TestGenerateDocsAllPackage/vcs/docs/aws-apigateway/api-docs/restapi/_index.md.golden
+++ b/tools/resourcedocsgen/cmd/docs/testdata/TestGenerateDocsAllPackage/vcs/docs/aws-apigateway/api-docs/restapi/_index.md.golden
@@ -1781,6 +1781,8 @@ APIKey<wbr>Source<pulumi-choosable type="language" values="python,go" class="inl
 <h4 id="authorizer">
 Authorizer<pulumi-choosable type="language" values="python,go" class="inline">, Authorizer<wbr>Args</pulumi-choosable>
 </h4>
+LambdaAuthorizer provides the definition for a custom Authorizer for API Gateway.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -2937,6 +2939,10 @@ Required<wbr>Parameter<pulumi-choosable type="language" values="python,go" class
 <h4 id="route">
 Route<pulumi-choosable type="language" values="python,go" class="inline">, Route<wbr>Args</pulumi-choosable>
 </h4>
+A route that that APIGateway should accept and forward to some type of destination. All routes
+have an incoming path that they match against.  However, destinations are determined by the kind
+of the route.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/gen.go
+++ b/tools/resourcedocsgen/pkg/docs/gen.go
@@ -286,11 +286,12 @@ type enum struct {
 
 // docNestedType represents a complex type.
 type docNestedType struct {
-	Name       string
-	Input      bool
-	AnchorID   string
-	Properties map[language.Language][]property
-	EnumValues map[language.Language][]enum
+	Name        string
+	Description string
+	Input       bool
+	AnchorID    string
+	Properties  map[language.Language][]property
+	EnumValues  map[language.Language][]enum
 }
 
 // propertyType represents the type of a property.
@@ -1116,9 +1117,10 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType, isProvid
 				//nolint:staticcheck
 				name := strings.Title(tokenToName(typ.Token))
 				typs = append(typs, docNestedType{
-					Name:       wbr(name),
-					AnchorID:   strings.ToLower(name),
-					Properties: props,
+					Name:        wbr(name),
+					AnchorID:    strings.ToLower(name),
+					Description: typ.Comment,
+					Properties:  props,
 				})
 			case *schema.EnumType:
 				if typ.Token != token || len(typ.Elements) == 0 {

--- a/tools/resourcedocsgen/pkg/docs/templates/resource.tmpl
+++ b/tools/resourcedocsgen/pkg/docs/templates/resource.tmpl
@@ -334,6 +334,9 @@ Only the first {{ .MaxNestedTypes }} types are included in this documentation.
 {{ htmlSafe $elem.Name }}<pulumi-choosable type="language" values="python,go" class="inline">, {{ htmlSafe $elem.Name }}<wbr>Args</pulumi-choosable>
 </h4>
 
+{{- if $elem.Description }}
+{{ markdownify $elem.Description }}
+{{ end -}}
 {{- if $elem.Properties }}{{template "properties" $elem.Properties -}}{{ end -}}
 {{- if $elem.EnumValues }}{{- template "enums" $elem.EnumValues -}}{{ end -}}
 {{- end -}}

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/kubernetes20/docs/core/v1/configmap/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/kubernetes20/docs/core/v1/configmap/_index.md
@@ -934,6 +934,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="managedfieldsentry">
 Managed<wbr>Fields<wbr>Entry<pulumi-choosable type="language" values="python,go" class="inline">, Managed<wbr>Fields<wbr>Entry<wbr>Args</pulumi-choosable>
 </h4>
+ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1310,6 +1312,8 @@ Managed<wbr>Fields<wbr>Entry<pulumi-choosable type="language" values="python,go"
 <h4 id="objectmeta">
 Object<wbr>Meta<pulumi-choosable type="language" values="python,go" class="inline">, Object<wbr>Meta<wbr>Args</pulumi-choosable>
 </h4>
+ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -2196,6 +2200,8 @@ Object<wbr>Meta<pulumi-choosable type="language" values="python,go" class="inlin
 <h4 id="ownerreference">
 Owner<wbr>Reference<pulumi-choosable type="language" values="python,go" class="inline">, Owner<wbr>Reference<wbr>Args</pulumi-choosable>
 </h4>
+OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/kubernetes20/docs/core/v1/configmaplist/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/kubernetes20/docs/core/v1/configmaplist/_index.md
@@ -901,6 +901,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="configmap">
 Config<wbr>Map<pulumi-choosable type="language" values="python,go" class="inline">, Config<wbr>Map<wbr>Args</pulumi-choosable>
 </h4>
+ConfigMap holds configuration data for pods to consume.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1133,6 +1135,8 @@ Config<wbr>Map<pulumi-choosable type="language" values="python,go" class="inline
 <h4 id="listmeta">
 List<wbr>Meta<pulumi-choosable type="language" values="python,go" class="inline">, List<wbr>Meta<wbr>Args</pulumi-choosable>
 </h4>
+ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1365,6 +1369,8 @@ List<wbr>Meta<pulumi-choosable type="language" values="python,go" class="inline"
 <h4 id="managedfieldsentry">
 Managed<wbr>Fields<wbr>Entry<pulumi-choosable type="language" values="python,go" class="inline">, Managed<wbr>Fields<wbr>Entry<wbr>Args</pulumi-choosable>
 </h4>
+ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1741,6 +1747,8 @@ Managed<wbr>Fields<wbr>Entry<pulumi-choosable type="language" values="python,go"
 <h4 id="objectmeta">
 Object<wbr>Meta<pulumi-choosable type="language" values="python,go" class="inline">, Object<wbr>Meta<wbr>Args</pulumi-choosable>
 </h4>
+ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -2627,6 +2635,8 @@ Object<wbr>Meta<pulumi-choosable type="language" values="python,go" class="inlin
 <h4 id="ownerreference">
 Owner<wbr>Reference<pulumi-choosable type="language" values="python,go" class="inline">, Owner<wbr>Reference<wbr>Args</pulumi-choosable>
 </h4>
+OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/kubernetes20/docs/provider/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/kubernetes20/docs/provider/_index.md
@@ -562,6 +562,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="kubeclientsettings">
 Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Kube<wbr>Client<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+Options for tuning the Kubernetes client used by a Provider.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-defaults/docs/foo/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-defaults/docs/foo/_index.md
@@ -836,6 +836,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="helmreleasesettings">
 Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Helm<wbr>Release<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+BETA FEATURE - Options to configure the Helm Release resource.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1020,6 +1022,8 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
 <h4 id="kubeclientsettings">
 Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Kube<wbr>Client<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+Options for tuning the Kubernetes client used by a Provider.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1204,6 +1208,8 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
 <h4 id="layeredtype">
 Layered<wbr>Type<pulumi-choosable type="language" values="python,go" class="inline">, Layered<wbr>Type<wbr>Args</pulumi-choosable>
 </h4>
+Make sure that defaults propagate through types
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-defaults/docs/moduletest/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-defaults/docs/moduletest/_index.md
@@ -640,6 +640,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="typ">
 Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr>Args</pulumi-choosable>
 </h4>
+A test for namespaces (mod main)
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -824,6 +826,8 @@ Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr
 <h4 id="typ">
 Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr>Args</pulumi-choosable>
 </h4>
+A test for namespaces (mod 1)
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -912,6 +916,8 @@ Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr
 <h4 id="typ">
 Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr>Args</pulumi-choosable>
 </h4>
+A test for namespaces (mod 2)
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-defaults/docs/provider/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-defaults/docs/provider/_index.md
@@ -422,6 +422,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="helmreleasesettings">
 Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Helm<wbr>Release<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+BETA FEATURE - Options to configure the Helm Release resource.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-disable-defaults/docs/foo/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-disable-defaults/docs/foo/_index.md
@@ -836,6 +836,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="helmreleasesettings">
 Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Helm<wbr>Release<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+BETA FEATURE - Options to configure the Helm Release resource.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1020,6 +1022,8 @@ Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go
 <h4 id="kubeclientsettings">
 Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Kube<wbr>Client<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+Options for tuning the Kubernetes client used by a Provider.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -1204,6 +1208,8 @@ Kube<wbr>Client<wbr>Settings<pulumi-choosable type="language" values="python,go"
 <h4 id="layeredtype">
 Layered<wbr>Type<pulumi-choosable type="language" values="python,go" class="inline">, Layered<wbr>Type<wbr>Args</pulumi-choosable>
 </h4>
+Make sure that defaults propagate through types
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -640,6 +640,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="typ">
 Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr>Args</pulumi-choosable>
 </h4>
+A test for namespaces (mod main)
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -824,6 +826,8 @@ Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr
 <h4 id="typ">
 Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr>Args</pulumi-choosable>
 </h4>
+A test for namespaces (mod 1)
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -912,6 +916,8 @@ Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr
 <h4 id="typ">
 Typ<pulumi-choosable type="language" values="python,go" class="inline">, Typ<wbr>Args</pulumi-choosable>
 </h4>
+A test for namespaces (mod 2)
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-disable-defaults/docs/provider/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/plain-object-disable-defaults/docs/provider/_index.md
@@ -422,6 +422,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="helmreleasesettings">
 Helm<wbr>Release<wbr>Settings<pulumi-choosable type="language" values="python,go" class="inline">, Helm<wbr>Release<wbr>Settings<wbr>Args</pulumi-choosable>
 </h4>
+BETA FEATURE - Options to configure the Helm Release resource.
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/replace-on-change/docs/cat/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/replace-on-change/docs/cat/_index.md
@@ -687,6 +687,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="toy">
 Toy<pulumi-choosable type="language" values="python,go" class="inline">, Toy<wbr>Args</pulumi-choosable>
 </h4>
+This is a toy
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/replace-on-change/docs/toystore/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/replace-on-change/docs/toystore/_index.md
@@ -639,6 +639,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="chew">
 Chew<pulumi-choosable type="language" values="python,go" class="inline">, Chew<wbr>Args</pulumi-choosable>
 </h4>
+A toy for a dog
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -727,6 +729,8 @@ Chew<pulumi-choosable type="language" values="python,go" class="inline">, Chew<w
 <h4 id="laser">
 Laser<pulumi-choosable type="language" values="python,go" class="inline">, Laser<wbr>Args</pulumi-choosable>
 </h4>
+A Toy for a cat
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">
@@ -911,6 +915,8 @@ Laser<pulumi-choosable type="language" values="python,go" class="inline">, Laser
 <h4 id="toy">
 Toy<pulumi-choosable type="language" values="python,go" class="inline">, Toy<wbr>Args</pulumi-choosable>
 </h4>
+This is a toy
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">

--- a/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/urn-id-properties/docs/res/_index.md
+++ b/tools/resourcedocsgen/pkg/docs/testdata/TestGeneratePackage/urn-id-properties/docs/res/_index.md
@@ -612,6 +612,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="innertype">
 Inner<wbr>Type<pulumi-choosable type="language" values="python,go" class="inline">, Inner<wbr>Type<wbr>Args</pulumi-choosable>
 </h4>
+It's fine to use urn and id in nested objects
+
 
 <div>
 <pulumi-choosable type="language" values="csharp">


### PR DESCRIPTION
This PR prevents having to create vanity attributes to document a resource. For instance, see pulumi/pulumi-docker-build#75 where we faced this problem.

In some cases, resources described in Provider's `schema.json` contain a `description` field. For instance:

<img width="777" height="293" alt="image" src="https://github.com/user-attachments/assets/92f7498b-e6f1-40c3-b6a3-56704225843a" />

This change propagates that value from the parsed schema all the way to the template. Hence, when the template gets rendered (and if a description field exists for that resource), it will display the resource associated description. For the case above, this is what gets rendered:

<img width="847" height="393" alt="description-field" src="https://github.com/user-attachments/assets/79d27620-bacf-4e1a-8f34-e1fc2663c721" />


