### PR TITLE
Rename and improve workflow documentation

### DIFF
--- a/.github/workflows/on-provider-update.yml
+++ b/.github/workflows/on-provider-update.yml
@@ -23,7 +23,7 @@ env:
   ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-registry
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
-name: provider docs build
+name: Handle Provider Update Events
 on:
   repository_dispatch:
     types:
@@ -36,8 +36,8 @@ on:
       # Optional inputs are:
       # - PROVIDER_SCHEMA_PATH
       - resource-provider
-      # An update for a provider that is hosted opaquely - where we don't assume a backing
-      # GH repo.
+      # An update for a provider without a GitHub repo (OpenTofu registry providers, anytf).
+      # Schema and docs are hosted at arbitrary URLs instead of GitHub repo structure.
       #
       # Required inputs are:
       # - PROVIDER_SHORT_NAME
@@ -80,6 +80,7 @@ jobs:
           --publisher Pulumi
       - name: git status
         run: git status && git diff
+      # Duplicate checking unnecessary: we own the repositories dispatching these events
       - name: Create registry PR
         uses: ./.github/actions/new-provider-version-pr
         with:
@@ -121,6 +122,7 @@ jobs:
           --indexFileURL  "${{ env.PROVIDER_INDEX_URL  }}"
       - name: git status
         run: git status && git diff
+      # Duplicate checking unnecessary: we own the repositories dispatching these events
       - name: Create registry PR
         uses: ./.github/actions/new-provider-version-pr
         with:

--- a/.github/workflows/poll-community-packages.yml
+++ b/.github/workflows/poll-community-packages.yml
@@ -1,5 +1,5 @@
 permissions: write-all # Equivalent to default permissions plus id-token: write
-name: Check for Community Package Updates
+name: Poll Community Packages for New Versions
 on:
   workflow_dispatch: null
   schedule:


### PR DESCRIPTION
Renamed workflows for clarity:
- generate-package-metadata.yml to poll-community-packages.yml
- publish-provider-update.yml to on-provider-update.yml

Updated display names and added documentation comments explaining provider types, duplicate checking strategy, and event handling.

<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [ ] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [ ] Typescript
                - [ ] Python
                - [ ] Go
                - [ ] C#
                - [ ] Java (optional)

        - [ ] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [ ] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [ ] `/docs/installation-configuration.md` links to all published SDKs.

            - [ ] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
