### PR TITLE
Stop using /preview registry URLs

### DIFF
--- a/scripts/ci/push-registry.py
+++ b/scripts/ci/push-registry.py
@@ -90,7 +90,7 @@ for filename in os.listdir(yaml_db_path):
         continue
 
 
-    api_url = f"{backend_url}/preview/registry/packages/{source}/{publisher}/{name}/versions/{version.removeprefix("v")}"
+    api_url = f"{backend_url}/registry/packages/{source}/{publisher}/{name}/versions/{version.removeprefix("v")}"
     existence_check = requests.get(api_url, headers={
         "Authorization": f"token {token}",
     }).status_code

--- a/tools/resourcedocsgen/cmd/docs/registry.go
+++ b/tools/resourcedocsgen/cmd/docs/registry.go
@@ -163,7 +163,7 @@ func getSchemaFromRegistry(metadata pkg.PackageMeta, schemaURL string) ([]byte, 
 		return nil, errors.Wrapf(err, "parsing version %q", metadata.Version)
 	}
 
-	apiURL := fmt.Sprintf("%s/preview/registry/packages/%s/%s/%s/versions/%s",
+	apiURL := fmt.Sprintf("%s/registry/packages/%s/%s/%s/versions/%s",
 		backendURL, source, publisher, metadata.Name, version)
 
 	//nolint:gosec // We're constructing the URL based on a predefined pattern.


### PR DESCRIPTION
These have been stabilized, so removing the /preview bit will allow us to get rid of /preview routes sooner.

<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [ ] Typescript
                - [ ] Python
                - [ ] Go
                - [ ] C#
                - [ ] Java (optional)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [ ] `/docs/installation-configuration.md` links to all published SDKs.

            - [ ] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
