### PR TITLE
Add Dependabot configuration for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,125 @@
+version: 2
+updates:
+  # Root package.json
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps"
+
+  # Theme package.json
+  - package-ecosystem: "npm"
+    directory: "/themes/default/theme"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "tailwindcss"
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps(theme)"
+
+  # Stencil package.json
+  - package-ecosystem: "npm"
+    directory: "/themes/default/theme/stencil"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps(stencil)"
+
+  # Infrastructure package.json
+  - package-ecosystem: "npm"
+    directory: "/infrastructure"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps(infra)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-actions:
+        patterns: ["*"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "ci"
+
+  # Go modules - resourcedocsgen
+  - package-ecosystem: "gomod"
+    directory: "/tools/resourcedocsgen"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-go-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps(resourcedocsgen)"
+
+  # Go modules - mktutorial
+  - package-ecosystem: "gomod"
+    directory: "/tools/mktutorial"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 1
+    groups:
+      all-go-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps(mktutorial)"


### PR DESCRIPTION
## Summary

Creates `.github/dependabot.yml` covering 7 ecosystems with monthly grouped updates:

- **npm (root)**: root `package.json`
- **npm (theme)**: `themes/default/theme/package.json` (Tailwind excluded — major rewrite risk)
- **npm (stencil)**: `themes/default/theme/stencil/package.json`
- **npm (infra)**: `infrastructure/package.json`
- **github-actions**: all workflow action pins
- **gomod (resourcedocsgen)**: `tools/resourcedocsgen/`
- **gomod (mktutorial)**: `tools/mktutorial/`

Major version bumps are blocked for all npm and gomod entries; they require intentional PRs. Updates are grouped so each ecosystem produces at most one PR per month.