### PR TITLE
Add copy-prompt button to provider pages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ go 1.23
 // will be considered a private Go module as well. We could configure an SSH key to get around
 // that but this is simpler for the time being.
 replace github.com/pulumi/registry/themes/default => ./themes/default
+
+require github.com/pulumi/registry/themes/default v0.0.0-20260426185403-5baa1a23dc98 // indirect

--- a/themes/default/layouts/partials/docs/table-of-contents.html
+++ b/themes/default/layouts/partials/docs/table-of-contents.html
@@ -51,6 +51,12 @@
     </div>
 {{ end }}
 <ul class="p-0 list-none table-of-contents-feedback">
+    <li>
+        <pulumi-llm-menu
+            page-url="{{ .Permalink }}"
+            page-title="{{ .Title }}"
+        ></pulumi-llm-menu>
+    </li>
     <!-- Only show "Edit this Page" for pages that are not generated. -->
     {{ $isCLICommand := hasPrefix .Path "docs/cli/commands" }}
     {{ $isAPIDoc := and (hasPrefix .Path "docs/reference/pkg/") (ne .Path "docs/reference/pkg/_index.md") }}

--- a/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
+++ b/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
@@ -1,34 +1,59 @@
 {{ $packageData := .packageData }}
 {{ $rawPackageName := .rawPackageName }}
-{{ $docsURL := printf "/registry/packages/%s/" $rawPackageName | absURL }}
-{{ $installURL := printf "/registry/packages/%s/installation-configuration/" $rawPackageName | absURL }}
-{{ $apiDocsURL := printf "/registry/packages/%s/api-docs/" $rawPackageName | absURL }}
-{{ $guidesURL := printf "/registry/packages/%s/how-to-guides/" $rawPackageName | absURL }}
-{{ $schemaURL := printf "/registry/packages/%s/schema.json" $rawPackageName | absURL }}
-{{ $installCmd := printf "pulumi plugin install resource %s %s" $rawPackageName $packageData.version }}
 
-{{ $prompt := printf `I want to use the Pulumi %s provider (%s) in my project.
+{{/* Use the Pulumi Cloud Registry API so the prompt covers private packages and every published version, not just what's rendered on the public Hugo site. */}}
+{{ $publishers := readFile "tools/resourcedocsgen/pkg/publishers/publisher-names.json" | transform.Unmarshal }}
+{{ $publisherSlug := index $publishers $packageData.publisher }}
+
+{{ $source := "pulumi" }}
+{{ with $packageData.schema_file_url }}
+    {{ if in . "registry.opentofu.org" }}
+        {{ $source = "opentofu" }}
+    {{ end }}
+{{ end }}
+
+{{ $apiBase := "" }}
+{{ if $publisherSlug }}
+    {{ $apiBase = printf "https://api.pulumi.com/api/registry/packages/%s/%s/%s/versions/latest" $source $publisherSlug $rawPackageName }}
+{{ end }}
+
+{{ $prompt := "" }}
+{{ if $apiBase }}
+    {{ $prompt = printf `I want to use the Pulumi %s provider (%s) in my project.
 
 ## Provider details
 - Package: %s
 - Version: %s
 - Publisher: %s
-
-## Installation
-Run the following to install the provider plugin:
-  %s
-
-Or add it as a dependency in your language of choice (npm, pip, go, nuget).
-
-## Reference links
-- Overview and getting started: %s
-- Installation and configuration: %s
-- API documentation: %s
-- How-to guides and examples: %s
-- Schema (JSON): %s
 - Repository: %s
 
-Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $installCmd $docsURL $installURL $apiDocsURL $guidesURL $schemaURL $packageData.repo_url }}
+## Documentation
+The Pulumi Cloud Registry API serves canonical, up-to-date docs for this package — including private packages and every published version. Send the "Accept: text/markdown" header for clean readable content, or "application/json" for structured data.
+
+Start at the navigation tree, which cross-links to the readme, installation guide, and per-resource docs URL template:
+- %s/nav
+
+Other endpoints:
+- Overview and getting started: %s/readme
+- Installation and configuration: %s/installation
+- Per-resource/function docs: %s/docs/{token}?lang={lang}
+  Replace {token} with the percent-encoded token from the nav response (for example aws:s3/bucket:Bucket).
+  Replace {lang} with typescript, python, go, csharp, java, or yaml.
+
+Fetch the installation endpoint above for the correct setup steps — install instructions vary between native providers, bridged Terraform providers, and component packages.
+
+Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $packageData.repo_url $apiBase $apiBase $apiBase $apiBase }}
+{{ else }}
+    {{ $prompt = printf `I want to use the Pulumi %s provider (%s) in my project.
+
+## Provider details
+- Package: %s
+- Version: %s
+- Publisher: %s
+- Repository: %s
+
+Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $packageData.repo_url }}
+{{ end }}
 
 {{ $encoded := $prompt | urlquery }}
 {{ $chatgptURL := printf "https://chatgpt.com/?q=%s" $encoded | safeURL }}

--- a/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
+++ b/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
@@ -1,0 +1,39 @@
+{{ $packageData := .packageData }}
+{{ $rawPackageName := .rawPackageName }}
+{{ $docsURL := printf "/registry/packages/%s/" $rawPackageName | absURL }}
+{{ $installURL := printf "/registry/packages/%s/installation-configuration/" $rawPackageName | absURL }}
+{{ $apiDocsURL := printf "/registry/packages/%s/api-docs/" $rawPackageName | absURL }}
+{{ $guidesURL := printf "/registry/packages/%s/how-to-guides/" $rawPackageName | absURL }}
+{{ $schemaURL := printf "/registry/packages/%s/schema.json" $rawPackageName | absURL }}
+{{ $installCmd := printf "pulumi plugin install resource %s %s" $rawPackageName $packageData.version }}
+
+<div class="copy-llm-prompt" data-component="copy-llm-prompt">
+  <template>I want to use the Pulumi {{ $packageData.title }} provider ({{ $rawPackageName }}) in my project.
+
+## Provider details
+- Package: {{ $rawPackageName }}
+- Version: {{ $packageData.version }}
+- Publisher: {{ $packageData.publisher }}
+
+## Installation
+Run the following to install the provider plugin:
+  {{ $installCmd }}
+
+Or add it as a dependency in your language of choice (npm, pip, go, nuget).
+
+## Reference links
+- Overview and getting started: {{ $docsURL }}
+- Installation and configuration: {{ $installURL }}
+- API documentation: {{ $apiDocsURL }}
+- How-to guides and examples: {{ $guidesURL }}
+- Schema (JSON): {{ $schemaURL }}
+- Repository: {{ $packageData.repo_url }}
+
+Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.</template>
+  <button type="button"
+          class="copy-llm-prompt__button"
+          aria-label="Copy LLM prompt to clipboard">
+    <i class="fas fa-copy copy-llm-prompt__icon" aria-hidden="true"></i>
+    <span class="copy-llm-prompt__text">Copy prompt</span>
+  </button>
+</div>

--- a/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
+++ b/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
@@ -7,33 +7,73 @@
 {{ $schemaURL := printf "/registry/packages/%s/schema.json" $rawPackageName | absURL }}
 {{ $installCmd := printf "pulumi plugin install resource %s %s" $rawPackageName $packageData.version }}
 
-<div class="copy-llm-prompt" data-component="copy-llm-prompt">
-  <template>I want to use the Pulumi {{ $packageData.title }} provider ({{ $rawPackageName }}) in my project.
+{{ $prompt := printf `I want to use the Pulumi %s provider (%s) in my project.
 
 ## Provider details
-- Package: {{ $rawPackageName }}
-- Version: {{ $packageData.version }}
-- Publisher: {{ $packageData.publisher }}
+- Package: %s
+- Version: %s
+- Publisher: %s
 
 ## Installation
 Run the following to install the provider plugin:
-  {{ $installCmd }}
+  %s
 
 Or add it as a dependency in your language of choice (npm, pip, go, nuget).
 
 ## Reference links
-- Overview and getting started: {{ $docsURL }}
-- Installation and configuration: {{ $installURL }}
-- API documentation: {{ $apiDocsURL }}
-- How-to guides and examples: {{ $guidesURL }}
-- Schema (JSON): {{ $schemaURL }}
-- Repository: {{ $packageData.repo_url }}
+- Overview and getting started: %s
+- Installation and configuration: %s
+- API documentation: %s
+- How-to guides and examples: %s
+- Schema (JSON): %s
+- Repository: %s
 
-Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.</template>
+Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $installCmd $docsURL $installURL $apiDocsURL $guidesURL $schemaURL $packageData.repo_url }}
+
+{{ $encoded := $prompt | urlquery }}
+
+<div class="copy-llm-prompt" data-component="copy-llm-prompt">
+  <template>{{ $prompt }}</template>
   <button type="button"
-          class="copy-llm-prompt__button"
-          aria-label="Copy LLM prompt to clipboard">
-    <i class="fas fa-copy copy-llm-prompt__icon" aria-hidden="true"></i>
-    <span class="copy-llm-prompt__text">Copy prompt</span>
+          class="copy-llm-prompt__trigger"
+          data-role="trigger"
+          aria-haspopup="true"
+          aria-expanded="false">
+    <i class="fas fa-wand-magic-sparkles copy-llm-prompt__icon" aria-hidden="true"></i>
+    <span class="copy-llm-prompt__text">Use with AI</span>
+    <i class="copy-llm-prompt__chevron fa fa-chevron-down" aria-hidden="true"></i>
   </button>
+  <div class="copy-llm-prompt__dropdown" role="menu" data-role="dropdown" hidden>
+    <a class="copy-llm-prompt__item"
+       href="https://chatgpt.com/?q={{ $encoded }}"
+       target="_blank" rel="noopener" role="menuitem">
+      <span class="copy-llm-prompt__item-icon" aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/></svg>
+      </span>
+      <span class="copy-llm-prompt__item-label">Open in ChatGPT</span>
+    </a>
+    <a class="copy-llm-prompt__item"
+       href="https://claude.ai/new?q={{ $encoded }}"
+       target="_blank" rel="noopener" role="menuitem">
+      <span class="copy-llm-prompt__item-icon" aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5527h3.7442L10.5363 3.541Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"/></svg>
+      </span>
+      <span class="copy-llm-prompt__item-label">Open in Claude</span>
+    </a>
+    <a class="copy-llm-prompt__item"
+       href="https://v0.dev/chat?q={{ $encoded }}"
+       target="_blank" rel="noopener" role="menuitem">
+      <span class="copy-llm-prompt__item-icon" aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M14.066 6.028v2.22h5.729q.075-.001.148.005l-5.853 5.752a2 2 0 0 1-.024-.309V8.247h-2.353v5.45c0 2.322 1.935 4.222 4.258 4.222h5.675v-2.22h-5.675q-.03 0-.059-.003l5.729-5.629q.006.082.006.166v5.465H24v-5.465a4.204 4.204 0 0 0-4.205-4.205zM0 8.245l8.28 9.266c.839.94 2.396.346 2.396-.914V8.245H8.19v5.44l-4.86-5.44Z"/></svg>
+      </span>
+      <span class="copy-llm-prompt__item-label">Open in v0</span>
+    </a>
+    <div class="copy-llm-prompt__divider"></div>
+    <button class="copy-llm-prompt__item copy-llm-prompt__copy-action" role="menuitem" data-role="copy">
+      <span class="copy-llm-prompt__item-icon" aria-hidden="true">
+        <i class="fas fa-copy" aria-hidden="true"></i>
+      </span>
+      <span class="copy-llm-prompt__item-label">Copy prompt</span>
+    </button>
+  </div>
 </div>

--- a/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
+++ b/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
@@ -19,12 +19,13 @@
 
 {{ $prompt := "" }}
 {{ if $apiBase }}
-    {{ $prompt = printf `I want to use the Pulumi %s provider (%s) in my project.
+    {{ $prompt = printf `I want to use the Pulumi %s package (%s) in my project.
 
 ## Provider details
 - Package: %s
 - Version: %s
 - Publisher: %s
+- Source: %s
 - Repository: %s
 
 ## Documentation
@@ -32,6 +33,7 @@ The Pulumi Cloud Registry API serves canonical, up-to-date docs for this package
 
 Start at the navigation tree, which cross-links to the readme, installation guide, and per-resource docs URL template:
 - %s/nav
+  Returns a summary by default. The full tree can be hundreds of kB for large providers, so prefer targeted search: append "?q=<query>&depth=full" to filter by resource/function title or token (for example "?q=bucket&depth=full"). Only request the full nav without a query if you actually need to enumerate every resource.
 
 Other endpoints:
 - Overview and getting started: %s/readme
@@ -42,17 +44,18 @@ Other endpoints:
 
 Fetch the installation endpoint above for the correct setup steps — install instructions vary between native providers, bridged Terraform providers, and component packages.
 
-Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $packageData.repo_url $apiBase $apiBase $apiBase $apiBase }}
+Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $source $packageData.repo_url $apiBase $apiBase $apiBase $apiBase }}
 {{ else }}
-    {{ $prompt = printf `I want to use the Pulumi %s provider (%s) in my project.
+    {{ $prompt = printf `I want to use the Pulumi %s package (%s) in my project.
 
 ## Provider details
 - Package: %s
 - Version: %s
 - Publisher: %s
+- Source: %s
 - Repository: %s
 
-Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $packageData.repo_url }}
+Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $source $packageData.repo_url }}
 {{ end }}
 
 {{ $encoded := $prompt | urlquery }}

--- a/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
+++ b/themes/default/layouts/partials/registry/package/copy-llm-prompt.html
@@ -31,6 +31,9 @@ Or add it as a dependency in your language of choice (npm, pip, go, nuget).
 Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.` $packageData.title $rawPackageName $rawPackageName $packageData.version $packageData.publisher $installCmd $docsURL $installURL $apiDocsURL $guidesURL $schemaURL $packageData.repo_url }}
 
 {{ $encoded := $prompt | urlquery }}
+{{ $chatgptURL := printf "https://chatgpt.com/?q=%s" $encoded | safeURL }}
+{{ $claudeURL := printf "https://claude.ai/new?q=%s" $encoded | safeURL }}
+{{ $v0URL := printf "https://v0.dev/chat?q=%s" $encoded | safeURL }}
 
 <div class="copy-llm-prompt" data-component="copy-llm-prompt">
   <template>{{ $prompt }}</template>
@@ -45,7 +48,7 @@ Help me get started using this provider. Show me a complete Pulumi program that 
   </button>
   <div class="copy-llm-prompt__dropdown" role="menu" data-role="dropdown" hidden>
     <a class="copy-llm-prompt__item"
-       href="https://chatgpt.com/?q={{ $encoded }}"
+       href="{{ $chatgptURL }}"
        target="_blank" rel="noopener" role="menuitem">
       <span class="copy-llm-prompt__item-icon" aria-hidden="true">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/></svg>
@@ -53,7 +56,7 @@ Help me get started using this provider. Show me a complete Pulumi program that 
       <span class="copy-llm-prompt__item-label">Open in ChatGPT</span>
     </a>
     <a class="copy-llm-prompt__item"
-       href="https://claude.ai/new?q={{ $encoded }}"
+       href="{{ $claudeURL }}"
        target="_blank" rel="noopener" role="menuitem">
       <span class="copy-llm-prompt__item-icon" aria-hidden="true">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5527h3.7442L10.5363 3.541Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"/></svg>
@@ -61,7 +64,7 @@ Help me get started using this provider. Show me a complete Pulumi program that 
       <span class="copy-llm-prompt__item-label">Open in Claude</span>
     </a>
     <a class="copy-llm-prompt__item"
-       href="https://v0.dev/chat?q={{ $encoded }}"
+       href="{{ $v0URL }}"
        target="_blank" rel="noopener" role="menuitem">
       <span class="copy-llm-prompt__item-icon" aria-hidden="true">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M14.066 6.028v2.22h5.729q.075-.001.148.005l-5.853 5.752a2 2 0 0 1-.024-.309V8.247h-2.353v5.45c0 2.322 1.935 4.222 4.258 4.222h5.675v-2.22h-5.675q-.03 0-.059-.003l5.729-5.629q.006.082.006.166v5.465H24v-5.465a4.204 4.204 0 0 0-4.205-4.205zM0 8.245l8.28 9.266c.839.94 2.396.346 2.396-.914V8.245H8.19v5.44l-4.86-5.44Z"/></svg>
@@ -69,7 +72,7 @@ Help me get started using this provider. Show me a complete Pulumi program that 
       <span class="copy-llm-prompt__item-label">Open in v0</span>
     </a>
     <div class="copy-llm-prompt__divider"></div>
-    <button class="copy-llm-prompt__item copy-llm-prompt__copy-action" role="menuitem" data-role="copy">
+    <button type="button" class="copy-llm-prompt__item copy-llm-prompt__copy-action" role="menuitem" data-role="copy">
       <span class="copy-llm-prompt__item-icon" aria-hidden="true">
         <i class="fas fa-copy" aria-hidden="true"></i>
       </span>

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -22,7 +22,8 @@
 
             {{ partial "registry/package/package-card-top-of-page.html" . }}
 
-            <div class="special-h1">
+            <div class="title-llm-prompt-container">
+                <div class="special-h1">
                 {{ if strings.Contains .Permalink "installation-configuration" }}
                 <h1>{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}: Installation & Configuration</h1>
                 {{ else if strings.HasSuffix .Permalink "how-to-guides/" }}
@@ -53,12 +54,13 @@
                 {{ end }}
                 {{ end }}
                 <div class="h1-gradient"></div>
-            </div>
+                </div>
 
-            {{ $copyPromptPackageData := index site.Data.registry.packages $packageName }}
-            {{ with $copyPromptPackageData }}
-                {{ partial "registry/package/copy-llm-prompt.html" (dict "packageData" . "rawPackageName" $packageName) }}
-            {{ end }}
+                {{ $copyPromptPackageData := index site.Data.registry.packages $packageName }}
+                {{ with $copyPromptPackageData }}
+                    {{ partial "registry/package/copy-llm-prompt.html" (dict "packageData" . "rawPackageName" $packageName) }}
+                {{ end }}
+            </div>
 
             <div class="docs-table-of-contents docs-toc-mobile">
                 {{ partial "docs/table-of-contents.html" . }}

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -55,6 +55,11 @@
                 <div class="h1-gradient"></div>
             </div>
 
+            {{ $copyPromptPackageData := index site.Data.registry.packages $packageName }}
+            {{ with $copyPromptPackageData }}
+                {{ partial "registry/package/copy-llm-prompt.html" (dict "packageData" . "rawPackageName" $packageName) }}
+            {{ end }}
+
             <div class="docs-table-of-contents docs-toc-mobile">
                 {{ partial "docs/table-of-contents.html" . }}
                 {{ partial "docs/right-nav-ad.html" }}

--- a/themes/default/layouts/registry/package.html
+++ b/themes/default/layouts/registry/package.html
@@ -22,42 +22,44 @@
 
                 {{ partial "registry/package/package-card-top-of-page.html" . }}
 
-                <div class="special-h1">
-                    {{ if strings.Contains .Permalink "installation-configuration" }}
-                        <h1>{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}: Installation & Configuration</h1>
-                    {{ else if strings.HasSuffix .Permalink "how-to-guides/" }}
-                        <h1>{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}: How-to-Guides</h1>
-                    {{ else if strings.Contains .Permalink "api-docs" }}
-                        <!--Don't show the title in the top-most index page.-->
-                        {{ if not (in .Page.File.Path "api-docs/_index.md") }}
+                <div class="title-llm-prompt-container">
+                    <div class="special-h1">
+                        {{ if strings.Contains .Permalink "installation-configuration" }}
+                            <h1>{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}: Installation & Configuration</h1>
+                        {{ else if strings.HasSuffix .Permalink "how-to-guides/" }}
+                            <h1>{{ with .GetPage $packageHome }}{{ .Title }}{{ end }}: How-to-Guides</h1>
+                        {{ else if strings.Contains .Permalink "api-docs" }}
+                            <!--Don't show the title in the top-most index page.-->
+                            {{ if not (in .Page.File.Path "api-docs/_index.md") }}
+                                {{ if and (.Params.h1) (not .Params.notitle) }}
+                                    <h1>{{ .Params.h1 }}</h1>
+                                {{ else if and (ne .Title "") (not .Params.notitle) }}
+                                <div class="title-ai-menu-container">
+                                    <h1 class="break-words">{{ $title_tag }}</h1>
+                                    {{ if not (strings.Contains .Params.meta_desc "module") }}
+                                        {{ .Scratch.Set "title_tag" $title_tag }}
+                                        {{ partial "registry/package/pulumi-ai.html" . }}
+                                    {{ end }}
+                                </div>
+                                {{ end }}
+                            {{ else if (in .Page.File.Path "api-docs/_index.md")}}
+                                <h1>{{ .Params.title }}: API Docs</h1>
+                            {{ end }}
+                        {{ else }}
                             {{ if and (.Params.h1) (not .Params.notitle) }}
                                 <h1>{{ .Params.h1 }}</h1>
-                            {{ else if and (ne .Title "") (not .Params.notitle) }}
-                            <div class="title-ai-menu-container">
-                                <h1 class="break-words">{{ $title_tag }}</h1>
-                                {{ if not (strings.Contains .Params.meta_desc "module") }}
-                                    {{ .Scratch.Set "title_tag" $title_tag }}
-                                    {{ partial "registry/package/pulumi-ai.html" . }}
-                                {{ end }}
-                            </div>
+                            {{ else if and (ne .Title "") (not .Params.notitle) (not (in .Page.File.Path "how-to-guides/_index.md")) }}
+                                <h1>{{ .Title }}</h1>
                             {{ end }}
-                        {{ else if (in .Page.File.Path "api-docs/_index.md")}}
-                            <h1>{{ .Params.title }}: API Docs</h1>
                         {{ end }}
-                    {{ else }}
-                        {{ if and (.Params.h1) (not .Params.notitle) }}
-                            <h1>{{ .Params.h1 }}</h1>
-                        {{ else if and (ne .Title "") (not .Params.notitle) (not (in .Page.File.Path "how-to-guides/_index.md")) }}
-                            <h1>{{ .Title }}</h1>
-                        {{ end }}
-                    {{ end }}
-                    <div class="h1-gradient"></div>
-                </div>
+                        <div class="h1-gradient"></div>
+                    </div>
 
-                {{ $copyPromptPackageData := index site.Data.registry.packages $packageName }}
-                {{ with $copyPromptPackageData }}
-                    {{ partial "registry/package/copy-llm-prompt.html" (dict "packageData" . "rawPackageName" $packageName) }}
-                {{ end }}
+                    {{ $copyPromptPackageData := index site.Data.registry.packages $packageName }}
+                    {{ with $copyPromptPackageData }}
+                        {{ partial "registry/package/copy-llm-prompt.html" (dict "packageData" . "rawPackageName" $packageName) }}
+                    {{ end }}
+                </div>
 
                 <div class="docs-table-of-contents docs-toc-mobile">
                     {{ partial "docs/table-of-contents.html" . }}

--- a/themes/default/layouts/registry/package.html
+++ b/themes/default/layouts/registry/package.html
@@ -54,6 +54,11 @@
                     <div class="h1-gradient"></div>
                 </div>
 
+                {{ $copyPromptPackageData := index site.Data.registry.packages $packageName }}
+                {{ with $copyPromptPackageData }}
+                    {{ partial "registry/package/copy-llm-prompt.html" (dict "packageData" . "rawPackageName" $packageName) }}
+                {{ end }}
+
                 <div class="docs-table-of-contents docs-toc-mobile">
                     {{ partial "docs/table-of-contents.html" . }}
                 </div>

--- a/themes/default/theme/src/scss/docs/_registry.scss
+++ b/themes/default/theme/src/scss/docs/_registry.scss
@@ -1,3 +1,42 @@
+.copy-llm-prompt {
+    margin: 8px 0 16px;
+
+    &__button {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 12px;
+        font-size: 13px;
+        font-weight: 500;
+        border: 1px solid map-get($gray, 300);
+        border-radius: 6px;
+        color: map-get($gray, 600);
+        background: #ffffff;
+        cursor: pointer;
+        appearance: none;
+        transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+
+        &:hover {
+            border-color: map-get($gray, 400);
+            color: map-get($gray, 800);
+            background-color: map-get($gray, 100);
+        }
+
+        &.is-copied {
+            border-color: #16a34a;
+            color: #16a34a;
+        }
+    }
+
+    &__icon {
+        font-size: 13px;
+    }
+
+    &__text {
+        line-height: 1;
+    }
+}
+
 .pulumi-ai-menu {
     position: relative;
     display: inline-flex;

--- a/themes/default/theme/src/scss/docs/_registry.scss
+++ b/themes/default/theme/src/scss/docs/_registry.scss
@@ -1,7 +1,25 @@
-.copy-llm-prompt {
-    margin: 8px 0 16px;
+.title-llm-prompt-container {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    column-gap: 16px;
+    row-gap: 8px;
 
-    &__button {
+    .special-h1 {
+        flex: 0 0 auto;
+    }
+
+    .h1-gradient {
+        margin-top: -12px;
+    }
+}
+
+.copy-llm-prompt {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+
+    &__trigger {
         display: inline-flex;
         align-items: center;
         gap: 6px;
@@ -22,9 +40,8 @@
             background-color: map-get($gray, 100);
         }
 
-        &.is-copied {
-            border-color: #16a34a;
-            color: #16a34a;
+        &:focus-visible {
+            outline: 1px solid map-get($gray, 400);
         }
     }
 
@@ -34,6 +51,96 @@
 
     &__text {
         line-height: 1;
+    }
+
+    &__chevron {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 10px;
+        height: 10px;
+        font-size: 10px;
+        flex-shrink: 0;
+        transition: transform 0.2s ease;
+        margin-left: 2px;
+    }
+
+    &.is-open &__chevron {
+        transform: rotate(180deg);
+    }
+
+    &__dropdown {
+        position: absolute;
+        left: 0;
+        top: 100%;
+        margin-top: 4px;
+        min-width: 200px;
+        background: #ffffff;
+        border: 1px solid map-get($gray, 200);
+        border-radius: 8px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.06);
+        display: none;
+        z-index: 10;
+        flex-direction: column;
+        padding: 4px 0;
+    }
+
+    &__dropdown[hidden] {
+        display: none !important;
+    }
+
+    &.is-open &__dropdown {
+        display: flex;
+    }
+
+    &__item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        font-size: 13px;
+        font-weight: 500;
+        color: map-get($gray, 700);
+        text-decoration: none;
+        cursor: pointer;
+        transition: background-color 0.15s ease;
+        border: none;
+        background: none;
+        width: 100%;
+        text-align: left;
+        appearance: none;
+
+        &:hover,
+        &:focus-visible {
+            background-color: map-get($gray, 100);
+            color: map-get($gray, 900);
+        }
+
+        &:focus-visible {
+            outline: none;
+        }
+    }
+
+    &__item-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        flex-shrink: 0;
+        font-size: 14px;
+        color: map-get($gray, 500);
+    }
+
+    &__item-label {
+        line-height: 1;
+        white-space: nowrap;
+    }
+
+    &__divider {
+        height: 1px;
+        background-color: map-get($gray, 200);
+        margin: 4px 0;
     }
 }
 

--- a/themes/default/theme/src/ts/copy-llm-prompt.ts
+++ b/themes/default/theme/src/ts/copy-llm-prompt.ts
@@ -50,13 +50,41 @@ const openMenu = ({ root, trigger, dropdown, items }: MenuElements) => {
     }
 };
 
+const writeToClipboard = async (text: string): Promise<boolean> => {
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return true;
+        } catch {
+            // Fall through to legacy path.
+        }
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    let ok = false;
+    try {
+        ok = document.execCommand("copy");
+    } catch {
+        ok = false;
+    }
+    document.body.removeChild(textarea);
+    return ok;
+};
+
 const bindCopyButton = (copyButton: HTMLButtonElement, prompt: string) => {
     const label = copyButton.querySelector<HTMLElement>(".copy-llm-prompt__item-label");
     const icon = copyButton.querySelector<HTMLElement>(".copy-llm-prompt__item-icon i");
     const originalLabel = label?.textContent ?? "";
 
     copyButton.addEventListener("click", async () => {
-        await navigator.clipboard.writeText(prompt);
+        const ok = await writeToClipboard(prompt);
+        if (!ok) return;
 
         if (label) label.textContent = "Copied!";
         icon?.classList.replace("fa-copy", "fa-check");

--- a/themes/default/theme/src/ts/copy-llm-prompt.ts
+++ b/themes/default/theme/src/ts/copy-llm-prompt.ts
@@ -1,46 +1,121 @@
+type MenuElements = {
+    root: HTMLElement;
+    trigger: HTMLButtonElement;
+    dropdown: HTMLElement;
+    items: HTMLElement[];
+    copyButton: HTMLButtonElement | null;
+    prompt: string;
+};
+
 const SELECTOR = '[data-component="copy-llm-prompt"]';
+const TRIGGER_SELECTOR = '[data-role="trigger"]';
+const DROPDOWN_SELECTOR = '[data-role="dropdown"]';
+const COPY_SELECTOR = '[data-role="copy"]';
+
+const collectMenus = (): MenuElements[] => {
+    return Array.from(document.querySelectorAll<HTMLElement>(SELECTOR))
+        .map((root) => {
+            const trigger = root.querySelector<HTMLButtonElement>(TRIGGER_SELECTOR);
+            const dropdown = root.querySelector<HTMLElement>(DROPDOWN_SELECTOR);
+            const template = root.querySelector<HTMLTemplateElement>("template");
+            if (!trigger || !dropdown || !template) {
+                return null;
+            }
+
+            const items = Array.from(
+                dropdown.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+            );
+            const copyButton = dropdown.querySelector<HTMLButtonElement>(COPY_SELECTOR);
+            const prompt = template.content.textContent?.trim() ?? "";
+
+            return { root, trigger, dropdown, items, copyButton, prompt };
+        })
+        .filter((value): value is MenuElements => value !== null);
+};
+
+const closeMenu = ({ root, trigger, dropdown }: MenuElements) => {
+    root.classList.remove("is-open");
+    trigger.setAttribute("aria-expanded", "false");
+    dropdown.setAttribute("hidden", "");
+};
+
+const openMenu = ({ root, trigger, dropdown, items }: MenuElements) => {
+    root.classList.add("is-open");
+    trigger.setAttribute("aria-expanded", "true");
+    dropdown.removeAttribute("hidden");
+
+    const firstItem = items[0];
+    if (document.activeElement === trigger && firstItem) {
+        firstItem.focus();
+    }
+};
+
+const bindCopyButton = (copyButton: HTMLButtonElement, prompt: string) => {
+    const label = copyButton.querySelector<HTMLElement>(".copy-llm-prompt__item-label");
+    const icon = copyButton.querySelector<HTMLElement>(".copy-llm-prompt__item-icon i");
+    const originalLabel = label?.textContent ?? "";
+
+    copyButton.addEventListener("click", async () => {
+        await navigator.clipboard.writeText(prompt);
+
+        if (label) label.textContent = "Copied!";
+        icon?.classList.replace("fa-copy", "fa-check");
+
+        setTimeout(() => {
+            if (label) label.textContent = originalLabel;
+            icon?.classList.replace("fa-check", "fa-copy");
+        }, 2000);
+    });
+};
 
 const initCopyPromptButtons = () => {
-    document.querySelectorAll<HTMLElement>(SELECTOR).forEach((root) => {
-        if (root.hasAttribute("data-initialized")) {
-            return;
-        }
-        root.setAttribute("data-initialized", "");
+    const menus = collectMenus();
+    if (!menus.length) {
+        return;
+    }
 
-        const template = root.querySelector<HTMLTemplateElement>("template");
-        const button = root.querySelector<HTMLButtonElement>("button");
-        if (!template || !button) {
-            return;
-        }
-
-        const prompt = template.content.textContent?.trim() ?? "";
-        const textEl = button.querySelector<HTMLElement>(".copy-llm-prompt__text");
-        const iconEl = button.querySelector<HTMLElement>(".copy-llm-prompt__icon");
-        const originalText = textEl?.textContent ?? "";
-
-        button.addEventListener("click", async () => {
-            await navigator.clipboard.writeText(prompt);
-
-            button.classList.add("is-copied");
-            if (textEl) {
-                textEl.textContent = "Copied!";
+    document.addEventListener("click", (event) => {
+        const target = event.target as Node | null;
+        if (!target) return;
+        menus.forEach((menu) => {
+            if (!menu.root.contains(target)) {
+                closeMenu(menu);
             }
-            if (iconEl) {
-                iconEl.classList.remove("fa-copy");
-                iconEl.classList.add("fa-check");
-            }
-
-            setTimeout(() => {
-                button.classList.remove("is-copied");
-                if (textEl) {
-                    textEl.textContent = originalText;
-                }
-                if (iconEl) {
-                    iconEl.classList.remove("fa-check");
-                    iconEl.classList.add("fa-copy");
-                }
-            }, 2000);
         });
+    });
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        menus.forEach((menu) => {
+            if (menu.root.classList.contains("is-open")) {
+                closeMenu(menu);
+                menu.trigger.focus();
+            }
+        });
+    });
+
+    menus.forEach((menu) => {
+        menu.trigger.addEventListener("click", (event) => {
+            event.preventDefault();
+            if (menu.root.classList.contains("is-open")) {
+                closeMenu(menu);
+            } else {
+                openMenu(menu);
+            }
+        });
+
+        menu.trigger.addEventListener("keydown", (event) => {
+            if (event.key === "ArrowDown") {
+                event.preventDefault();
+                openMenu(menu);
+            } else if (event.key === "Escape") {
+                closeMenu(menu);
+            }
+        });
+
+        if (menu.copyButton) {
+            bindCopyButton(menu.copyButton, menu.prompt);
+        }
     });
 };
 

--- a/themes/default/theme/src/ts/copy-llm-prompt.ts
+++ b/themes/default/theme/src/ts/copy-llm-prompt.ts
@@ -1,0 +1,53 @@
+const SELECTOR = '[data-component="copy-llm-prompt"]';
+
+const initCopyPromptButtons = () => {
+    document.querySelectorAll<HTMLElement>(SELECTOR).forEach((root) => {
+        if (root.hasAttribute("data-initialized")) {
+            return;
+        }
+        root.setAttribute("data-initialized", "");
+
+        const template = root.querySelector<HTMLTemplateElement>("template");
+        const button = root.querySelector<HTMLButtonElement>("button");
+        if (!template || !button) {
+            return;
+        }
+
+        const prompt = template.content.textContent?.trim() ?? "";
+        const textEl = button.querySelector<HTMLElement>(".copy-llm-prompt__text");
+        const iconEl = button.querySelector<HTMLElement>(".copy-llm-prompt__icon");
+        const originalText = textEl?.textContent ?? "";
+
+        button.addEventListener("click", async () => {
+            await navigator.clipboard.writeText(prompt);
+
+            button.classList.add("is-copied");
+            if (textEl) {
+                textEl.textContent = "Copied!";
+            }
+            if (iconEl) {
+                iconEl.classList.remove("fa-copy");
+                iconEl.classList.add("fa-check");
+            }
+
+            setTimeout(() => {
+                button.classList.remove("is-copied");
+                if (textEl) {
+                    textEl.textContent = originalText;
+                }
+                if (iconEl) {
+                    iconEl.classList.remove("fa-check");
+                    iconEl.classList.add("fa-copy");
+                }
+            }, 2000);
+        });
+    });
+};
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initCopyPromptButtons);
+} else {
+    initCopyPromptButtons();
+}
+
+export { initCopyPromptButtons };

--- a/themes/default/theme/src/ts/main.ts
+++ b/themes/default/theme/src/ts/main.ts
@@ -12,6 +12,7 @@ import "./code-tabbed";
 import "./packages";
 import "./toc";
 import "./pulumi-ai-menu";
+import "./copy-llm-prompt";
 import "./docs-main";
 import "./algolia/autocomplete";
 import "./consent-manager";

--- a/themes/default/theme/stencil/src/components.d.ts
+++ b/themes/default/theme/stencil/src/components.d.ts
@@ -114,6 +114,10 @@ export namespace Components {
         "goToWebinarKey"?: string;
         "salesforceCampaignId": string;
     }
+    interface PulumiLlmMenu {
+        "pageTitle": string;
+        "pageUrl": string;
+    }
     interface PulumiMultiSelectForm {
         /**
           * @default ""
@@ -299,6 +303,12 @@ declare global {
         prototype: HTMLPulumiHubspotFormElement;
         new (): HTMLPulumiHubspotFormElement;
     };
+    interface HTMLPulumiLlmMenuElement extends Components.PulumiLlmMenu, HTMLStencilElement {
+    }
+    var HTMLPulumiLlmMenuElement: {
+        prototype: HTMLPulumiLlmMenuElement;
+        new (): HTMLPulumiLlmMenuElement;
+    };
     interface HTMLPulumiMultiSelectFormElement extends Components.PulumiMultiSelectForm, HTMLStencilElement {
     }
     var HTMLPulumiMultiSelectFormElement: {
@@ -389,6 +399,7 @@ declare global {
         "pulumi-filter-select-option": HTMLPulumiFilterSelectOptionElement;
         "pulumi-filter-select-option-group": HTMLPulumiFilterSelectOptionGroupElement;
         "pulumi-hubspot-form": HTMLPulumiHubspotFormElement;
+        "pulumi-llm-menu": HTMLPulumiLlmMenuElement;
         "pulumi-multi-select-form": HTMLPulumiMultiSelectFormElement;
         "pulumi-registry-list-search": HTMLPulumiRegistryListSearchElement;
         "pulumi-resource-links": HTMLPulumiResourceLinksElement;
@@ -491,6 +502,10 @@ declare namespace LocalJSX {
         "goToWebinarKey"?: string;
         "salesforceCampaignId"?: string;
     }
+    interface PulumiLlmMenu {
+        "pageTitle"?: string;
+        "pageUrl"?: string;
+    }
     interface PulumiMultiSelectForm {
         /**
           * @default ""
@@ -587,6 +602,10 @@ declare namespace LocalJSX {
         "goToWebinarKey": string;
         "class": string;
     }
+    interface PulumiLlmMenuAttributes {
+        "pageUrl": string;
+        "pageTitle": string;
+    }
     interface PulumiMultiSelectFormAttributes {
         "selectClass": string;
         "labelClass": string;
@@ -616,6 +635,7 @@ declare namespace LocalJSX {
         "pulumi-filter-select-option": Omit<PulumiFilterSelectOption, keyof PulumiFilterSelectOptionAttributes> & { [K in keyof PulumiFilterSelectOption & keyof PulumiFilterSelectOptionAttributes]?: PulumiFilterSelectOption[K] } & { [K in keyof PulumiFilterSelectOption & keyof PulumiFilterSelectOptionAttributes as `attr:${K}`]?: PulumiFilterSelectOptionAttributes[K] } & { [K in keyof PulumiFilterSelectOption & keyof PulumiFilterSelectOptionAttributes as `prop:${K}`]?: PulumiFilterSelectOption[K] };
         "pulumi-filter-select-option-group": Omit<PulumiFilterSelectOptionGroup, keyof PulumiFilterSelectOptionGroupAttributes> & { [K in keyof PulumiFilterSelectOptionGroup & keyof PulumiFilterSelectOptionGroupAttributes]?: PulumiFilterSelectOptionGroup[K] } & { [K in keyof PulumiFilterSelectOptionGroup & keyof PulumiFilterSelectOptionGroupAttributes as `attr:${K}`]?: PulumiFilterSelectOptionGroupAttributes[K] } & { [K in keyof PulumiFilterSelectOptionGroup & keyof PulumiFilterSelectOptionGroupAttributes as `prop:${K}`]?: PulumiFilterSelectOptionGroup[K] };
         "pulumi-hubspot-form": Omit<PulumiHubspotForm, keyof PulumiHubspotFormAttributes> & { [K in keyof PulumiHubspotForm & keyof PulumiHubspotFormAttributes]?: PulumiHubspotForm[K] } & { [K in keyof PulumiHubspotForm & keyof PulumiHubspotFormAttributes as `attr:${K}`]?: PulumiHubspotFormAttributes[K] } & { [K in keyof PulumiHubspotForm & keyof PulumiHubspotFormAttributes as `prop:${K}`]?: PulumiHubspotForm[K] };
+        "pulumi-llm-menu": Omit<PulumiLlmMenu, keyof PulumiLlmMenuAttributes> & { [K in keyof PulumiLlmMenu & keyof PulumiLlmMenuAttributes]?: PulumiLlmMenu[K] } & { [K in keyof PulumiLlmMenu & keyof PulumiLlmMenuAttributes as `attr:${K}`]?: PulumiLlmMenuAttributes[K] } & { [K in keyof PulumiLlmMenu & keyof PulumiLlmMenuAttributes as `prop:${K}`]?: PulumiLlmMenu[K] };
         "pulumi-multi-select-form": Omit<PulumiMultiSelectForm, keyof PulumiMultiSelectFormAttributes> & { [K in keyof PulumiMultiSelectForm & keyof PulumiMultiSelectFormAttributes]?: PulumiMultiSelectForm[K] } & { [K in keyof PulumiMultiSelectForm & keyof PulumiMultiSelectFormAttributes as `attr:${K}`]?: PulumiMultiSelectFormAttributes[K] } & { [K in keyof PulumiMultiSelectForm & keyof PulumiMultiSelectFormAttributes as `prop:${K}`]?: PulumiMultiSelectForm[K] };
         "pulumi-registry-list-search": PulumiRegistryListSearch;
         "pulumi-resource-links": Omit<PulumiResourceLinks, keyof PulumiResourceLinksAttributes> & { [K in keyof PulumiResourceLinks & keyof PulumiResourceLinksAttributes]?: PulumiResourceLinks[K] } & { [K in keyof PulumiResourceLinks & keyof PulumiResourceLinksAttributes as `attr:${K}`]?: PulumiResourceLinksAttributes[K] } & { [K in keyof PulumiResourceLinks & keyof PulumiResourceLinksAttributes as `prop:${K}`]?: PulumiResourceLinks[K] };
@@ -666,6 +686,7 @@ declare module "@stencil/core" {
             "pulumi-filter-select-option": LocalJSX.IntrinsicElements["pulumi-filter-select-option"] & JSXBase.HTMLAttributes<HTMLPulumiFilterSelectOptionElement>;
             "pulumi-filter-select-option-group": LocalJSX.IntrinsicElements["pulumi-filter-select-option-group"] & JSXBase.HTMLAttributes<HTMLPulumiFilterSelectOptionGroupElement>;
             "pulumi-hubspot-form": LocalJSX.IntrinsicElements["pulumi-hubspot-form"] & JSXBase.HTMLAttributes<HTMLPulumiHubspotFormElement>;
+            "pulumi-llm-menu": LocalJSX.IntrinsicElements["pulumi-llm-menu"] & JSXBase.HTMLAttributes<HTMLPulumiLlmMenuElement>;
             "pulumi-multi-select-form": LocalJSX.IntrinsicElements["pulumi-multi-select-form"] & JSXBase.HTMLAttributes<HTMLPulumiMultiSelectFormElement>;
             "pulumi-registry-list-search": LocalJSX.IntrinsicElements["pulumi-registry-list-search"] & JSXBase.HTMLAttributes<HTMLPulumiRegistryListSearchElement>;
             "pulumi-resource-links": LocalJSX.IntrinsicElements["pulumi-resource-links"] & JSXBase.HTMLAttributes<HTMLPulumiResourceLinksElement>;

--- a/themes/default/theme/stencil/src/components/llm-menu/llm-menu.scss
+++ b/themes/default/theme/stencil/src/components/llm-menu/llm-menu.scss
@@ -1,0 +1,108 @@
+.llm-menu-container {
+    position: relative;
+    display: block;
+}
+
+.llm-menu-trigger {
+    display: inline-flex;
+    align-items: center;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.2s ease;
+
+    i:first-child {
+        width: 14px;
+        margin-right: 0.5rem;
+    }
+
+    .fa-chevron-up,
+    .fa-chevron-down {
+        font-size: 0.625rem;
+        margin-left: 0.25rem;
+    }
+}
+
+.llm-menu-dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    min-width: 14rem;
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    z-index: 50;
+}
+
+.llm-menu-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color 0.15s ease;
+    gap: 0.75rem;
+
+    &:hover {
+        background-color: #f7fafc;
+    }
+
+    &:first-child {
+        border-top-left-radius: 0.5rem;
+        border-top-right-radius: 0.5rem;
+    }
+
+    &:last-child {
+        border-bottom-left-radius: 0.5rem;
+        border-bottom-right-radius: 0.5rem;
+    }
+}
+
+.llm-menu-icon {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: 1.125rem;
+    color: #4a5568;
+}
+
+.llm-menu-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.llm-menu-title {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #2d3748;
+    line-height: 1.25;
+}
+
+.llm-menu-subtitle {
+    font-size: 0.75rem;
+    color: #718096;
+    line-height: 1.25;
+}
+
+.llm-menu-external {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: #a0aec0;
+}
+
+.llm-menu-dropdown hr {
+    margin: 0.25rem 0;
+    border: 0;
+    border-top: 1px solid #e2e8f0;
+}

--- a/themes/default/theme/stencil/src/components/llm-menu/llm-menu.tsx
+++ b/themes/default/theme/stencil/src/components/llm-menu/llm-menu.tsx
@@ -1,0 +1,210 @@
+import { Component, Prop, State, h, Host, Element } from "@stencil/core";
+
+@Component({
+    tag: "pulumi-llm-menu",
+    styleUrl: "llm-menu.scss",
+    shadow: false,
+})
+export class LlmMenu {
+    @Element() el: HTMLElement;
+
+    @Prop() pageUrl: string;
+    @Prop() pageTitle: string;
+
+    @State() isOpen: boolean = false;
+    @State() copied: string = "";
+
+    componentDidLoad() {
+        document.addEventListener("click", this.handleClickOutside);
+    }
+
+    disconnectedCallback() {
+        document.removeEventListener("click", this.handleClickOutside);
+    }
+
+    private handleClickOutside = (event: MouseEvent) => {
+        if (this.isOpen && !this.el.contains(event.target as Node)) {
+            this.isOpen = false;
+        }
+    };
+
+    private getMarkdownUrl(): string {
+        // The server-side markdown output lives at index.md alongside index.html
+        const pathname = this.getPathname();
+        return `${window.location.origin}${pathname.replace(/\/?$/, "/")}index.md`;
+    }
+
+    private getPathname(): string {
+        let pathname = this.pageUrl;
+
+        if (pathname.startsWith("//")) {
+            pathname = pathname.substring(pathname.indexOf("/", 2));
+        } else {
+            try {
+                const url = new URL(this.pageUrl, window.location.origin);
+                pathname = url.pathname;
+            } catch {
+                // pageUrl is already a pathname, use as-is
+            }
+        }
+
+        return pathname;
+    }
+
+    private async copyPage() {
+        try {
+            const response = await fetch(this.getMarkdownUrl());
+            if (!response.ok) {
+                throw new Error(`Failed to fetch markdown: ${response.status}`);
+            }
+            const markdown = await response.text();
+            await navigator.clipboard.writeText(markdown);
+            this.showCopied("page");
+            this.trackEvent("copy-page");
+        } catch (error) {
+            console.error("Failed to copy page to clipboard:", error);
+        }
+    }
+
+    private viewMarkdown() {
+        window.open(this.getMarkdownUrl(), "_blank");
+        this.trackEvent("view-markdown");
+    }
+
+    private showCopied(type: string) {
+        this.copied = type;
+        setTimeout(() => (this.copied = ""), 2000);
+    }
+
+    private trackEvent(action: string) {
+        const analytics = (window as any).analytics;
+        if (analytics?.track) {
+            analytics.track("llm-helper", { action, page: this.pageUrl });
+        }
+    }
+
+    private openInChatGPT() {
+        const mdUrl = `https://pulumi.com${this.getPathname().replace(/\/?$/, "/")}index.md`;
+        const prompt = `Read from ${mdUrl} so I can ask questions about it.`;
+        window.open(`https://chat.openai.com/?q=${encodeURIComponent(prompt)}`, "_blank");
+        this.trackEvent("open-chatgpt");
+    }
+
+    private openInClaude() {
+        const mdUrl = `https://pulumi.com${this.getPathname().replace(/\/?$/, "/")}index.md`;
+        const prompt = `Read from ${mdUrl} so I can ask questions about it.`;
+        window.open(`https://claude.ai/new?q=${encodeURIComponent(prompt)}`, "_blank");
+        this.trackEvent("open-claude");
+    }
+
+    private async copyUrl() {
+        try {
+            await navigator.clipboard.writeText(window.location.href);
+            this.showCopied("url");
+            this.trackEvent("copy-url");
+        } catch (error) {
+            console.error("Failed to copy URL to clipboard:", error);
+        }
+    }
+
+    render() {
+        const linkIcon = (
+            <svg class="llm-menu-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M9.172 14.828L14.828 9.172M7.05 11.293L4.222 14.121C2.562 15.781 2.562 18.439 4.222 20.099C5.882 21.759 8.54 21.759 10.2 20.099L13.029 17.271M10.971 6.729L13.8 3.901C15.46 2.241 18.118 2.241 19.778 3.901C21.438 5.561 21.438 8.219 19.778 9.879L16.95 12.707"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                />
+            </svg>
+        );
+
+        const markdownIcon = (
+            <svg class="llm-menu-icon" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M14 3a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h12zM2 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H2z"
+                />
+                <path
+                    d="M9.146 8.146a.5.5 0 0 1 .708 0L11.5 9.793l1.646-1.647a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 0-.708zM11.5 5a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-1 0v-4a.5.5 0 0 1 .5-.5zM3.56 11V5.01h1.44L6.5 7.98 8 5.01h1.44V11H8.2V6.57L6.5 9.56l-1.7-2.99V11H3.56z"
+                />
+            </svg>
+        );
+
+        const chatGptLogo = (
+            <svg class="llm-menu-icon" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    fill="currentColor"
+                    d="m297.06 130.97c7.26-21.79 4.76-45.66-6.85-65.48-17.46-30.4-52.56-46.04-86.84-38.68-15.25-17.18-37.16-26.95-60.13-26.81-35.04-.08-66.13 22.48-76.91 55.82-22.51 4.61-41.94 18.7-53.31 38.67-17.59 30.32-13.58 68.54 9.92 94.54-7.26 21.79-4.76 45.66 6.85 65.48 17.46 30.4 52.56 46.04 86.84 38.68 15.24 17.18 37.16 26.95 60.13 26.8 35.06.09 66.16-22.49 76.94-55.86 22.51-4.61 41.94-18.7 53.31-38.67 17.57-30.32 13.55-68.51-9.94-94.51zm-120.28 168.11c-14.03.02-27.62-4.89-38.39-13.88.49-.26 1.34-.73 1.89-1.07l63.72-36.8c3.26-1.85 5.26-5.32 5.24-9.07v-89.83l26.93 15.55c.29.14.48.42.52.74v74.39c-.04 33.08-26.83 59.9-59.91 59.97zm-128.84-55.03c-7.03-12.14-9.56-26.37-7.15-40.18.47.28 1.3.79 1.89 1.13l63.72 36.8c3.23 1.89 7.23 1.89 10.47 0l77.79-44.92v31.1c.02.32-.13.63-.38.83l-64.41 37.19c-28.69 16.52-65.33 6.7-81.92-21.95zm-16.77-139.09c7-12.16 18.05-21.46 31.21-26.29 0 .55-.03 1.52-.03 2.2v73.61c-.02 3.74 1.98 7.21 5.23 9.06l77.79 44.91-26.93 15.55c-.27.18-.61.21-.91.08l-64.42-37.22c-28.63-16.58-38.45-53.21-21.95-81.89zm221.26 51.49-77.79-44.92 26.93-15.54c.27-.18.61-.21.91-.08l64.42 37.19c28.68 16.57 38.51 53.26 21.94 81.94-7.01 12.14-18.05 21.44-31.2 26.28v-75.81c.03-3.74-1.96-7.2-5.2-9.06zm26.8-40.34c-.47-.29-1.3-.79-1.89-1.13l-63.72-36.8c-3.23-1.89-7.23-1.89-10.47 0l-77.79 44.92v-31.1c-.02-.32.13-.63.38-.83l64.41-37.16c28.69-16.55 65.37-6.7 81.91 22 6.99 12.12 9.52 26.31 7.15 40.1zm-168.51 55.43-26.94-15.55c-.29-.14-.48-.42-.52-.74v-74.39c.02-33.12 26.89-59.96 60.01-59.94 14.01 0 27.57 4.92 38.34 13.88-.49.26-1.33.73-1.89 1.07l-63.72 36.8c-3.26 1.85-5.26 5.31-5.24 9.06l-.04 89.79zm14.63-31.54 34.65-20.01 34.65 20v40.01l-34.65 20-34.65-20z"
+                />
+            </svg>
+        );
+
+        const claudeLogo = (
+            <svg class="llm-menu-icon" viewBox="0 0 1200 1200" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    fill="currentColor"
+                    d="M 233.959793 800.214905 L 468.644287 668.536987 L 472.590637 657.100647 L 468.644287 650.738403 L 457.208069 650.738403 L 417.986633 648.322144 L 283.892639 644.69812 L 167.597321 639.865845 L 54.926208 633.825623 L 26.577238 627.785339 L 3.3e-05 592.751709 L 2.73832 575.27533 L 26.577238 559.248352 L 60.724873 562.228149 L 136.187973 567.382629 L 249.422867 575.194763 L 331.570496 580.026978 L 453.261841 592.671082 L 472.590637 592.671082 L 475.328857 584.859009 L 468.724915 580.026978 L 463.570557 575.194763 L 346.389313 495.785217 L 219.543671 411.865906 L 153.100723 363.543762 L 117.181267 339.060425 L 99.060455 316.107361 L 91.248367 266.01355 L 123.865784 230.093994 L 167.677887 233.073853 L 178.872513 236.053772 L 223.248367 270.201477 L 318.040283 343.570496 L 441.825592 434.738342 L 459.946411 449.798706 L 467.194672 444.64447 L 468.080597 441.020203 L 459.946411 427.409485 L 392.617493 305.718323 L 320.778564 181.932983 L 288.80542 130.630859 L 280.348999 99.865845 C 277.369171 87.221436 275.194641 76.590698 275.194641 63.624268 L 312.322174 13.20813 L 332.8591 6.604126 L 382.389313 13.20813 L 403.248352 31.328979 L 434.013519 101.71814 L 483.865753 212.537048 L 561.181274 363.221497 L 583.812134 407.919434 L 595.892639 449.315491 L 600.40271 461.959839 L 608.214783 461.959839 L 608.214783 454.711609 L 614.577271 369.825623 L 626.335632 265.61084 L 637.771851 131.516846 L 641.718201 93.745117 L 660.402832 48.483276 L 697.530334 24.000122 L 726.52356 37.852417 L 750.362549 72 L 747.060486 94.067139 L 732.886047 186.201416 L 705.100708 330.52356 L 686.979919 427.167847 L 697.530334 427.167847 L 709.61084 415.087341 L 758.496704 350.174561 L 840.644348 247.490051 L 876.885925 206.738342 L 919.167847 161.71814 L 946.308838 140.29541 L 997.61084 140.29541 L 1035.38269 196.429626 L 1018.469849 254.416199 L 965.637634 321.422852 L 921.825562 378.201538 L 859.006714 462.765259 L 819.785278 530.41626 L 823.409424 535.812073 L 832.75177 534.92627 L 974.657776 504.724915 L 1051.328979 490.872559 L 1142.818848 475.167786 L 1184.214844 494.496582 L 1188.724854 514.147644 L 1172.456421 554.335693 L 1074.604126 578.496765 L 959.838989 601.449829 L 788.939636 641.879272 L 786.845764 643.409485 L 789.261841 646.389343 L 866.255127 653.637634 L 899.194702 655.409424 L 979.812134 655.409424 L 1129.932861 666.604187 L 1169.154419 692.537109 L 1192.671265 724.268677 L 1188.724854 748.429688 L 1128.322144 779.194641 L 1046.818848 759.865845 L 856.590759 714.604126 L 791.355774 698.335754 L 782.335693 698.335754 L 782.335693 703.731567 L 836.69812 756.885986 L 936.322205 846.845581 L 1061.073975 962.81897 L 1067.436279 991.490112 L 1051.409424 1014.120911 L 1034.496704 1011.704712 L 924.885986 929.234924 L 882.604126 892.107544 L 786.845764 811.48999 L 780.483276 811.48999 L 780.483276 819.946289 L 802.550415 852.241699 L 919.087341 1027.409424 L 925.127625 1081.127686 L 916.671204 1098.604126 L 886.469849 1109.154419 L 853.288696 1103.114136 L 785.073914 1007.355835 L 714.684631 899.516785 L 657.906067 802.872498 L 650.979858 806.81897 L 617.476624 1167.704834 L 601.771851 1186.147705 L 565.530212 1200 L 535.328857 1177.046997 L 519.302124 1139.919556 L 535.328857 1066.550537 L 554.657776 970.792053 L 570.362488 894.68457 L 584.536926 800.134277 L 592.993347 768.724976 L 592.429626 766.630859 L 585.503479 767.516968 L 514.22821 865.369263 L 405.825531 1011.865906 L 320.053711 1103.677979 L 299.516815 1111.812256 L 263.919525 1093.369263 L 267.221497 1060.429688 L 287.114136 1031.114136 L 405.825531 880.107361 L 477.422913 786.52356 L 523.651062 732.483276 L 523.328918 724.671265 L 520.590698 724.671265 L 205.288605 929.395935 L 149.154434 936.644409 L 124.993355 914.01355 L 127.973183 876.885986 L 139.409409 864.80542 L 234.201385 799.570435 L 233.879227 799.8927 Z"
+                />
+            </svg>
+        );
+
+        return (
+            <Host>
+                <div class="llm-menu-container">
+                    <button class="llm-menu-trigger text-gray-600 hover:text-gray-700 text-xs" onClick={() => (this.isOpen = !this.isOpen)}>
+                        <i class="fas fa-copy mr-2" style={{ width: "14px" }}></i>
+                        Copy Page
+                        <i class={`fas fa-chevron-${this.isOpen ? "up" : "down"}`}></i>
+                    </button>
+
+                    {this.isOpen && (
+                        <div class="llm-menu-dropdown">
+                            <div>
+                                <button class="llm-menu-item" onClick={() => this.copyUrl()}>
+                                    {linkIcon}
+                                    <div class="llm-menu-text">
+                                        <div class="llm-menu-title">{this.copied === "url" ? "Copied!" : "Copy URL"}</div>
+                                        <div class="llm-menu-subtitle">Copy page link to share</div>
+                                    </div>
+                                </button>
+                                <button class="llm-menu-item" onClick={() => this.copyPage()}>
+                                    <i class="fas fa-copy llm-menu-icon"></i>
+                                    <div class="llm-menu-text">
+                                        <div class="llm-menu-title">{this.copied === "page" ? "Copied!" : "Copy as Markdown"}</div>
+                                        <div class="llm-menu-subtitle">Copy page for LLMs</div>
+                                    </div>
+                                </button>
+                                <button class="llm-menu-item" onClick={() => this.viewMarkdown()}>
+                                    {markdownIcon}
+                                    <div class="llm-menu-text">
+                                        <div class="llm-menu-title">View as Markdown</div>
+                                        <div class="llm-menu-subtitle">Open Markdown in new tab</div>
+                                    </div>
+                                    <i class="fas fa-external-link-alt llm-menu-external"></i>
+                                </button>
+                                <hr />
+                                <button class="llm-menu-item" onClick={() => this.openInChatGPT()}>
+                                    {chatGptLogo}
+                                    <div class="llm-menu-text">
+                                        <div class="llm-menu-title">Open in ChatGPT</div>
+                                        <div class="llm-menu-subtitle">Ask ChatGPT about this page</div>
+                                    </div>
+                                    <i class="fas fa-external-link-alt llm-menu-external"></i>
+                                </button>
+                                <button class="llm-menu-item" onClick={() => this.openInClaude()}>
+                                    {claudeLogo}
+                                    <div class="llm-menu-text">
+                                        <div class="llm-menu-title">Open in Claude</div>
+                                        <div class="llm-menu-subtitle">Ask Claude about this page</div>
+                                    </div>
+                                    <i class="fas fa-external-link-alt llm-menu-external"></i>
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </Host>
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a "Use with AI" dropdown for each package. It allow to open different LLMs services with a prompt guiding how to use the corresponding packages.

In addition, we added a "copy page button" for consistency with docs. This button supports copying the content on the page on markdown or request an llm to read it.

<img width="1442" height="626" alt="image" src="https://github.com/user-attachments/assets/019a47e6-6411-44e4-a91e-453686a2085f" />
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/41fb29ec-74c8-4610-be51-39e6c8816db0" />

Cannot be merged before the new cloud endpoints for registry are available: https://github.com/pulumi/pulumi/pull/22728

eg. 

```
I want to use the Pulumi AWS provider (aws) in my project.

## Provider details
- Package: aws
- Version: v7.26.0
- Publisher: Pulumi
- Repository: https://github.com/pulumi/pulumi-aws

## Documentation
The Pulumi Cloud Registry API serves canonical, up-to-date docs for this package — including private packages and every published version. Send the "Accept: text/markdown" header for clean readable content, or "application/json" for structured data.

Start at the navigation tree, which cross-links to the readme, installation guide, and per-resource docs URL template:
- https://api.pulumi.com/api/registry/packages/pulumi/pulumi/aws/versions/latest/nav

Other endpoints:
- Overview and getting started: https://api.pulumi.com/api/registry/packages/pulumi/pulumi/aws/versions/latest/readme
- Installation and configuration: https://api.pulumi.com/api/registry/packages/pulumi/pulumi/aws/versions/latest/installation
- Per-resource/function docs: https://api.pulumi.com/api/registry/packages/pulumi/pulumi/aws/versions/latest/docs/{token}?lang={lang}
  Replace {token} with the percent-encoded token from the nav response (for example aws:s3/bucket:Bucket).
  Replace {lang} with typescript, python, go, csharp, java, or yaml.

Fetch the installation endpoint above for the correct setup steps — install instructions vary between native providers, bridged Terraform providers, and component packages.

Help me get started using this provider. Show me a complete Pulumi program that provisions a common resource, including all necessary configuration and imports.```
```



## Test plan

1. Open registry (use the latest build available)
2. Enter on any package
3. Click on the "open in <llm provider" button>

Note: Clipboard API only available on https, so it will not work on the preview build
🤖 Generated with [Claude Code](https://claude.com/claude-code)