### PR TITLE
Fix: use updated source repo for provider dex

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -397,7 +397,7 @@
       "schemaFile": "provider/cmd/pulumi-resource-bytepluscc/schema.json"
     },
     {
-      "repoSlug": "kotaicode/pulumi-provider-dex",
+      "repoSlug": "kotaicode/pulumi-dex",
       "schemaFile": "schema.json"
     }
   ]


### PR DESCRIPTION
<!--

        +--------------------------------------------------------+
        | If you are adding a new package to the Pulumi Registry |
        +--------------------------------------------------------+

        Please make sure that you have:

        - [x] Released your package with a version prefixed with `v` (e.g. `v0.1.0`). The
              part after the leading `v` must be valid semver 2.0.

            - Published an SDK for your provider in:
                - [x] Typescript
                - [x] Python
                - [x] Go
                - [ ] C#
                - [ ] Java (optional)

        - [x] Have checked in a schema.json that matches the location of the `schemaFile`
              specified in `/community-packages/package-list.json`.

        - [x] Have a `/docs/_index.md` and `/docs/installation-configuration.md` filled
              out in your repo.

            - [x] `/docs/installation-configuration.md` links to all published SDKs.

            - [x] `/docs/index.md` shows an example of using your provider in each language.

        Once you are ready to publish, opening a PR will tag a member of Pulumi who will
        review your PR.

        Thanks for contributing to the Pulumi Registry!

        ---

        For maintainers, see the full checklist for adding a new provider at
        <https://github.com/pulumi/registry/blob/main/docs/adding-a-new-pacakge.md>.

-->
