### PR TITLE
Fix gitignore to not ignore generated package docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ bin
 .make
 mise.local.toml
 .claude/settings.local.json
-content/
+/content/
 static/registry/


### PR DESCRIPTION
This change was made inadvertently in #8902 and it was meant to only target the root content directory, not themes/default/content


This should unblock the auto PRs for `pulumi/pulumi-std` that are failing:
- #9835
- #9793

[Here is where](https://github.com/pulumi/registry/blob/79e20b4eebb7bca7316fa1debea200fbb1d5dfd6/.github/workflows/publish-provider-update.yml#L83) we are creating the PR in the Github action and because the file is ignored by git it isn't being caught up in the commit. Existing packages get updated fine because the files are already tracked.