### PR TITLE
Fix Dart Sass deprecation warnings in FontAwesome SCSS

### DIFF
--- a/themes/default/theme/src/scss/fontawesome/_larger.scss
+++ b/themes/default/theme/src/scss/fontawesome/_larger.scss
@@ -1,10 +1,12 @@
 // Icon Sizes
 // -------------------------
 
+@use "sass:math";
+
 // makes the font 33% larger relative to the icon container
 .#{$fa-css-prefix}-lg {
-    font-size: (4em / 3);
-    line-height: (3em / 4);
+    font-size: math.div(4em, 3);
+    line-height: math.div(3em, 4);
     vertical-align: -0.0667em;
 }
 

--- a/themes/default/theme/src/scss/fontawesome/_list.scss
+++ b/themes/default/theme/src/scss/fontawesome/_list.scss
@@ -1,9 +1,11 @@
 // List Icons
 // -------------------------
 
+@use "sass:math";
+
 .#{$fa-css-prefix}-ul {
     list-style-type: none;
-    margin-left: $fa-li-width * 5/4;
+    margin-left: math.div($fa-li-width * 5, 4);
     padding-left: 0;
 
     > li {

--- a/themes/default/theme/src/scss/fontawesome/_variables.scss
+++ b/themes/default/theme/src/scss/fontawesome/_variables.scss
@@ -1,6 +1,8 @@
 // Variables
 // --------------------------
 
+@use "sass:math";
+
 $fa-font-path: "../assets/fonts/fontawesome" !default;
 $fa-font-size-base: 16px !default;
 $fa-font-display: auto !default;
@@ -9,7 +11,7 @@ $fa-version: "5.8.1" !default;
 $fa-border-color: #eee !default;
 $fa-inverse: #fff !default;
 $fa-li-width: 2em !default;
-$fa-fw-width: (20em / 16);
+$fa-fw-width: math.div(20em, 16);
 
 // Convenience function used to set content property
 @function fa-content($fa-var) {


### PR DESCRIPTION
## Summary

- Adds `@use "sass:math"` to three FontAwesome SCSS partial files
- Replaces the deprecated `/` division operator with `math.div()` in each location:
  - `_variables.scss`: `(20em / 16)` → `math.div(20em, 16)`
  - `_larger.scss`: `(4em / 3)` and `(3em / 4)` → `math.div()` equivalents
  - `_list.scss`: `$fa-li-width * 5/4` → `math.div($fa-li-width * 5, 4)`

Resolves 4 Dart Sass deprecation warnings emitted during `make build-assets`.