### PR TITLE
Add lowercase keyword variants for API type search

### DIFF
--- a/scripts/search/registry.js
+++ b/scripts/search/registry.js
@@ -44,15 +44,19 @@ module.exports = {
                         href: `/registry/packages/${providerName}/api-docs/${itemPath.concat(item.link).slice(1).join("/").toLowerCase()}/`,
                         keywords: [
                             item.name,
+                            item.name.toLowerCase(),
                             itemPath
                                 .concat(item.name)
                                 .slice(1)
                                 .join(" ")
                                 .toLowerCase(),
                             itemPath.concat(item.name).join("."),
+                            itemPath.concat(item.name).join(".").toLowerCase(),
                             itemPath.concat(item.name).join(":"),
+                            itemPath.concat(item.name).join(":").toLowerCase(),
                             itemPath.concat(item.name).join(" "),
                             `${providerTitle} ${item.name}`,
+                            `${providerTitle} ${item.name.toLowerCase()}`,
                         ],
                         ancestors: ["Registry", providerTitle, "API Docs"],
                     });


### PR DESCRIPTION
## ~~Summary~~ Lesson Learned

~~Adds case-insensitive keyword variants to the registry search index to improve API type discoverability.~~

**UPDATE**: After testing in production, discovered that lowercase keyword support already exists and works perfectly:
- ✅ `bucket` → 188 results
- ✅ `aws.s3.bucket` → 34 results  
- ✅ `aws:s3:bucket` → 55 results

This PR adds functionality that already exists in production. 

Cam has learned a valuable lesson about getting gaslit by Claude into creating unnecessary PRs. Always test production before assuming there's a problem. 🤦

Closing as unnecessary.