### PR TITLE
Update nav/footer links that hit pulumi.com 301 redirects

### DIFF
--- a/themes/default/layouts/partials/docs-top-nav.html
+++ b/themes/default/layouts/partials/docs-top-nav.html
@@ -10,7 +10,7 @@
                     <li role="none"><a role="menuitem" href="/">Pulumi home</a></li>
                     <li role="none"><a role="menuitem" href="/pricing/">Pricing</a></li>
                     <li role="none"><a role="menuitem" href="/blog/">Blog</a></li>
-                    <li role="none"><a role="menuitem" href="/resources/">Events & workshops</a></li>
+                    <li role="none"><a role="menuitem" href="/events/">Events & workshops</a></li>
                 </ul>
             </div>
             <div class="get-started">

--- a/themes/default/layouts/partials/footer.html
+++ b/themes/default/layouts/partials/footer.html
@@ -8,7 +8,7 @@
             <div class="hidden md:w-1/12"></div>
             <ul>
                 <li><a data-track="footer-get-started" href="/docs/get-started/" class="link">Get Started</a></li>
-                <li><a data-track="footer-install" href="/docs/install/" class="link">Install</a></li>
+                <li><a data-track="footer-install" href="/docs/get-started/download-install/" class="link">Install</a></li>
                 <li><a data-track="footer-documentation" href="/docs/" class="link">Documentation</a></li>
                 <li><a data-track="footer-apis" href="/registry/" class="link">Registry</a></li>
                 <li><a data-track="public-roadmap" href="https://github.com/orgs/pulumi/projects/44/" class="link">Public Roadmap</a></li>

--- a/themes/default/layouts/partials/footer.html
+++ b/themes/default/layouts/partials/footer.html
@@ -34,7 +34,7 @@
             </ul>
 
             <ul>
-                <li><a data-track="footer-events" href="/resources/" class="link">Resources</a></li>
+                <li><a data-track="footer-events" href="/events/" class="link">Resources</a></li>
                 <li><a data-track="footer-events" href="https://archive.pulumi.com/" target="_blank" rel="noopener noreferrer" class="link">Slack Archive</a></li>
                 <li><a data-track="footer-events" href="/case-studies/" class="link">Case Studies</a></li>
                 <li><a data-track="footer-events" href="/awards/" class="link">Awards &amp; Recognitions</a></li>

--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -40,7 +40,7 @@
                     </a>
                 </li>
                 <li class="mr-8">
-                    <a data-track="header-ai" href="/ai/">
+                    <a data-track="header-ai" href="/product/neo/">
                         <i class="fas fa-robot mr-0.5"></i>
                         Pulumi AI
                     </a>
@@ -289,7 +289,7 @@
                                         </li>
                                         <li>
                                             <div class="list-title">
-                                                <a href="/learn/">
+                                                <a href="/tutorials/">
                                                     <i class="fas fa-chalkboard-teacher fa-fw"></i>
                                                     Learn Pulumi
                                                     <div class="list-sub-title">Get hands-on with Pulumi concepts</div>
@@ -454,7 +454,7 @@
                                         <a href="/ai/answers/"> <i class="fas fa-robot mr-0.5"></i> Pulumi AI Answers </a>
                                     </li>
                                     <li>
-                                        <a href="/learn/"> <i class="fas fa-chalkboard-teacher fa-fw"></i> Learn Pulumi </a>
+                                        <a href="/tutorials/"> <i class="fas fa-chalkboard-teacher fa-fw"></i> Learn Pulumi </a>
                                     </li>
                                     <li>
                                         <a href="/community/"> <i class="fas fa-users fa-fw"></i> Community </a>
@@ -471,7 +471,7 @@
                                 <a href="https://slack.pulumi.com/">Slack</a>
                                 <a href="/docs/">Docs</a>
                                 <a href="/registry/">Registry</a>
-                                <a href="/ai/">Pulumi AI</a>
+                                <a href="/product/neo/">Pulumi AI</a>
                                 <a href="https://app.pulumi.com/signin">
                                     {{ partial "top-nav-user-toggle" }}
                                 </a>

--- a/themes/default/layouts/partials/learnmore-ai.html
+++ b/themes/default/layouts/partials/learnmore-ai.html
@@ -21,7 +21,7 @@
             <div>
                 <h4>Pulumi AI</h3>
                 <p class="mb-6">Generate Pulumi infrastructure-as-code programs in any language.</p>
-                <a class="text-blue-600 hover:text-blue-700 transition-colors" href="/ai">Try Pulumi AI &rarr;</a>
+                <a class="text-blue-600 hover:text-blue-700 transition-colors" href="/product/neo/">Try Pulumi AI &rarr;</a>
             </div>
         </div>
     </div>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -15,13 +15,13 @@
             <li role="none"><a role="menuitem" href="/pricing/">Pricing</a></li>
             <li role="none"><a role="menuitem" href="/docs/">Docs</a></li>
             <li role="none"><a role="menuitem" href="/blog/">Blog</a></li>
-            <li role="none"><a role="menuitem" href="/learn/">Learn Pulumi</a></li>
+            <li role="none"><a role="menuitem" href="/tutorials/">Learn Pulumi</a></li>
             <li role="none"><a role="menuitem" href="/events/">Events & Workshops</a></li>
             <ul role="menu" class="sm:hidden">
                 <li role="none"><a role="menuitem" href="https://github.com/pulumi/pulumi">GitHub</a></li>
                 <li role="none"><a role="menuitem" href="https://slack.pulumi.com">Slack</a></li>
                 <li role="none"><a role="menuitem" href="/registry/">Registry</a></li>
-                <li role="none"><a role="menuitem" href="/ai">Pulumi AI</a></li>
+                <li role="none"><a role="menuitem" href="/product/neo/">Pulumi AI</a></li>
                 <li role="none">
                     <a role="menuitem" href="https://app.pulumi.com">
                         {{ partial "top-nav-user-toggle" }}
@@ -63,7 +63,7 @@
                 </a>
             </li>
             <li class="mr-8">
-                <a data-track="header-ai" href="/ai">
+                <a data-track="header-ai" href="/product/neo/">
                     <i class="fas fa-robot mr-0.5"></i>
                     Pulumi AI
                 </a>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -16,7 +16,7 @@
             <li role="none"><a role="menuitem" href="/docs/">Docs</a></li>
             <li role="none"><a role="menuitem" href="/blog/">Blog</a></li>
             <li role="none"><a role="menuitem" href="/learn/">Learn Pulumi</a></li>
-            <li role="none"><a role="menuitem" href="/resources/">Events & Workshops</a></li>
+            <li role="none"><a role="menuitem" href="/events/">Events & Workshops</a></li>
             <ul role="menu" class="sm:hidden">
                 <li role="none"><a role="menuitem" href="https://github.com/pulumi/pulumi">GitHub</a></li>
                 <li role="none"><a role="menuitem" href="https://slack.pulumi.com">Slack</a></li>

--- a/themes/default/layouts/shortcodes/aws-eks-prereqs.html
+++ b/themes/default/layouts/shortcodes/aws-eks-prereqs.html
@@ -1,7 +1,7 @@
 <h2 id="prerequisites">Prerequisites</h2>
 
 <ol>
-    <li><a href="/docs/install/">Install Pulumi</a></li>
+    <li><a href="/docs/get-started/download-install/">Install Pulumi</a></li>
     <li><a href="https://nodejs.org/en/download/">Install Node.js</a></li>
     <li>Install a package manager for Node.js, such as <a href="https://www.npmjs.com/get-npm">npm</a> or <a href="https://yarnpkg.com/en/docs/install">Yarn</a>.</li>
     <li><a href="/registry/packages/aws/installation-configuration/">Configure AWS credentials</a></li>

--- a/themes/default/layouts/shortcodes/aws-js-prereqs.html
+++ b/themes/default/layouts/shortcodes/aws-js-prereqs.html
@@ -1,6 +1,6 @@
 <h2 id="prerequisites">Prerequisites</h2>
 
 <ol>
-    <li><a href="/docs/install/">Install Pulumi</a></li>
+    <li><a href="/docs/get-started/download-install/">Install Pulumi</a></li>
     <li><a href="/registry/packages/aws/installation-configuration/">Configure AWS credentials</a></li>
 </ol>

--- a/themes/default/layouts/shortcodes/azure-aks-prereqs.html
+++ b/themes/default/layouts/shortcodes/azure-aks-prereqs.html
@@ -1,6 +1,6 @@
 <h2 id="prerequisites">Prerequisites</h2>
 
 <ol>
-    <li><a href="/docs/install/">Install Pulumi</a></li>
+    <li><a href="/docs/get-started/download-install/">Install Pulumi</a></li>
     <li><a href="/registry/packages/azure/installation-configuration/">Configure Azure credentials</a></li>
 </ol>

--- a/themes/default/layouts/shortcodes/install-pulumi.html
+++ b/themes/default/layouts/shortcodes/install-pulumi.html
@@ -17,7 +17,7 @@
     </pulumi-choosable>
 </pulumi-chooser>
 <p>
-    Other installation options <a href="/docs/install/" target="_blank" rel="noopener">are available</a>.
+    Other installation options <a href="/docs/get-started/download-install/" target="_blank" rel="noopener">are available</a>.
     When the installation completes, you can test it out by reading the current version:
 </p>
 <pulumi-choosable type="os" value="macos">

--- a/themes/default/layouts/shortcodes/multilang-tutorial-prereqs.html
+++ b/themes/default/layouts/shortcodes/multilang-tutorial-prereqs.html
@@ -1,7 +1,7 @@
 <h2 id="prerequisites">Prerequisites</h2>
 
 <ol>
-    <li><a href="/docs/install/">Install Pulumi</a></li>
+    <li><a href="/docs/get-started/download-install/">Install Pulumi</a></li>
     <li><a href="/registry/packages/aws/installation-configuration/">Configure AWS credentials</a></li>
     <li>Choose your language and install the required version</li>
 </ol>


### PR DESCRIPTION
## Summary
Several links in the registry's nav, header, footer, and tutorial-prereq shortcodes point at pulumi.com paths that now serve a 301 redirect. This PR retargets each link to its canonical destination so users (and crawlers) skip the redirect hop. Visible link text is unchanged.

| Old path | Canonical destination | Where used |
|---|---|---|
| `/resources/` | `/events/` | top nav, docs top nav, footer |
| `/ai` and `/ai/` | `/product/neo/` | top nav (2x), header, mobile menu, learnmore-ai partial |
| `/learn/` | `/tutorials/` | top nav, header (2x) |
| `/docs/install/` | `/docs/get-started/download-install/` | footer + 5 prereq shortcodes |

Each redirect was confirmed against `https://www.pulumi.com` returning HTTP 301.

## Out of scope (flagged for follow-up)
- `/ai/answers/` — referenced in [header.html](themes/default/layouts/partials/header.html) lines 319 and 454. The destination returns **HTTP 410 Gone**, so this needs the link removed (or pointed somewhere else), not retargeted.
- `/containers/` — referenced in [footer.html](themes/default/layouts/partials/footer.html) line 23 (label: "Containers"). Redirects to `/docs/iac/clouds/kubernetes/`, which is a semantic mismatch for a footer item literally labeled "Containers". May want to drop the link instead of retargeting.

## Test plan
- [ ] Spot-check the deploy preview: top nav, docs top nav, header, footer, and a tutorial page using one of the prereq shortcodes
- [ ] Confirm "Events & Workshops", "Pulumi AI", "Learn Pulumi", and "Install" links land on their canonical pages without a redirect hop
- [ ] Confirm visible link text is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)