### PR TITLE
Switch PR preview workflows to pure OIDC

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -26,10 +26,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
+          role-duration-seconds: 7200
           role-session-name: PullRequestCleanupSession
 
       - name: Find and remove buckets

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -193,10 +193,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
+          role-duration-seconds: 7200
           role-session-name: PullRequestPreviewSession
 
       - name: Build and deploy preview


### PR DESCRIPTION
## Summary

- Replaces static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets with OIDC-based authentication in `pull-request.yml` and `pull-request-closed.yml`
- Both workflows now assume `arn:aws:iam::571684982431:role/ContinuousDelivery` directly — the same role and account already used by `testing-deploy.yml`
- Fixes Dependabot PR build failures natively: Dependabot can use OIDC without repository secret access, so no `pull_request_target` workaround is needed
- The role ARN is hardcoded, consistent with how `pulumi/docs` workflows (`testing-build-and-deploy.yml`, etc.) handle the same role

## Notes

- Existing preview buckets created by PRs open before this change (in account `894850187425`) will need manual cleanup, as the cleanup job will now look in `571684982431`
- After this is validated, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` can be removed from the repo's GitHub Actions secrets
- Closes #10103