### PR TITLE
Remove broken GitHub links from github-buttons shortcode

### DIFF
--- a/themes/default/content/registry/packages/aws-v6/how-to-guides/ec2-webserver.md
+++ b/themes/default/content/registry/packages/aws-v6/how-to-guides/ec2-webserver.md
@@ -6,7 +6,7 @@ aliases: ["/docs/reference/tutorials/aws/tutorial-ec2-webserver/"]
 layout: package
 ---
 
-{{< github-buttons "aws-ts-webserver" "aws-js-webserver" "aws-py-webserver" "aws-cs-webserver" >}}
+{{< github-buttons "aws-ts-webserver" "aws-py-webserver" "aws-cs-webserver" >}}
 
 In this tutorial, we will show you how to deploy a simple webserver using an Amazon EC2 instance.
 

--- a/themes/default/content/registry/packages/aws-v6/how-to-guides/s3-website.md
+++ b/themes/default/content/registry/packages/aws-v6/how-to-guides/s3-website.md
@@ -6,7 +6,7 @@ aliases: ["/docs/reference/tutorials/aws/tutorial-s3-website/"]
 layout: package
 ---
 
-{{< github-buttons "aws-js-s3-folder" "aws-py-s3-folder" >}}
+{{< github-buttons "aws-py-s3-folder" >}}
 
 In this tutorial, we'll show you how to provision raw resources in AWS using the [@pulumi/aws] package. First, we'll create a Pulumi program that uploads files from the `www` directory to S3. Then, we'll configure the bucket to serve a website. We'll be using JavaScript in this tutorial, but you can also run through this example [in Python].
 

--- a/themes/default/content/registry/packages/aws/how-to-guides/ec2-webserver.md
+++ b/themes/default/content/registry/packages/aws/how-to-guides/ec2-webserver.md
@@ -6,7 +6,7 @@ aliases: ["/docs/reference/tutorials/aws/tutorial-ec2-webserver/"]
 layout: package
 ---
 
-{{< github-buttons "aws-ts-webserver" "aws-js-webserver" "aws-py-webserver" "aws-cs-webserver" >}}
+{{< github-buttons "aws-ts-webserver" "aws-py-webserver" "aws-cs-webserver" >}}
 
 In this tutorial, we will show you how to deploy a simple webserver using an Amazon EC2 instance.
 

--- a/themes/default/content/registry/packages/aws/how-to-guides/s3-website.md
+++ b/themes/default/content/registry/packages/aws/how-to-guides/s3-website.md
@@ -6,7 +6,7 @@ aliases: ["/docs/reference/tutorials/aws/tutorial-s3-website/"]
 layout: package
 ---
 
-{{< github-buttons "aws-js-s3-folder" "aws-py-s3-folder" >}}
+{{< github-buttons "aws-py-s3-folder" >}}
 
 In this tutorial, we'll show you how to provision raw resources in AWS using the [@pulumi/aws] package. First, we'll create a Pulumi program that uploads files from the `www` directory to S3. Then, we'll configure the bucket to serve a website. We'll be using JavaScript in this tutorial, but you can also run through this example [in Python].
 


### PR DESCRIPTION
The aws-js-webserver and aws-js-s3-folder examples no longer exist in the pulumi/examples repository, resulting in 404 errors. This removes those broken links from the github-buttons shortcodes in the how-to-guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
