### PR TITLE
Fix build warnings: Hugo taxonomy kind, missing license fields

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -31,7 +31,7 @@ security:
       - ALGOLIA_APP_SEARCH_KEY
 
 disableKinds:
-  - taxonomyTerm
+  - taxonomy
 
 sectionPagesMenu: main
 pygmentsCodeFences: true

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,6 +1,7 @@
 {
     "name": "registry",
     "main": "index.ts",
+    "license": "Apache-2.0",
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/themes/default/theme/stencil/package.json
+++ b/themes/default/theme/stencil/package.json
@@ -2,6 +2,7 @@
     "name": "stencil-custom-elements",
     "version": "0.0.1",
     "private": "true",
+    "license": "Apache-2.0",
     "scripts": {
         "build": "stencil build",
         "start": "stencil build --dev --watch --serve --no-open",


### PR DESCRIPTION
## Summary

- Changes `taxonomyTerm` to `taxonomy` in `config/_default/config.yml` to fix the Hugo deprecation warning: _Kind "taxonomyterm" is deprecated, use "taxonomy"_
- Adds `"license": "Apache-2.0"` to `infrastructure/package.json` and `themes/default/theme/stencil/package.json` to suppress yarn `No license field` warnings