### PR TITLE
Fix Dependabot PR build/deploy failures

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,132 @@
+permissions: write-all
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-registry
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
+name: Dependabot
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+jobs:
+
+  # Deploy a preview for open/updated Dependabot PRs.
+  preview:
+    name: Build and deploy preview
+    if: github.actor == 'dependabot[bot]' && github.event.action != 'closed'
+    runs-on: pulumi-service-ubuntu-24.04-16core
+    environment: testing
+    env:
+      GOPATH: ${{ github.workspace }}/go
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
+
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            infrastructure/yarn.lock
+            themes/default/yarn.lock
+            themes/default/theme/yarn.lock
+            themes/default/theme/stencil/yarn.lock
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.x
+
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.135.0"
+          extended: true
+
+      - name: Validate JSON file syntax
+        uses: limitusus/json-syntax-check@v2
+        with:
+          pattern: "community-packages/package-list.json"
+
+      - name: Yarn Install
+        run: yarn install
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
+          role-session-name: DependabotPreviewSession
+
+      - name: Build and deploy preview
+        run: make ci-pull-request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+          PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
+          NODE_OPTIONS: "--max_old_space_size=8192"
+          ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
+          ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
+
+  # Write the required "Sentinel" status check on success.
+  sentinel:
+    name: Sentinel Tower
+    if: github.actor == 'dependabot[bot]' && github.event.action != 'closed'
+    needs: [preview]
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76 # v1.1.13
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'Sentinel'
+          description: 'All required checks passed'
+          state: 'success'
+          sha: ${{ github.event.pull_request.head.sha }}
+
+  # Clean up the preview S3 bucket when the Dependabot PR is closed.
+  cleanup:
+    name: Find and remove buckets
+    if: github.actor == 'dependabot[bot]' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
+
+      - name: Check out branch
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
+          role-session-name: DependabotCleanupSession
+
+      - name: Find and remove buckets
+        run: make ci-pull-request-closed
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -147,7 +147,7 @@ jobs:
     name: Build and deploy preview
     # Only run this job for events that originate on this repository and if the automation/merge label is not applied to the PR.
     # PRs with the automation/tfgen-provider-docs label contain only metadata file changes and don't need a PR build.
-    if: github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'automation/tfgen-provider-docs') != true
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'automation/tfgen-provider-docs') != true
     runs-on: pulumi-service-ubuntu-24.04-16core
     environment: testing
     env:


### PR DESCRIPTION
## Summary

- Add `.github/workflows/dependabot.yml` using `pull_request_target` so Dependabot PRs can access repository secrets (AWS credentials, ESC tokens) for preview builds and S3 cleanup
- Add `github.actor != 'dependabot[bot]'` guard to the `preview` job in `pull-request.yml` so Dependabot PRs skip (rather than fail) that job, unblocking the Sentinel required check

## Details

Dependabot PRs triggered via `pull_request` cannot access `secrets.*`, causing AWS credential setup to fail and the Sentinel required check to never post success. The fix uses GitHub's recommended pattern: a separate `pull_request_target` workflow that runs in the base-branch context with full secret access.

The new workflow handles three events for Dependabot PRs:
- **`preview`** — builds and deploys a preview on open/synchronize/reopen
- **`sentinel`** — writes the required "Sentinel" status check on success
- **`cleanup`** — removes the preview S3 bucket on close