### PR TITLE
Add stackitcloud/pulumi-stackit to community-package list

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -399,6 +399,10 @@
     {
       "repoSlug": "kotaicode/pulumi-dex",
       "schemaFile": "schema.json"
+    },
+    {
+      "repoSlug": "stackitcloud/pulumi-stackit",
+      "schemaFile": "provider/cmd/pulumi-resource-stackit/schema.json"
     }
   ]
 }


### PR DESCRIPTION
  - [X] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
        part after the leading `v` must be valid semver 2.0.

      - Published an SDK for your provider in:
          - [X] Typescript
          - [ ] Python
          - [ ] Go
          - [ ] C#
          - [ ] Java (optional)

  - [X] Have checked in a schema.json that matches the location of the `schemaFile`
        specified in `/community-packages/package-list.json`.

  - [X] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
        out in your repo.

      - [X] `/docs/installation-configuration.md` links to all published SDKs.

      - [X] `/docs/index.md` shows an example of using your provider in each language (only TypeScript).


The SDK is present in the repository for every language but our Pulumi provider is currently in ALPHA version (v0.0.2). Only the TypeScript is currently published to npm the others like Python, dotnet and go will be published later.