### PR TITLE
Fix broken links and remove empty README in docs

### DIFF
--- a/docs/adding-a-new-package.md
+++ b/docs/adding-a-new-package.md
@@ -57,8 +57,8 @@ To keep quality in the Pulumi Registry high, we have a check-list before merging
 
 When a community member requests adding a provider to the registry, a Pulumi staff member should perform the following steps:
 
-1. Add the package to the [community packages list](./community-packages/package-list.json) via pull request to this repository.
-1. Follow the instructions outlined in [docs/adding-a-new-package.md](./docs/adding-a-new-package.md) to validate the PR, requesting updates as necessary.
+1. Add the package to the community packages list (`community-packages/package-list.json`) via pull request to this repository.
+1. Follow the instructions outlined in this document to validate the PR, requesting updates as necessary.
 1. Merge the PR.
 
 In pulumi/docs, a [scheduled task](https://github.com/pulumi/docs/actions/workflows/update-theme.yml) runs hourly and will pick up any changes in this repo, generate files from the provider schema and `data/registry/${PROVIDER}.yaml`, and publish to pulumi.com.


### PR DESCRIPTION
Fix self-referential and broken relative links in docs/adding-a-new-package.md, and delete the empty community-packages/README.md.
