### PR TITLE
Exclude non-canonical pages from sitemap (#10639)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ static/registry/
 themes/default/content/registry/packages/*/api-docs/
 themes/default/content/registry/packages/*@*/
 themes/default/static/registry/packages/navs/
+themes/default/static/registry/packages/*/schema.json
 themes/default/static/registry/js/
 themes/default/static/registry/css/
 themes/default/data/asset_manifest.json

--- a/scripts/split-sitemap.js
+++ b/scripts/split-sitemap.js
@@ -19,15 +19,31 @@ async function splitSitemap() {
     const urlPattern =
         /<url>\s*<loc>([^<]+)<\/loc>(?:\s*<lastmod>([^<]+)<\/lastmod>)?/g;
     const items = [];
+    let droppedNonCanonical = 0;
     let match;
     while ((match = urlPattern.exec(xml)) !== null) {
-        const item = { url: match[1] };
+        const url = match[1];
+        // Defense in depth for #10639: drop versioned package URLs
+        // (e.g. /registry/packages/aws@6.x/...) whose canonical tag
+        // points to the unversioned sibling. The Hugo sitemap template
+        // should already exclude these, but filtering here catches any
+        // template regression before it reaches search engines.
+        if (url.includes("@") || url.includes("%40")) {
+            droppedNonCanonical++;
+            continue;
+        }
+        const item = { url };
         if (match[2]) {
             item.lastmod = match[2];
         }
         items.push(item);
     }
 
+    if (droppedNonCanonical > 0) {
+        console.log(
+            `Dropped ${droppedNonCanonical} non-canonical (@-versioned) URLs.`,
+        );
+    }
     console.log(`Sitemap contains ${items.length} URLs.`);
 
     if (items.length === 0) {

--- a/themes/default/layouts/_default/sitemap.xml
+++ b/themes/default/layouts/_default/sitemap.xml
@@ -1,7 +1,18 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  {{ if not (or .Params.private .Params.block_external_search_index) }}
+  {{- /*
+      Exclude pages that should not be crawled, and exclude non-canonical
+      pages (those whose <link rel="canonical"> points elsewhere — e.g.
+      versioned package docs at /registry/packages/<pkg>@<ver>/ whose
+      canonical points to the unversioned sibling). See #10639.
+  */ -}}
+  {{ $canonicalPath := partial "canonical-path.html" . }}
+  {{ if and
+        (strings.HasPrefix .RelPermalink "/registry")
+        (not (or .Params.private .Params.block_external_search_index))
+        (not (strings.HasPrefix .RelPermalink "/registry/packages/azure-native-v2"))
+        (eq $canonicalPath .RelPermalink) }}
   <url>
     <loc>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/themes/default/layouts/partials/canonical-path.html
+++ b/themes/default/layouts/partials/canonical-path.html
@@ -1,0 +1,19 @@
+{{- /*
+    Returns the canonical path for a page. Used by head.html (to emit
+    <link rel="canonical">) and sitemap.xml (to decide whether a page
+    belongs in the sitemap — non-canonical pages are excluded).
+
+    Resolution order:
+    1. If .Params.canonical_url is set, return it verbatim.
+    2. If the RelPermalink contains a "@vX.Y" version segment (versioned
+       package docs like /registry/packages/aws@6.x/...), strip the
+       @version portion so the canonical points to the unversioned page.
+    3. Otherwise, return RelPermalink unchanged.
+*/ -}}
+{{- if .Params.canonical_url -}}
+{{- .Params.canonical_url -}}
+{{- else if strings.Contains .RelPermalink "@" -}}
+{{- replaceRE `([^/]+)@[^/]+` "$1" .RelPermalink -}}
+{{- else -}}
+{{- .RelPermalink -}}
+{{- end -}}

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -224,13 +224,10 @@
         https://en.wikipedia.org/wiki/Canonical_link_element
     -->
 
-    {{ if .Params.canonical_url }}
-        <link rel="canonical" href="{{ .Params.canonical_url }}" />
+    {{ $canonicalPath := partial "canonical-path.html" . }}
+    {{ if or (hasPrefix $canonicalPath "http://") (hasPrefix $canonicalPath "https://") }}
+        <link rel="canonical" href="{{ $canonicalPath }}" />
     {{ else }}
-        {{ $canonicalPath := .RelPermalink }}
-        {{ if strings.Contains $canonicalPath "@" }}
-            {{ $canonicalPath = replaceRE `([^/]+)@[^/]+` "$1" $canonicalPath }}
-        {{ end }}
         <link rel="canonical" href="{{ .Site.Params.canonicalURL }}{{ $canonicalPath }}" />
     {{ end }}
 

--- a/themes/default/layouts/sitemap.xml
+++ b/themes/default/layouts/sitemap.xml
@@ -1,7 +1,21 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  {{ if and (strings.HasPrefix .RelPermalink "/registry") (not (or .Params.private .Params.block_external_search_index)) (not (strings.HasPrefix .RelPermalink "/registry/packages/azure-native-v2")) (not (strings.Contains .RelPermalink "@")) }}
+  {{- /*
+      Exclude pages that should not be crawled, and exclude non-canonical
+      pages (those whose <link rel="canonical"> points elsewhere — e.g.
+      versioned package docs at /registry/packages/<pkg>@<ver>/ whose
+      canonical points to the unversioned sibling). See #10639.
+
+      Kept in sync with layouts/_default/sitemap.xml; Hugo may resolve
+      either depending on version/config, so both carry the same logic.
+  */ -}}
+  {{ $canonicalPath := partial "canonical-path.html" . }}
+  {{ if and
+        (strings.HasPrefix .RelPermalink "/registry")
+        (not (or .Params.private .Params.block_external_search_index))
+        (not (strings.HasPrefix .RelPermalink "/registry/packages/azure-native-v2"))
+        (eq $canonicalPath .RelPermalink) }}
   <url>
     <loc>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}


### PR DESCRIPTION
Fixes #10639.

Versioned package docs (e.g. `/registry/packages/aws@6.x/...`) emit a `<link rel="canonical">` pointing to their unversioned sibling, but were still listed in the sitemap. Google flagged ~18k pages as "Alternate page with proper canonical tag."

A GSC export of 999 affected URLs confirmed ~99.8% of registry-scoped entries contain `@`; the rest are query-param crawl artifacts that aren't in our sitemap.

## Changes

- New shared partial `canonical-path.html` used by both `head.html` and the sitemap templates -- single source of truth for canonical URL computation.
- Both sitemap templates (`_default/sitemap.xml` and `sitemap.xml`) now include a page only when its canonical equals its own RelPermalink.
- `split-sitemap.js` defensively drops `@` / `%40` URLs as a regression guard.
- `.gitignore` covers the generated `themes/default/static/registry/packages/*/schema.json` artifacts that were leaking into `git status`.

## Test plan

- [ ] Verify preview `/registry/sitemap-0.xml` and `sitemap-1.xml` contain no `@` URLs
- [ ] Spot-check a versioned package page's HTML for correct `<link rel="canonical">`
- [ ] After deploy: resubmit sitemap in GSC, monitor "Alternate page with proper canonical tag" count over 1-2 weeks