### PR TITLE
Delist 9 outdated Pulumi-published packages

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -65,10 +65,6 @@
       "schemaFile": "provider/cmd/pulumi-resource-astra/schema.json"
     },
     {
-      "repoSlug": "pulumi/pulumi-azure-justrun",
-      "schemaFile": "schema.json"
-    },
-    {
       "repoSlug": "muhlba91/pulumi-proxmoxve",
       "schemaFile": "provider/cmd/pulumi-resource-proxmoxve/schema.json"
     },
@@ -93,23 +89,11 @@
       "schemaFile": "provider/cmd/pulumi-resource-launchdarkly/schema.json"
     },
     {
-      "repoSlug": "pulumi/pulumi-azure-static-website",
-      "schemaFile": "schema.json"
-    },
-    {
       "repoSlug": "lbrlabs/pulumi-harness",
       "schemaFile": "provider/cmd/pulumi-resource-harness/schema.json"
     },
     {
-      "repoSlug": "pulumi/pulumi-google-cloud-static-website",
-      "schemaFile": "schema.json"
-    },
-    {
       "repoSlug": "pulumi/pulumi-synced-folder",
-      "schemaFile": "schema.json"
-    },
-    {
-      "repoSlug": "pulumi/pulumi-tls-self-signed-cert",
       "schemaFile": "schema.json"
     },
     {
@@ -135,10 +119,6 @@
     {
       "repoSlug": "pulumiverse/pulumi-heroku",
       "schemaFile": "provider/cmd/pulumi-resource-heroku/schema.json"
-    },
-    {
-      "repoSlug": "pulumi/pulumi-str",
-      "schemaFile": "sdk/schema.json"
     },
     {
       "repoSlug": "pulumiverse/pulumi-unifi",

--- a/themes/default/data/registry/packages/azure-justrun.yaml
+++ b/themes/default/data/registry/packages/azure-justrun.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: azure-justrun
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-azure-justrun
 schema_file_url: https://raw.githubusercontent.com/pulumi/pulumi-azure-justrun/v0.2.3/schema.json
 title: azure-justrun

--- a/themes/default/data/registry/packages/azure-static-website.yaml
+++ b/themes/default/data/registry/packages/azure-static-website.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: azure-static-website
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-azure-static-website
 schema_file_path: schema.json
 title: Azure Static Website

--- a/themes/default/data/registry/packages/confluent.yaml
+++ b/themes/default/data/registry/packages/confluent.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: confluent
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-confluent
 schema_file_path: /provider/cmd/pulumi-resource-confluent/schema.json
 title: Confluent Cloud

--- a/themes/default/data/registry/packages/google-cloud-static-website.yaml
+++ b/themes/default/data/registry/packages/google-cloud-static-website.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: google-cloud-static-website
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-google-cloud-static-website
 schema_file_path: schema.json
 title: Google Cloud Static Website

--- a/themes/default/data/registry/packages/metabase.yaml
+++ b/themes/default/data/registry/packages/metabase.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: metabase
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-metabase
 schema_file_path: schema.yaml
 title: Metabase (AWS)

--- a/themes/default/data/registry/packages/packet.yaml
+++ b/themes/default/data/registry/packages/packet.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: packet
 native: false
 package_status: ga
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-packet
 schema_file_path: /provider/cmd/pulumi-resource-packet/schema.json
 title: Packet

--- a/themes/default/data/registry/packages/str.yaml
+++ b/themes/default/data/registry/packages/str.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: str
 native: true
 package_status: ga
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-str
 schema_file_path: sdk/schema.json
 title: String

--- a/themes/default/data/registry/packages/tls-self-signed-cert.yaml
+++ b/themes/default/data/registry/packages/tls-self-signed-cert.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: tls-self-signed-cert
 native: true
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-tls-self-signed-cert
 schema_file_path: schema.json
 title: Self Signed Certificate

--- a/themes/default/data/registry/packages/yandex.yaml
+++ b/themes/default/data/registry/packages/yandex.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: yandex
 native: false
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-yandex
 schema_file_path: /provider/cmd/pulumi-resource-yandex/schema.json
 title: Yandex


### PR DESCRIPTION
Delist packet, confluent, yandex, metabase, azure-justrun, azure-static-website, google-cloud-static-website, str, and tls-self-signed-cert. These packages have not been updated since 2023 or earlier and are no longer actively maintained.
