### PR TITLE
Point top-nav sign-in link directly to /signin

### DIFF
--- a/themes/default/layouts/partials/docs-top-nav.html
+++ b/themes/default/layouts/partials/docs-top-nav.html
@@ -56,7 +56,7 @@
                     </a>
                 </li>
                 <li>
-                    <a data-track="header-console" href="https://app.pulumi.com/" target="_blank">
+                    <a data-track="header-console" href="https://app.pulumi.com/signin" target="_blank">
                         <i class="fa fa-refular fa-user-circle"></i>
                         {{ partial "top-nav-user-toggle" }}
                     </a>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -23,7 +23,7 @@
                 <li role="none"><a role="menuitem" href="/registry/">Registry</a></li>
                 <li role="none"><a role="menuitem" href="/ai">Pulumi AI</a></li>
                 <li role="none">
-                    <a role="menuitem" href="https://app.pulumi.com">
+                    <a role="menuitem" href="https://app.pulumi.com/signin">
                         {{ partial "top-nav-user-toggle" }}
                     </a>
                 </li>
@@ -69,7 +69,7 @@
                 </a>
             </li>
             <li>
-                <a data-track="header-console" href="https://app.pulumi.com/" target="_blank">
+                <a data-track="header-console" href="https://app.pulumi.com/signin" target="_blank">
                     <i class="fas fa-user-circle"></i>
                     {{ partial "top-nav-user-toggle" }}
                 </a>


### PR DESCRIPTION
## Summary
- Updates the top-nav user toggle in `top-nav.html` (mobile + desktop) and `docs-top-nav.html` to link to `https://app.pulumi.com/signin` instead of `https://app.pulumi.com/`.
- Sends unauthenticated visitors straight to the sign-in page rather than depending on the app to redirect from the root.
- The standalone "Sign In" link in `header.html` already pointed at `/signin`; this brings the rest of the nav in line.

## Notes
- The `top-nav-user-toggle` partial swaps the label between "Sign In" (signed out) and "Pulumi Cloud" (signed in), but the `href` is static. Signed-in users clicking "Pulumi Cloud" will now also hit `/signin`, which Pulumi Cloud should handle by sending an authenticated session through to the dashboard. Flag if a different destination is preferred for the signed-in case.

## Test plan
- [ ] `make serve` locally and confirm the top-nav (logged-out) link goes to `app.pulumi.com/signin`.
- [ ] Verify on a docs page that the docs top-nav link also points at `/signin`.
- [ ] Spot-check the mobile menu link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)