### PR TITLE
Fix left navigation scroll behavior

### DIFF
--- a/themes/default/theme/src/scss/docs/_docs-main.scss
+++ b/themes/default/theme/src/scss/docs/_docs-main.scss
@@ -145,13 +145,13 @@ body.section-registry {
 
         .docs-main-nav {
             border: none;
-            display: block;
+            display: flex;
+            flex-direction: column;
             padding-bottom: 24px;
             flex-shrink: 0;
             margin: 0;
             width: 32px;
             flex-basis: 32px;
-            overflow-y: auto;
             height: calc(100vh - 38px);
             position: sticky;
             left: 0;
@@ -164,6 +164,21 @@ body.section-registry {
             nav.main-nav {
                 display: none; // Hidden on mobile, shown on desktop via media query below
                 padding: 0;
+                flex: 1;
+                min-height: 0;
+                display: flex;
+                flex-direction: column;
+                overflow-y: auto; // Make nav itself scrollable
+            }
+
+            // Keep search box pinned at top when scrolling
+            .docs-search {
+                position: sticky;
+                top: 0;
+                z-index: 10;
+                background: #fff;
+                padding-bottom: 0.5rem;
+                padding-right: 0.75rem; // Space for scrollbar
             }
 
             h2,
@@ -239,7 +254,7 @@ body.section-registry {
                 position: sticky;
 
                 nav.main-nav {
-                    display: block !important;
+                    display: flex !important;
                 }
             }
         }
@@ -284,7 +299,6 @@ body.section-registry {
             .docs-main-nav-wrapper .docs-main-nav {
                 width: 240px;
                 flex-basis: 240px;
-                overflow-y: auto;
                 height: calc(100vh);
                 padding-left: 16px;
                 background-color: $white;
@@ -297,7 +311,7 @@ body.section-registry {
             }
 
             nav.main-nav {
-                display: block !important;
+                display: flex !important;
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix search box scroll behavior in registry left navigation
- Search box now stays pinned at the top while menu items scroll
- Works on both package pages and registry landing page

## Changes
- Changed `.docs-main-nav` to use flexbox layout
- Made `nav.main-nav` scrollable with `overflow-y: auto`
- Used `position: sticky` on `.docs-search` to keep it pinned at top
- Changed media query display rules from `block` to `flex`
- Added rem-based padding to search box for scrollbar spacing

## Test plan
- [x] Test on registry landing page (/registry)
- [x] Test on package pages (e.g., /registry/packages/azure-native-v2/api-docs/)
- [x] Verify search box stays pinned while scrolling menu items
- [x] Verify scrollbar appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)