### PR TITLE
Delist outdated AWS packages from registry

### DIFF
--- a/.claude/commands/delist-package.md
+++ b/.claude/commands/delist-package.md
@@ -1,0 +1,66 @@
+---
+description: Delist (deprecate) a provider package from the Pulumi Registry.
+---
+
+# Delist Package
+
+**Use this when:** You want to remove a package from the Pulumi Registry by marking it as deprecated.
+
+---
+
+## Usage
+
+`/delist-package [package-name]`
+
+If `package-name` is not provided, ask the user which package to delist.
+
+---
+
+## Process
+
+### Step 1: Locate Package YAML
+
+Look for `themes/default/data/registry/packages/{{arg}}.yaml`.
+
+- If not found, report error and exit
+- If the package already has `publisher: DEPRECATED`, inform the user it's already delisted
+
+### Step 2: Update Package YAML
+
+Set the `publisher` field to `DEPRECATED` in the package YAML file.
+
+### Step 3: Remove from Community Packages List
+
+Read `community-packages/package-list.json` and check if the package's repo slug appears in the `include` array.
+
+- If found, remove the entry from the JSON array
+- If not found, skip this step
+
+### Step 4: Verify Changes
+
+Run `git diff` to confirm:
+
+- The `publisher` field in the YAML was changed to `DEPRECATED`
+- The community packages list entry was removed (if applicable)
+
+### Step 5: Report Results
+
+Present a summary:
+
+```
+Package Delisted: <package-name>
+═══════════════════════════════════════════════════
+
+Changes:
+  ✓ Set publisher to DEPRECATED in <package-name>.yaml
+  ✓ Removed from community-packages/package-list.json (if applicable)
+
+Note: The package YAML file is kept in the repo but will be
+skipped by the publishing scripts (push-registry.py and
+publish_to_registry.py) on the next deploy.
+═══════════════════════════════════════════════════
+```
+
+## Background
+
+Delisting works by setting `publisher: DEPRECATED` in the package YAML. Both publishing scripts (`scripts/ci/push-registry.py` and `scripts/ci/publish_to_registry.py`) skip packages with this publisher value, effectively removing them from the live registry without deleting the metadata files.

--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -69,10 +69,6 @@
       "schemaFile": "schema.json"
     },
     {
-      "repoSlug": "pulumi/pulumi-aws-static-website",
-      "schemaFile": "schema.json"
-    },
-    {
       "repoSlug": "muhlba91/pulumi-proxmoxve",
       "schemaFile": "provider/cmd/pulumi-resource-proxmoxve/schema.json"
     },

--- a/themes/default/data/registry/packages/aws-iam.yaml
+++ b/themes/default/data/registry/packages/aws-iam.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: aws-iam
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-aws-iam
 schema_file_path: schema.yaml
 title: AWS IAM

--- a/themes/default/data/registry/packages/aws-quickstart-aurora-postgres.yaml
+++ b/themes/default/data/registry/packages/aws-quickstart-aurora-postgres.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: aws-quickstart-aurora-postgres
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-quickstart-aurora-postgres"
 schema_file_path: /schema.yaml
 title: AWS QuickStart Aurora Postgres

--- a/themes/default/data/registry/packages/aws-quickstart-redshift.yaml
+++ b/themes/default/data/registry/packages/aws-quickstart-redshift.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: aws-quickstart-redshift
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-quickstart-redshift"
 schema_file_path: /schema.yaml
 title: AWS QuickStart Redshift

--- a/themes/default/data/registry/packages/aws-quickstart-vpc.yaml
+++ b/themes/default/data/registry/packages/aws-quickstart-vpc.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: aws-quickstart-vpc
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-quickstart-vpc"
 schema_file_path: /schema.yaml
 title: AWS QuickStart VPC

--- a/themes/default/data/registry/packages/aws-s3-replicated-bucket.yaml
+++ b/themes/default/data/registry/packages/aws-s3-replicated-bucket.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: aws-s3-replicated-bucket
 native: false
 package_status: public_preview
-publisher: Lee Zen
+publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-s3-replicated-bucket"
 schema_file_path: /schema.json
 title: AWS S3 Replicated Bucket

--- a/themes/default/data/registry/packages/aws-static-website.yaml
+++ b/themes/default/data/registry/packages/aws-static-website.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: aws-static-website
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-aws-static-website
 schema_file_path: schema.json
 title: AWS Static Website


### PR DESCRIPTION
Mark 6 packages as DEPRECATED: aws-iam, aws-static-website, aws-quickstart-aurora-postgres, aws-quickstart-redshift, aws-quickstart-vpc, and aws-s3-replicated-bucket.

Also adds a /delist-package Claude skill.

Fixes #10250
