### PR TITLE
Add auto-approve workflow for pulumi-bot PRs

### DIFF
--- a/.github/workflows/auto-approve-for-auto-merge.yml
+++ b/.github/workflows/auto-approve-for-auto-merge.yml
@@ -1,4 +1,4 @@
-name: Auto approve pulumi-bot PRs for auto-merge
+name: Auto approve
 
 on: pull_request
 


### PR DESCRIPTION
Adds a workflow that automatically approves PRs authored by `pulumi-bot` from within the repository, satisfying the code owner review requirement so that automerge can proceed without manual intervention.

Modeled after the equivalent workflow in `pulumi/docs`.