### PR TITLE
Skip Test Live Registry Publish on fork PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -104,6 +104,8 @@ jobs:
 
   test-live-publish:
     name: Test Live Registry Publish
+    # OIDC isn't granted to pull_request runs from forks, so this job can't authenticate to ESC. Skip on fork PRs (sentinel/preview already follow the same pattern).
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Fetch secrets from ESC


### PR DESCRIPTION
## Summary
- Add a fork guard (`if: github.event.pull_request.head.repo.full_name == github.repository`) to the `test-live-publish` job in `pull-request.yml`.
- Matches the existing pattern already used by `sentinel` (line 19) and `preview` (line 165).

The job authenticates to ESC via OIDC, but GitHub does not grant `id-token: write` to `pull_request` runs from forks regardless of `permissions: write-all`. It fails on every fork PR with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` (e.g. #10932). With this guard, the job skips cleanly on fork PRs; same-repo PRs are unaffected.

Trade-off: fork PRs lose the registry-publish dry-run validation. The same check still runs on `master` via `push.yml`. If we want the dry-run on fork PRs too, the bigger fix is to refactor `push-registry.py --dry-run` to skip the authenticated existence-check call so it doesn't need `PULUMI_ACCESS_TOKEN`.

## Test plan
- [ ] Verify same-repo PR still runs `Test Live Registry Publish`
- [ ] Verify fork PR shows `Test Live Registry Publish` as skipped (not failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)