### PR TITLE
feat: add pulumi-bytepluscc

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -399,6 +399,10 @@
     {
       "repoSlug": "formalco/pulumi-formal",
       "schemaFile": "provider/cmd/pulumi-resource-formal/schema.json"
+    },
+    {
+      "repoSlug": "byteplus-sdk/pulumi-bytepluscc",
+      "schemaFile": "provider/cmd/pulumi-resource-bytepluscc/schema.json"
     }
   ]
 }


### PR DESCRIPTION
Copy of https://github.com/pulumi/registry/pull/9010 to bypass CI failures.