### PR TITLE
perf: gzip cli-docs.json bundles at upload so the CDN serves them compressed

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -488,7 +488,7 @@ The `scripts/ci/build.sh` script manages the cache lifecycle:
 2. **Generate**: `make api-docs` runs `resourcedocsgen`, which skips fresh packages and regenerates stale ones.
 3. **Save**: copies the generated output (including updated sentinel files) back to `.cache/api-docs/` for the next run.
 
-CLI docs follow the same lifecycle: on restore, `.cache/api-docs/cli-docs/<pkg>/api-docs/` is copied to `cli-docs-out/registry/packages/<pkg>/api-docs/`; on save, the reverse copy is performed. Only `schema.json` (not the entire directory tree) is cached per package in the schema layer, to avoid persisting stale CLI doc files from older builds. CLI docs are stored uncompressed in the cache; `sync.sh` gzip-compresses them in place immediately before uploading to S3 (with `Content-Encoding: gzip`).
+CLI docs follow the same lifecycle: on restore, `.cache/api-docs/cli-docs/<pkg>/api-docs/` is copied to `cli-docs-out/registry/packages/<pkg>/api-docs/`; on save, the reverse copy is performed. Only `schema.json` (not the entire directory tree) is cached per package in the schema layer, to avoid persisting stale CLI doc files from older builds. CLI docs and provider `schema.json` files are stored uncompressed in the cache and in the Hugo build tree; `sync.sh` gzip-compresses them immediately before uploading to S3 (with `Content-Encoding: gzip`). For `schema.json`, this happens by extracting the files out of `public/` into a sibling `schema-out/` tree before the main `s5cmd sync --delete public/` runs, so the main sync does not upload them with the wrong metadata.
 
 #### Versioned docs cache
 
@@ -576,9 +576,11 @@ PR opened / committed
         │               ├── scripts/ci/build.sh preview
         │               └── scripts/ci/sync.sh preview
         │                       ├── Create / reuse S3 bucket
-        │                       ├── s5cmd sync public/ → bucket
+        │                       ├── Extract + gzip -9 public/**/schema.json → schema-out/ (parallel)
+        │                       ├── s5cmd sync public/ → bucket (--delete)
         │                       ├── gzip -9 cli-docs-out/ (parallel pre-compress)
         │                       ├── s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
+        │                       ├── s5cmd sync schema-out/ → bucket (Content-Encoding: gzip)
         │                       ├── Run browser tests (Cypress smoke test)
         │                       ├── Write origin-bucket-metadata.json
         │                       └── Post PR comment with preview URL
@@ -629,9 +631,11 @@ Push to master
                 │       ├── scripts/ci/build.sh update
                 │       ├── scripts/ci/sync.sh update
                 │       │       ├── Create / reuse S3 bucket
-                │       │       ├── s5cmd sync public/ → bucket
+                │       │       ├── Extract + gzip -9 public/**/schema.json → schema-out/ (parallel)
+                │       │       ├── s5cmd sync public/ → bucket (--delete)
                 │       │       ├── gzip -9 cli-docs-out/ (parallel pre-compress)
                 │       │       ├── s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
+                │       │       ├── s5cmd sync schema-out/ → bucket (Content-Encoding: gzip)
                 │       │       ├── Run browser tests (Cypress smoke test)
                 │       │       └── Write origin-bucket-metadata.json
                 │       ├── scripts/generate-search-index.sh
@@ -833,10 +837,12 @@ PR commit pushed
 scripts/ci/sync.sh preview
   1. aws s3 mb registry-testing-origin-pr-<N>-<sha8>
   2. Enable static website hosting
+  2a. Extract + gzip -9 public/**/schema.json files into schema-out/ (parallel)
   3. s5cmd sync public/ → bucket (--delete)
   3a. gzip -9 cli-docs.json files in cli-docs-out/ (parallel)
   3b. s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
-  4. Run Cypress smoke tests
+  3c. s5cmd sync schema-out/ → bucket (Content-Encoding: gzip)
+  4. Run Cypress smoke tests (including origin-gzip assertions on random)
   5. Write origin-bucket-metadata.json
   6. aws ssm put-parameter /registry/commits/<sha>/bucket = <bucket-name>
   7. Post PR comment: "Your preview is ready at http://..."

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -488,7 +488,7 @@ The `scripts/ci/build.sh` script manages the cache lifecycle:
 2. **Generate**: `make api-docs` runs `resourcedocsgen`, which skips fresh packages and regenerates stale ones.
 3. **Save**: copies the generated output (including updated sentinel files) back to `.cache/api-docs/` for the next run.
 
-CLI docs follow the same lifecycle: on restore, `.cache/api-docs/cli-docs/<pkg>/api-docs/` is copied to `cli-docs-out/registry/packages/<pkg>/api-docs/`; on save, the reverse copy is performed. Only `schema.json` (not the entire directory tree) is cached per package in the schema layer, to avoid persisting stale CLI doc files from older builds.
+CLI docs follow the same lifecycle: on restore, `.cache/api-docs/cli-docs/<pkg>/api-docs/` is copied to `cli-docs-out/registry/packages/<pkg>/api-docs/`; on save, the reverse copy is performed. Only `schema.json` (not the entire directory tree) is cached per package in the schema layer, to avoid persisting stale CLI doc files from older builds. CLI docs are stored uncompressed in the cache; `sync.sh` gzip-compresses them in place immediately before uploading to S3 (with `Content-Encoding: gzip`).
 
 #### Versioned docs cache
 
@@ -577,7 +577,8 @@ PR opened / committed
         │               └── scripts/ci/sync.sh preview
         │                       ├── Create / reuse S3 bucket
         │                       ├── s5cmd sync public/ → bucket
-        │                       ├── s5cmd sync cli-docs-out/ → bucket
+        │                       ├── gzip -9 cli-docs-out/ (parallel pre-compress)
+        │                       ├── s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
         │                       ├── Run browser tests (Cypress smoke test)
         │                       ├── Write origin-bucket-metadata.json
         │                       └── Post PR comment with preview URL
@@ -629,7 +630,8 @@ Push to master
                 │       ├── scripts/ci/sync.sh update
                 │       │       ├── Create / reuse S3 bucket
                 │       │       ├── s5cmd sync public/ → bucket
-                │       │       ├── s5cmd sync cli-docs-out/ → bucket
+                │       │       ├── gzip -9 cli-docs-out/ (parallel pre-compress)
+                │       │       ├── s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
                 │       │       ├── Run browser tests (Cypress smoke test)
                 │       │       └── Write origin-bucket-metadata.json
                 │       ├── scripts/generate-search-index.sh
@@ -832,7 +834,8 @@ scripts/ci/sync.sh preview
   1. aws s3 mb registry-testing-origin-pr-<N>-<sha8>
   2. Enable static website hosting
   3. s5cmd sync public/ → bucket (--delete)
-  3a. s5cmd sync cli-docs-out/ → bucket
+  3a. gzip -9 cli-docs.json files in cli-docs-out/ (parallel)
+  3b. s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
   4. Run Cypress smoke tests
   5. Write origin-bucket-metadata.json
   6. aws ssm put-parameter /registry/commits/<sha>/bucket = <bucket-name>

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -488,7 +488,7 @@ The `scripts/ci/build.sh` script manages the cache lifecycle:
 2. **Generate**: `make api-docs` runs `resourcedocsgen`, which skips fresh packages and regenerates stale ones.
 3. **Save**: copies the generated output (including updated sentinel files) back to `.cache/api-docs/` for the next run.
 
-CLI docs follow the same lifecycle: on restore, `.cache/api-docs/cli-docs/<pkg>/api-docs/` is copied to `cli-docs-out/registry/packages/<pkg>/api-docs/`; on save, the reverse copy is performed. Only `schema.json` (not the entire directory tree) is cached per package in the schema layer, to avoid persisting stale CLI doc files from older builds. CLI docs and provider `schema.json` files are stored uncompressed in the cache and in the Hugo build tree; `sync.sh` gzip-compresses them immediately before uploading to S3 (with `Content-Encoding: gzip`). For `schema.json`, this happens by extracting the files out of `public/` into a sibling `schema-out/` tree before the main `s5cmd sync --delete public/` runs, so the main sync does not upload them with the wrong metadata.
+CLI docs follow the same lifecycle: on restore, `.cache/api-docs/cli-docs/<pkg>/api-docs/` is copied to `cli-docs-out/registry/packages/<pkg>/api-docs/`; on save, the reverse copy is performed. Only `schema.json` (not the entire directory tree) is cached per package in the schema layer, to avoid persisting stale CLI doc files from older builds. CLI docs are stored uncompressed in the cache; `sync.sh` gzip-compresses them in place immediately before uploading to S3 (with `Content-Encoding: gzip`).
 
 #### Versioned docs cache
 
@@ -576,11 +576,9 @@ PR opened / committed
         │               ├── scripts/ci/build.sh preview
         │               └── scripts/ci/sync.sh preview
         │                       ├── Create / reuse S3 bucket
-        │                       ├── Extract + gzip -9 public/**/schema.json → schema-out/ (parallel)
-        │                       ├── s5cmd sync public/ → bucket (--delete)
+        │                       ├── s5cmd sync public/ → bucket
         │                       ├── gzip -9 cli-docs-out/ (parallel pre-compress)
         │                       ├── s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
-        │                       ├── s5cmd sync schema-out/ → bucket (Content-Encoding: gzip)
         │                       ├── Run browser tests (Cypress smoke test)
         │                       ├── Write origin-bucket-metadata.json
         │                       └── Post PR comment with preview URL
@@ -631,11 +629,9 @@ Push to master
                 │       ├── scripts/ci/build.sh update
                 │       ├── scripts/ci/sync.sh update
                 │       │       ├── Create / reuse S3 bucket
-                │       │       ├── Extract + gzip -9 public/**/schema.json → schema-out/ (parallel)
-                │       │       ├── s5cmd sync public/ → bucket (--delete)
+                │       │       ├── s5cmd sync public/ → bucket
                 │       │       ├── gzip -9 cli-docs-out/ (parallel pre-compress)
                 │       │       ├── s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
-                │       │       ├── s5cmd sync schema-out/ → bucket (Content-Encoding: gzip)
                 │       │       ├── Run browser tests (Cypress smoke test)
                 │       │       └── Write origin-bucket-metadata.json
                 │       ├── scripts/generate-search-index.sh
@@ -837,12 +833,10 @@ PR commit pushed
 scripts/ci/sync.sh preview
   1. aws s3 mb registry-testing-origin-pr-<N>-<sha8>
   2. Enable static website hosting
-  2a. Extract + gzip -9 public/**/schema.json files into schema-out/ (parallel)
   3. s5cmd sync public/ → bucket (--delete)
   3a. gzip -9 cli-docs.json files in cli-docs-out/ (parallel)
   3b. s5cmd sync cli-docs-out/ → bucket (Content-Encoding: gzip)
-  3c. s5cmd sync schema-out/ → bucket (Content-Encoding: gzip)
-  4. Run Cypress smoke tests (including origin-gzip assertions on random)
+  4. Run Cypress smoke tests
   5. Write origin-bucket-metadata.json
   6. aws ssm put-parameter /registry/commits/<sha>/bucket = <bucket-name>
   7. Post PR comment: "Your preview is ready at http://..."

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -105,17 +105,22 @@ aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version"
 if [[ -d "$cli_docs_dir" && -f "$cli_docs_dir/registry/packages/random/api-docs/cli-docs.json" ]]; then
     log "Smoke-testing CLI docs compression..."
     cli_docs_test_url="${s3_website_url}/registry/packages/random/api-docs/cli-docs.json"
-    cli_docs_headers=$(curl -fsSI "$cli_docs_test_url")
+    cli_docs_headers_file=$(mktemp)
+    if ! curl -fsS --dump-header "$cli_docs_headers_file" "$cli_docs_test_url" | gunzip -t; then
+        echo "ERROR: $cli_docs_test_url body did not decompress as gzip (or request failed)." >&2
+        rm -f "$cli_docs_headers_file"
+        exit 1
+    fi
+    cli_docs_headers=$(cat "$cli_docs_headers_file")
+    rm -f "$cli_docs_headers_file"
     if ! grep -qi '^content-encoding: gzip' <<< "$cli_docs_headers"; then
         echo "ERROR: $cli_docs_test_url is missing 'Content-Encoding: gzip'. Response headers:" >&2
         echo "$cli_docs_headers" >&2
         exit 1
     fi
-    if ! curl -fsS "$cli_docs_test_url" | gunzip -t; then
-        echo "ERROR: $cli_docs_test_url body did not decompress as gzip." >&2
-        exit 1
-    fi
     log "CLI docs compression smoke test passed."
+else
+    log "Skipping CLI docs compression smoke test: $cli_docs_dir/registry/packages/random/api-docs/cli-docs.json not found."
 fi
 
 # Smoke test the deployed website.

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -52,39 +52,6 @@ aws s3api put-bucket-tagging --bucket $destination_bucket --tagging "TagSet=[{$(
 # Make the bucket an S3 website.
 aws s3 website $destination_bucket_uri --index-document index.html --error-document 404.html --region "$(aws_region)"
 
-# Extract schema.json files out of the Hugo build tree and gzip them into a sibling
-# schema-out/ tree. They get uploaded separately (below, after the main sync) with
-# Content-Encoding: gzip set on the object, so both CloudFront layers pass them through
-# verbatim without relying on automatic compression -- which is disabled on /registry/*
-# at the outer CDN (Accept-Encoding forwarded via AllViewerExceptHostHeader) and
-# wouldn't help anyway for schemas over the 10 MB auto-compress ceiling
-# (aws/schema.json is >50 MB).
-#
-# This pull-aside has to happen BEFORE the main `s5cmd sync --delete` runs: removing
-# the raw schema.json files from the source tree first means that (a) the main sync
-# won't upload them with text/html or application/json content-type and no encoding
-# header, and (b) --delete will clean up any raw schema.json objects left in the
-# destination bucket by previous commits on the same PR preview bucket.
-schema_out_dir="schema-out"
-rm -rf "$schema_out_dir"
-if find "$build_dir/registry/packages" -name 'schema.json' -type f -print -quit 2>/dev/null | grep -q .; then
-    log "Extracting and pre-gzipping schema.json files..."
-    find "$build_dir/registry/packages" -name 'schema.json' -type f -print0 \
-        | xargs -0 -P"$(nproc)" -I{} sh -c '
-            src="$1"
-            build_dir="$2"
-            schema_out_dir="$3"
-            rel="${src#"$build_dir/"}"
-            dest="$schema_out_dir/$rel"
-            mkdir -p "$(dirname "$dest")"
-            gzip -9 < "$src" > "$dest"
-            rm "$src"
-        ' _ {} "$build_dir" "$schema_out_dir"
-    log "Schema extraction complete."
-else
-    log "No schema.json files found under $build_dir/registry/packages; skipping schema extraction."
-fi
-
 # Sync the local build directory to the bucket using s5cmd for massively parallel uploads.
 # s5cmd uses hundreds of concurrent goroutines vs aws cli's ~10-16 concurrent requests,
 # resulting in 10-50x faster uploads for large file counts.
@@ -123,19 +90,6 @@ if [[ -d "$cli_docs_dir" ]]; then
     log "CLI docs sync complete."
 fi
 
-# Sync the extracted + gzipped schema.json tree separately, with Content-Encoding: gzip
-# and Content-Type: application/json set on every object. No --delete here: the main
-# sync above already reconciled the destination against the (schema-free) public/ tree,
-# so this pass only needs to add the correctly-tagged gzipped schemas back.
-if [[ -d "$schema_out_dir" ]]; then
-    log "Synchronizing schemas to $destination_bucket_uri..."
-    s5cmd --log error sync --acl public-read \
-        --content-encoding gzip \
-        --content-type application/json \
-        "$schema_out_dir/" "$destination_bucket_uri/"
-    log "Schema sync complete."
-fi
-
 s3_website_url="http://${destination_bucket}.s3-website.$(aws_region).amazonaws.com"
 echo "$s3_website_url"
 
@@ -143,46 +97,33 @@ echo "$s3_website_url"
 aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version" \
     --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
 
-# Smoke test origin-gzipped assets at the S3 website layer (before either CloudFront
-# layer has a chance to mask a regression). Uses the random package because it has
-# small, reliably-present cli-docs.json and schema.json bundles. Catches the regression
-# where we accidentally upload either file without Content-Encoding: gzip, which would
-# otherwise only surface after deploy when consumers start paying full wire cost again.
+# Smoke test CLI docs compression at the S3 website layer (before either CloudFront
+# layer has a chance to mask a regression). Uses the random package because it has a
+# small, reliably-present cli-docs.json bundle. Catches the regression where we
+# accidentally upload cli-docs.json files without Content-Encoding: gzip, which would
+# otherwise only surface after deploy when the CLI starts paying full wire cost again.
 #
 # Uses curl --dump-header to validate the body (gunzip -t) and capture the headers in
 # a single round trip, rather than issuing separate HEAD and GET requests.
-check_gzip_asset() {
-    local label="$1"
-    local url="$2"
-    log "Smoke-testing $label compression at $url..."
-    local headers_file
-    headers_file=$(mktemp)
-    if ! curl -fsS --dump-header "$headers_file" "$url" | gunzip -t; then
-        echo "ERROR: $url body did not decompress as gzip (or request failed)." >&2
-        rm -f "$headers_file"
-        exit 1
-    fi
-    local headers
-    headers=$(cat "$headers_file")
-    rm -f "$headers_file"
-    if ! grep -qi '^content-encoding: gzip' <<< "$headers"; then
-        echo "ERROR: $url is missing 'Content-Encoding: gzip'. Response headers:" >&2
-        echo "$headers" >&2
-        exit 1
-    fi
-    log "$label compression smoke test passed."
-}
-
 if [[ -d "$cli_docs_dir" && -f "$cli_docs_dir/registry/packages/random/api-docs/cli-docs.json" ]]; then
-    check_gzip_asset "CLI docs" "${s3_website_url}/registry/packages/random/api-docs/cli-docs.json"
+    log "Smoke-testing CLI docs compression..."
+    cli_docs_test_url="${s3_website_url}/registry/packages/random/api-docs/cli-docs.json"
+    cli_docs_headers_file=$(mktemp)
+    if ! curl -fsS --dump-header "$cli_docs_headers_file" "$cli_docs_test_url" | gunzip -t; then
+        echo "ERROR: $cli_docs_test_url body did not decompress as gzip (or request failed)." >&2
+        rm -f "$cli_docs_headers_file"
+        exit 1
+    fi
+    cli_docs_headers=$(cat "$cli_docs_headers_file")
+    rm -f "$cli_docs_headers_file"
+    if ! grep -qi '^content-encoding: gzip' <<< "$cli_docs_headers"; then
+        echo "ERROR: $cli_docs_test_url is missing 'Content-Encoding: gzip'. Response headers:" >&2
+        echo "$cli_docs_headers" >&2
+        exit 1
+    fi
+    log "CLI docs compression smoke test passed."
 else
     log "Skipping CLI docs compression smoke test: $cli_docs_dir/registry/packages/random/api-docs/cli-docs.json not found."
-fi
-
-if [[ -d "$schema_out_dir" && -f "$schema_out_dir/registry/packages/random/schema.json" ]]; then
-    check_gzip_asset "Schema" "${s3_website_url}/registry/packages/random/schema.json"
-else
-    log "Skipping schema compression smoke test: $schema_out_dir/registry/packages/random/schema.json not found."
 fi
 
 # Smoke test the deployed website.

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -65,10 +65,27 @@ log "Sync complete."
 # Sync CLI docs separately. These are generated outside the Hugo build tree to avoid
 # Hugo processing static files. They're uploaded directly to the same URL paths
 # they'd occupy if they were in the Hugo static directory.
+#
+# CLI docs bundles are uploaded gzip-compressed with Content-Encoding: gzip so they
+# pass through both CloudFront layers (registry CDN + www.pulumi.com CDN) without
+# relying on CloudFront's automatic compression -- which is disabled on /registry/*
+# because the outer CDN forwards Accept-Encoding via AllViewerExceptHostHeader, and
+# wouldn't help anyway for bundles over CloudFront's 10 MB auto-compress ceiling
+# (the aws bundle is >100 MB uncompressed). Go's http.Client decompresses
+# Content-Encoding: gzip transparently, so the pulumi docs CLI requires no changes.
+#
+# The cli-docs-out/ tree contains only cli-docs.json files, so it is safe to apply
+# --content-encoding/--content-type globally to every object in the sync.
 cli_docs_dir="cli-docs-out"
 if [[ -d "$cli_docs_dir" ]]; then
+    log "Pre-gzipping CLI docs..."
+    find "$cli_docs_dir" -type f -name 'cli-docs.json' -print0 \
+        | xargs -0 -P"$(nproc)" -I{} sh -c 'gzip -9 < "$1" > "$1.gz.tmp" && mv "$1.gz.tmp" "$1"' _ {}
+
     log "Synchronizing CLI docs to $destination_bucket_uri..."
     s5cmd --log error sync --acl public-read \
+        --content-encoding gzip \
+        --content-type application/json \
         "$cli_docs_dir/" "$destination_bucket_uri/"
     log "CLI docs sync complete."
 fi
@@ -79,6 +96,27 @@ echo "$s3_website_url"
 # Set the content-type of latest-version explicitly. (Otherwise, it'll be set as binary/octet-stream.)
 aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version" \
     --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
+
+# Smoke test CLI docs compression at the S3 website layer (before either CloudFront
+# layer has a chance to mask a regression). Uses the random package because it has a
+# small, reliably-present cli-docs.json bundle. Catches the regression where we
+# accidentally upload cli-docs.json files without Content-Encoding: gzip, which would
+# otherwise only surface after deploy when the CLI starts paying full wire cost again.
+if [[ -d "$cli_docs_dir" && -f "$cli_docs_dir/registry/packages/random/api-docs/cli-docs.json" ]]; then
+    log "Smoke-testing CLI docs compression..."
+    cli_docs_test_url="${s3_website_url}/registry/packages/random/api-docs/cli-docs.json"
+    cli_docs_headers=$(curl -fsSI "$cli_docs_test_url")
+    if ! grep -qi '^content-encoding: gzip' <<< "$cli_docs_headers"; then
+        echo "ERROR: $cli_docs_test_url is missing 'Content-Encoding: gzip'. Response headers:" >&2
+        echo "$cli_docs_headers" >&2
+        exit 1
+    fi
+    if ! curl -fsS "$cli_docs_test_url" | gunzip -t; then
+        echo "ERROR: $cli_docs_test_url body did not decompress as gzip." >&2
+        exit 1
+    fi
+    log "CLI docs compression smoke test passed."
+fi
 
 # Smoke test the deployed website.
 log "Running browser tests on $s3_website_url..."

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -52,6 +52,39 @@ aws s3api put-bucket-tagging --bucket $destination_bucket --tagging "TagSet=[{$(
 # Make the bucket an S3 website.
 aws s3 website $destination_bucket_uri --index-document index.html --error-document 404.html --region "$(aws_region)"
 
+# Extract schema.json files out of the Hugo build tree and gzip them into a sibling
+# schema-out/ tree. They get uploaded separately (below, after the main sync) with
+# Content-Encoding: gzip set on the object, so both CloudFront layers pass them through
+# verbatim without relying on automatic compression -- which is disabled on /registry/*
+# at the outer CDN (Accept-Encoding forwarded via AllViewerExceptHostHeader) and
+# wouldn't help anyway for schemas over the 10 MB auto-compress ceiling
+# (aws/schema.json is >50 MB).
+#
+# This pull-aside has to happen BEFORE the main `s5cmd sync --delete` runs: removing
+# the raw schema.json files from the source tree first means that (a) the main sync
+# won't upload them with text/html or application/json content-type and no encoding
+# header, and (b) --delete will clean up any raw schema.json objects left in the
+# destination bucket by previous commits on the same PR preview bucket.
+schema_out_dir="schema-out"
+rm -rf "$schema_out_dir"
+if find "$build_dir/registry/packages" -name 'schema.json' -type f -print -quit 2>/dev/null | grep -q .; then
+    log "Extracting and pre-gzipping schema.json files..."
+    find "$build_dir/registry/packages" -name 'schema.json' -type f -print0 \
+        | xargs -0 -P"$(nproc)" -I{} sh -c '
+            src="$1"
+            build_dir="$2"
+            schema_out_dir="$3"
+            rel="${src#"$build_dir/"}"
+            dest="$schema_out_dir/$rel"
+            mkdir -p "$(dirname "$dest")"
+            gzip -9 < "$src" > "$dest"
+            rm "$src"
+        ' _ {} "$build_dir" "$schema_out_dir"
+    log "Schema extraction complete."
+else
+    log "No schema.json files found under $build_dir/registry/packages; skipping schema extraction."
+fi
+
 # Sync the local build directory to the bucket using s5cmd for massively parallel uploads.
 # s5cmd uses hundreds of concurrent goroutines vs aws cli's ~10-16 concurrent requests,
 # resulting in 10-50x faster uploads for large file counts.
@@ -90,6 +123,19 @@ if [[ -d "$cli_docs_dir" ]]; then
     log "CLI docs sync complete."
 fi
 
+# Sync the extracted + gzipped schema.json tree separately, with Content-Encoding: gzip
+# and Content-Type: application/json set on every object. No --delete here: the main
+# sync above already reconciled the destination against the (schema-free) public/ tree,
+# so this pass only needs to add the correctly-tagged gzipped schemas back.
+if [[ -d "$schema_out_dir" ]]; then
+    log "Synchronizing schemas to $destination_bucket_uri..."
+    s5cmd --log error sync --acl public-read \
+        --content-encoding gzip \
+        --content-type application/json \
+        "$schema_out_dir/" "$destination_bucket_uri/"
+    log "Schema sync complete."
+fi
+
 s3_website_url="http://${destination_bucket}.s3-website.$(aws_region).amazonaws.com"
 echo "$s3_website_url"
 
@@ -97,30 +143,46 @@ echo "$s3_website_url"
 aws s3 cp "$build_dir/latest-version" "${destination_bucket_uri}/latest-version" \
     --content-type "text/plain" --acl public-read --region "$(aws_region)" --metadata-directive REPLACE
 
-# Smoke test CLI docs compression at the S3 website layer (before either CloudFront
-# layer has a chance to mask a regression). Uses the random package because it has a
-# small, reliably-present cli-docs.json bundle. Catches the regression where we
-# accidentally upload cli-docs.json files without Content-Encoding: gzip, which would
-# otherwise only surface after deploy when the CLI starts paying full wire cost again.
+# Smoke test origin-gzipped assets at the S3 website layer (before either CloudFront
+# layer has a chance to mask a regression). Uses the random package because it has
+# small, reliably-present cli-docs.json and schema.json bundles. Catches the regression
+# where we accidentally upload either file without Content-Encoding: gzip, which would
+# otherwise only surface after deploy when consumers start paying full wire cost again.
+#
+# Uses curl --dump-header to validate the body (gunzip -t) and capture the headers in
+# a single round trip, rather than issuing separate HEAD and GET requests.
+check_gzip_asset() {
+    local label="$1"
+    local url="$2"
+    log "Smoke-testing $label compression at $url..."
+    local headers_file
+    headers_file=$(mktemp)
+    if ! curl -fsS --dump-header "$headers_file" "$url" | gunzip -t; then
+        echo "ERROR: $url body did not decompress as gzip (or request failed)." >&2
+        rm -f "$headers_file"
+        exit 1
+    fi
+    local headers
+    headers=$(cat "$headers_file")
+    rm -f "$headers_file"
+    if ! grep -qi '^content-encoding: gzip' <<< "$headers"; then
+        echo "ERROR: $url is missing 'Content-Encoding: gzip'. Response headers:" >&2
+        echo "$headers" >&2
+        exit 1
+    fi
+    log "$label compression smoke test passed."
+}
+
 if [[ -d "$cli_docs_dir" && -f "$cli_docs_dir/registry/packages/random/api-docs/cli-docs.json" ]]; then
-    log "Smoke-testing CLI docs compression..."
-    cli_docs_test_url="${s3_website_url}/registry/packages/random/api-docs/cli-docs.json"
-    cli_docs_headers_file=$(mktemp)
-    if ! curl -fsS --dump-header "$cli_docs_headers_file" "$cli_docs_test_url" | gunzip -t; then
-        echo "ERROR: $cli_docs_test_url body did not decompress as gzip (or request failed)." >&2
-        rm -f "$cli_docs_headers_file"
-        exit 1
-    fi
-    cli_docs_headers=$(cat "$cli_docs_headers_file")
-    rm -f "$cli_docs_headers_file"
-    if ! grep -qi '^content-encoding: gzip' <<< "$cli_docs_headers"; then
-        echo "ERROR: $cli_docs_test_url is missing 'Content-Encoding: gzip'. Response headers:" >&2
-        echo "$cli_docs_headers" >&2
-        exit 1
-    fi
-    log "CLI docs compression smoke test passed."
+    check_gzip_asset "CLI docs" "${s3_website_url}/registry/packages/random/api-docs/cli-docs.json"
 else
     log "Skipping CLI docs compression smoke test: $cli_docs_dir/registry/packages/random/api-docs/cli-docs.json not found."
+fi
+
+if [[ -d "$schema_out_dir" && -f "$schema_out_dir/registry/packages/random/schema.json" ]]; then
+    check_gzip_asset "Schema" "${s3_website_url}/registry/packages/random/schema.json"
+else
+    log "Skipping schema compression smoke test: $schema_out_dir/registry/packages/random/schema.json not found."
 fi
 
 # Smoke test the deployed website.


### PR DESCRIPTION
## Summary

The `cli-docs.json` bundles served at `/registry/packages/<pkg>/api-docs/cli-docs.json` -- consumed by the **not-yet-released** `pulumi docs` command (pulumi/pulumi#22538, pulumi/pulumi#22539) -- were coming back **uncompressed**. For aws the bundle is 103 MB on the wire when it could be ~7 MB gzipped. This PR pre-gzips the bundles at upload time and sets `Content-Encoding: gzip` on the S3 object, which makes both CloudFront layers pass them through verbatim without relying on (or being constrained by) their automatic compression.

No released Pulumi client fetches these URLs today, so this change has **zero blast radius on existing users**.

## Why the CDN wasn't compressing

Responses traverse two CloudFront distributions in series: the outer `www.pulumi.com` CDN (defined in `pulumi/docs/infrastructure/index.ts`) and the inner registry CDN (this repo).

1. **Outer CDN, `/registry/*` behavior:** attaches `originRequestPolicyId: allViewerExceptHostHeaderId` (the managed `AllViewerExceptHostHeader` policy) to forward viewer headers to the inner CDN. That policy forwards `Accept-Encoding`, and **CloudFront silently disables automatic compression on any cache behavior that forwards `Accept-Encoding` to the origin.** So `compress: true` on that behavior is a no-op for all registry traffic.
2. **Inner registry CDN:** uses the S3 website endpoint as a custom origin, which has edge cases that prevent reliable auto-compression even for smaller files. And for the aws bundle it's moot: CloudFront's auto-compression has a hard 10 MB object-size ceiling, and the aws bundle is 103 MB.

A follow-up brief for the `pulumi/docs` repo is queued separately to fix the outer-CDN policy so that HTML package pages and smaller JSON also start compressing on the fly. That's out of scope here.

## The fix

Localized to `scripts/ci/sync.sh`. The `cli-docs-out/` tree contains only `cli-docs.json` files, so:

1. Parallel `gzip -9` over every `cli-docs.json` in place (`xargs -P \"$(nproc)\"`).
2. Existing `s5cmd sync cli-docs-out/` invocation gains `--content-encoding gzip --content-type application/json` globally. s5cmd v2.3.0 (the pinned version in `.github/workflows/*.yml`) supports these flags on `sync`.

### Smoke test

New post-sync assertion against the S3 website endpoint for `random/api-docs/cli-docs.json`: uses `curl --dump-header` + `gunzip -t` in a single round trip to verify both that the response carries `Content-Encoding: gzip` and that the body decompresses cleanly. Fails CI closed if either check fails, catching any regression at the origin layer before either CloudFront can mask it.

## Measured impact (end-to-end through both CloudFront layers on `www.pulumi-test.io`)

| Package | Before (raw) | After (gzip wire) | Ratio |
|---|---:|---:|---:|
| random | 204 KB | 16.7 KB | 12.2x |
| azuread | 2.8 MB | 203 KB | 13.9x |
| **aws** | **103 MB** | **7.38 MB** | **14.0x** |

The aws bundle (bold) was previously **unreachable by any CDN-side fix** (over the 10 MB auto-compress ceiling). The fix cuts its wire size by ~93%. For the `pulumi docs` CLI, cold runs for aws drop from ~13 s to the low single digits. No client-side changes needed -- Go's `http.Client` decompresses `Content-Encoding: gzip` transparently.
