### PR TITLE
Remove defang from nightly community package update list

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -345,10 +345,6 @@
       "schemaFile": "provider/cmd/pulumi-resource-upcloud/schema.json"
     },
     {
-      "repoSlug": "DefangLabs/pulumi-defang",
-      "schemaFile": "provider/cmd/pulumi-resource-defang/schema.json"
-    },
-    {
       "repoSlug": "vatesfr/pulumi-xenorchestra",
       "schemaFile": "provider/cmd/pulumi-resource-xenorchestra/schema.json"
     },


### PR DESCRIPTION
## Summary

- The DefangLabs/pulumi-defang repo split the single `defang` provider into three (`defang-aws`, `defang-azure`, `defang-gcp`) in [c4273d8](https://github.com/DefangLabs/pulumi-defang/commit/c4273d854c8c422d2abc339d3efe224da67d6eb5), so `provider/cmd/pulumi-resource-defang/schema.json` no longer exists.
- None of the new providers commit a `schema.json` to the source tree, and `v2.0.0-beta.4` (currently marked as the latest GitHub release) ships no `schema.json` in its release assets either, so the nightly auto-bump has been failing on 404 — e.g. https://github.com/pulumi/registry/actions/runs/25245562869/job/74029146966.
- Removing the entry from `community-packages/package-list.json` stops the failing nightly check. `themes/default/data/registry/packages/defang.yaml` is untouched, so the registry page stays pinned at `v1.0.0` (whose schema URL still resolves). Once upstream publishes schemas, we can re-add as three per-cloud entries.

## Test plan

- [ ] Next scheduled run of `Check for Community Package Updates` no longer attempts to bump `defang` and does not fail on the schema 404.
- [x] `defang` package page still renders at v1.0.0 on preview/production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)