### PR TITLE
Recover docs for aws v7

### DIFF
--- a/themes/default/content/registry/packages/aws/_index.md
+++ b/themes/default/content/registry/packages/aws/_index.md
@@ -1,7 +1,7 @@
 ---
-# WARNING: this file was fetched from https://raw.githubusercontent.com/pulumi/pulumi-aws/v6.83.1/docs/_index.md
+# WARNING: this file was fetched from https://raw.githubusercontent.com/pulumi/pulumi-aws/v7.9.0/docs/_index.md
 # Do not edit by hand unless you're certain you know what you are doing!
-edit_url: https://github.com/pulumi/pulumi-aws/blob/v6.83.1/docs/_index.md
+edit_url: https://github.com/pulumi/pulumi-aws/blob/v7.9.0/docs/_index.md
 title: AWS
 meta_desc: Learn how you can use Pulumi's AWS Provider to reduce the complexity of provisioning and managing resources on AWS.
 layout: package
@@ -119,3 +119,10 @@ Pulumi offers Components that provide simpler interfaces and higher-productivity
 
 * [Amazon EKS](/registry/packages/eks)
 * [Crosswalk for AWS](/docs/guides/crosswalk/aws), which includes API Gateway, CloudWatch, Elastic Container Registry, Elastic Container Service, Elastic Kubernetes Service, Elastic Load Balancing, Identity & Access Management, Lambda, Virtual Private Cloud, and more
+
+## Migrations
+
+Information about updating the major versions of the AWS Provider, along with any breaking changes that you should be aware of can be found on the following pages:
+
+* [Migrating to v6.x.x guide](/registry/packages/aws/how-to-guides/6-0-migration/)
+* [Migrating to v7.x.x guide](/registry/packages/aws/how-to-guides/7-0-migration/)

--- a/themes/default/content/registry/packages/aws/installation-configuration.md
+++ b/themes/default/content/registry/packages/aws/installation-configuration.md
@@ -1,7 +1,7 @@
 ---
-# WARNING: this file was fetched from https://raw.githubusercontent.com/pulumi/pulumi-aws/v6.83.1/docs/installation-configuration.md
+# WARNING: this file was fetched from https://raw.githubusercontent.com/pulumi/pulumi-aws/v7.9.0/docs/installation-configuration.md
 # Do not edit by hand unless you're certain you know what you are doing!
-edit_url: https://github.com/pulumi/pulumi-aws/blob/v6.83.1/docs/installation-configuration.md
+edit_url: https://github.com/pulumi/pulumi-aws/blob/v7.9.0/docs/installation-configuration.md
 title: AWS Installation & Configuration
 meta_desc: How to set up credentials to use the Pulumi AWS Provider and choose configuration options to tailor the provider to suit your use case.
 layout: package
@@ -273,8 +273,8 @@ values:
     AWS_REGION: <YOUR_AWS_REGION>
   pulumiConfig: # exposes Pulumi config values to the Pulumi CLI
     project:environment: 'dev'
-    aws:assumeRole:
-      roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
+    aws:assumeRoles:
+      - roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
     aws:dynamodbEndpoint: 'dynamodb.us-east-2.amazonaws.com'
 ```
 
@@ -295,8 +295,8 @@ values:
     aws:secretKey: ${aws.login.secretAccessKey}
     aws:token: ${aws.login.sessionToken}
     project:environment: 'dev'
-    aws:assumeRole:
-      roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
+    aws:assumeRoles:
+      - roleArn: 'arn:aws:iam::058111598222:role/OrganizationAccountAccessRole'
     aws:dynamodbEndpoint: 'dynamodb.us-east-2.amazonaws.com'
 ```
 
@@ -335,7 +335,7 @@ Use `pulumi config set aws:<option>` or pass options to the [constructor of `new
 | `region` | Required | The region where AWS operations will take place. Examples are `us-east-1`, `us-west-2`, etc. |
 | `allowedAccountIds` | Optional | List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one (and potentially end up destroying a live environment). Conflicts with `forbiddenAccountIds`. |
 | `accessKey` | Optional | The access key for API operations. You can retrieve this from the ‘Security & Credentials’ section of the AWS console. |
-| `assumeRole` | Optional | A JSON object representing an IAM role to assume.  To set these nested properties, see docs on [structured configuration](/docs/concepts/config#structured-configuration), for example `pulumi config set --path aws:assumeRole.roleArn arn:aws:iam::058111598222:role/OrganizationAccountAccessRole`. The object contains the properties marked with a ↳ below: |
+| `assumeRoles` | Optional | A List of JSON objects representing an IAM role to assume.  To set these nested properties, see docs on [structured configuration](/docs/concepts/config#structured-configuration), for example `pulumi config set --path aws:assumeRoles[0].roleArn arn:aws:iam::058111598222:role/OrganizationAccountAccessRole`. The object contains the properties marked with a ↳ below: |
 | ↳ `durationSeconds` | Optional |  Number of seconds to restrict the assume role session duration. |
 | ↳ `externalId` | Optional | External identifier to use when assuming the role. |
 | ↳ `policy` | Optional | IAM Policy JSON describing further restricting permissions for the IAM Role being assumed. |

--- a/themes/default/data/registry/packages/aws.yaml
+++ b/themes/default/data/registry/packages/aws.yaml
@@ -11,7 +11,7 @@ native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aws
-schema_file_url: https://raw.githubusercontent.com/pulumi/pulumi-aws/v6.83.1/provider/cmd/pulumi-resource-aws/schema.json
+schema_file_url: https://raw.githubusercontent.com/pulumi/pulumi-aws/v7.9.0/provider/cmd/pulumi-resource-aws/schema.json
 title: AWS
-updated_on: 1761174037
-version: v6.83.1
+updated_on: 1761090036
+version: v7.9.0


### PR DESCRIPTION
Publish aws [v6.83.1](https://github.com/pulumi/pulumi-aws/releases/tag/v6.83.1) caused us to set the docs to this version even though the aws provider is already on v7.
This recovers the v7 docs by manually generating the package metadata files:
```
./tools/resourcedocsgen/resourcedocsgen metadata from-github \
          --providerName=aws \
          --repoSlug pulumi/pulumi-aws \
          --schemaFile="" \
          --version="v7.9.0" \
          --publisher Pulumi
```