### PR TITLE
Update docs-nav Get Started button to match pulumi.com

### DIFF
--- a/themes/default/layouts/partials/docs-top-nav.html
+++ b/themes/default/layouts/partials/docs-top-nav.html
@@ -14,7 +14,7 @@
                 </ul>
             </div>
             <div class="get-started">
-                <a class="get-started-header-button" data-track="get-started-practitioner-nav" href="/docs/get-started/">Get Started</a>
+                <a class="btn btn-primary" data-track="get-started-practitioner-nav" href="https://app.pulumi.com/signup">Get Started</a>
             </div>
         </div>
         <div class="nav-items">

--- a/themes/default/theme/src/scss/_buttons.scss
+++ b/themes/default/theme/src/scss/_buttons.scss
@@ -5,14 +5,14 @@
     @include transition;
 
     @apply cursor-pointer text-sm whitespace-nowrap py-2 px-3 rounded inline-block;
-    @apply bg-blue-600 border-2 border-blue-600 text-white text-center;
+    @apply bg-violet-600 border-2 border-violet-600 text-white text-center;
 
     &:hover {
-        @apply bg-blue-500 border-blue-500 text-white;
+        @apply bg-violet-500 border-violet-500 text-white;
     }
 
     &:active {
-        @apply bg-blue-500;
+        @apply bg-violet-500;
     }
 }
 

--- a/themes/default/theme/src/scss/_colors.scss
+++ b/themes/default/theme/src/scss/_colors.scss
@@ -7,7 +7,7 @@ $brand: (
     "fuchsia": #bd4c85,
     "fuchsia-darker": #be5188,
     "purple": #8a3391,
-    "violet": #805ac3,
+    "violet": #5a30c5,
     "blue-lighter": #7682f4,
     "blue": #4d5bd9,
     "blue-darker": #4552c3,

--- a/themes/default/theme/src/scss/_header.scss
+++ b/themes/default/theme/src/scss/_header.scss
@@ -107,7 +107,7 @@
 
                 &:hover,
                 &:active {
-                    background: linear-gradient(90deg, #be5188 0%, #805ac3 100%) border-box;
+                    background: linear-gradient(90deg, #be5188 0%, #5a30c5 100%) border-box;
                     border-color: transparent;
                     border-radius: 20px;
                 }
@@ -506,7 +506,7 @@
 
             &:hover,
             &:active {
-                background: linear-gradient(90deg, #be5188 0%, #805ac3 100%) border-box;
+                background: linear-gradient(90deg, #be5188 0%, #5a30c5 100%) border-box;
                 color: $white;
                 box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.14), 0px 1px 5px rgba(0, 0, 0, 0.12);
                 border-color: transparent;

--- a/themes/default/theme/src/scss/_theme.scss
+++ b/themes/default/theme/src/scss/_theme.scss
@@ -55,7 +55,7 @@
   --color-violet-300: #ccbde7;
   --color-violet-400: #b39cdb;
   --color-violet-500: #997bcf;
-  --color-violet-600: #805ac3;
+  --color-violet-600: #5a30c5;
   --color-violet-700: #66489c;
   --color-violet-800: #4d3675;
   --color-violet-900: #33244e;

--- a/themes/default/theme/src/scss/docs/_docs-main.scss
+++ b/themes/default/theme/src/scss/docs/_docs-main.scss
@@ -762,7 +762,7 @@ body.section-registry {
                 font-weight: 700;
 
                 &::before {
-                    background-color: #805ac3;
+                    background-color: #5a30c5;
                     border-radius: 50%;
                     width: 10px;
                     height: 10px;

--- a/themes/default/theme/src/scss/docs/_docs-top-nav.scss
+++ b/themes/default/theme/src/scss/docs/_docs-top-nav.scss
@@ -57,9 +57,9 @@ nav.actually-docs {
                 box-shadow: none;
                 color: #fff;
                 padding: 8px 16px;
-                border: 1px solid #805ac3;
+                border: 1px solid #5a30c5;
                 border-radius: 20px;
-                background: linear-gradient(90deg,#be5188,#805ac3) border-box;
+                background: linear-gradient(90deg,#be5188,#5a30c5) border-box;
 
                 &:hover {
                     color: #131314;

--- a/themes/default/theme/src/scss/docs/_docs-top-nav.scss
+++ b/themes/default/theme/src/scss/docs/_docs-top-nav.scss
@@ -33,10 +33,6 @@ nav.actually-docs {
             align-items: center;
             gap: 18px;
 
-            div.get-started a.get-started-header-button {
-                margin-left: 0;
-            }
-
             @media (min-width: 640px){
                 gap: 36px;
             }
@@ -46,25 +42,6 @@ nav.actually-docs {
         div.logo-parent {
             @media (min-width: 640px){
                 width: auto;
-            }
-        }
-
-        div.get-started {
-            a.get-started-header-button {
-                width: auto;
-                height: auto;
-                display: flex;
-                box-shadow: none;
-                color: #fff;
-                padding: 8px 16px;
-                border: 1px solid #5a30c5;
-                border-radius: 20px;
-                background: linear-gradient(90deg,#be5188,#5a30c5) border-box;
-
-                &:hover {
-                    color: #131314;
-                    background: transparent;
-                }
             }
         }
 

--- a/themes/default/theme/src/scss/main.scss
+++ b/themes/default/theme/src/scss/main.scss
@@ -21,7 +21,7 @@ $sitenav-offset: calc($sitenav-height + 16px);
 @utility btn {
     transition: all 120ms linear;
     @apply cursor-pointer text-sm whitespace-nowrap py-2 px-3 rounded inline-block;
-    @apply bg-blue-600 border border-blue-600 text-white text-center;
+    @apply bg-violet-600 border border-violet-600 text-white text-center;
 }
 
 @utility btn-lg {

--- a/themes/default/theme/src/scss/marketing/_pulumi-up.scss
+++ b/themes/default/theme/src/scss/marketing/_pulumi-up.scss
@@ -95,7 +95,7 @@ body.section-pulumi-up {
     }
 
     .btn-primary:hover {
-        background:linear-gradient(90deg, #be5188 0%, #805ac3 100%)
+        background:linear-gradient(90deg, #be5188 0%, #5a30c5 100%)
     }
 
 }


### PR DESCRIPTION
## Summary

Brings the Pulumi Registry docs top-nav Get Started button in line with the live `pulumi.com/docs` button — class, color, and destination.

- **Class + href**: switch the button from `.get-started-header-button` to `.btn .btn-primary` (matches the markup pulumi.com/docs renders) and point it at `https://app.pulumi.com/signup` instead of `/docs/get-started/`.
- **Brand violet**: pulumi.com uses `--color-violet-primary: #5a30c5` (a deeper, more saturated violet); this repo had `#805ac3`. Updated `$brand-violet`, `--color-violet-600` (the Tailwind v4 token `bg-violet-600` resolves to), and the violet endpoints of brand gradients in `_header.scss`, `_docs-top-nav.scss`, and `_pulumi-up.scss`, plus the active-link bullet in `_docs-main.scss`. The multi-stop brand-rainbow gradients (`_about.scss`, `_pricing.scss`, etc.) were left alone — `#805ac3` there is one stop in a fixed designed sequence, not a "violet-600" reference.
- **`.btn` default**: switched the `.btn` rule in `_buttons.scss` and the higher-priority `@utility btn` in `main.scss` from `blue-600` → `violet-600` (with `violet-500` hover/active). Both definitions had to change because `@utility btn` lives in Tailwind's `utilities` layer and overrides the `_buttons.scss` `components`-layer rule.
- **Dead-CSS cleanup**: removed the now-orphan `.get-started-header-button` rules in `_docs-top-nav.scss` (lines 36, 52–68) — they were scoped under `nav.actually-docs` and no longer matched anything after the markup switch.

## Scope

This PR is intentionally limited to the **docs top-nav** (`docs-top-nav.html` / `nav.actually-docs`). The regular top-nav (`top-nav.html`, used on the registry index and package pages) still uses the legacy `.get-started-header-button` class and links to `/docs/get-started/`. Bringing the registry-side nav in line with pulumi.com is a separate visual change that warrants its own review and QA pass; tracking as a follow-up.

## Test plan

- [ ] `make build-assets` produces a fresh bundle (verified locally — new hash `bundle-registry.67d9a125.css`).
- [ ] `make serve` and load a docs/registry page; confirm the Get Started button in the top nav is now violet (`#5a30c5`), not blue.
- [ ] Hover the button and confirm the hover state still looks right.
- [ ] Click the button and confirm it navigates to `https://app.pulumi.com/signup`.
- [ ] Spot-check other pages that use `.btn` (e.g. `/docs/continuous-delivery`, `get-started-stepper` shortcodes) to confirm they render in violet without regressions.
- [ ] Spot-check pages using `bg-violet-600` directly (any badges, marketing CTAs) to confirm the brand-color shift looks intentional rather than off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)