### PR TITLE
Fix issue: Update Pulumi AI badge image to use new URL for "Get Started" button.

### DIFF
--- a/themes/default/layouts/partials/registry/package/pulumi-ai.html
+++ b/themes/default/layouts/partials/registry/package/pulumi-ai.html
@@ -8,5 +8,5 @@
 {{ $title_tag := .Scratch.Get "title_tag" }}
 {{ $prompt := printf "Explain resource %s, it's top scenarios and create a example usage for me." $title_tag }}
 <a class="pulumi-ai-badge" target="_blank" href="https://app.pulumi.com/neo?prompt={{ $prompt | urlquery }}&prefer_signup=true">
-    <img src="https://get.pulumi.com/new/button.svg" alt="Get Started">
+    <img src="/images/docs/icons/get-started-with-pulumi.svg" alt="Get Started">
 </a>


### PR DESCRIPTION
Fix button from this PR:

https://github.com/pulumi/registry/pull/8912/files

since getting 404. Added here:
https://github.com/pulumi/docs/pull/16369