### PR TITLE
Fix `api-docs/%` Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ bin/mktutorial: $(shell ${HELPMAKEGO} tools/mktutorial)
 # Generate the API docs for `content/registry/packages/<pkg>`, where <pkg> is the name of
 # the package to be handed off to resourcedocsgen.
 .SECONDEXPANSION: # Needed for content/registry/packages/% to have dependencies that reference %.
-api-docs/%: .make/content/registry/packages/$$*/api-docs
+api-docs/%: .make/content/registry/packages/$$*/api-docs ;
 .make/content/registry/packages/%/api-docs: bin/resourcedocsgen \
 				themes/default/data/registry/packages/%.yaml \
 				$$(wildcard themes/default/content/registry/packages/%/*)


### PR DESCRIPTION
While working on https://github.com/pulumi/pulumi-terraform-bridge/issues/3233, I was trying to generate locally the `aws` registry documentation. Based on `Makefile` targets, running the following command should work:

```
make api-docs/aws
```

However, I was obtaining the following error:

```
make: *** No rule to make target `api-docs/aws'.  Stop.
```

By adding a `;` to the end of the target, `make` would now handle it as an [empty recipe](https://www.gnu.org/software/make/manual/make.html#Empty-Recipes) and work as expected. Previously, `make` was handling it as a [rule without recipe](https://www.gnu.org/software/make/manual/make.html#Force-Targets) which does effectively nothing and gets ignored.
