### PR TITLE
Use CSS variables for custom font-family declarations

### DIFF
--- a/themes/default/theme/src/scss/_breadcrumb.scss
+++ b/themes/default/theme/src/scss/_breadcrumb.scss
@@ -9,7 +9,7 @@ ol.docs-breadcrumb {
         margin: 0;
 
         a {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-weight: 500;
             font-size: 12px;
             line-height: 1.5;

--- a/themes/default/theme/src/scss/_copy-button.scss
+++ b/themes/default/theme/src/scss/_copy-button.scss
@@ -71,7 +71,7 @@ div.highlight {
         @include transition;
         color: #fff;
         font-size: 12px;
-        font-family: 'Inter';
+        font-family: var(--font-body);
 
         .code-mode-dark & {
             @apply text-gray-600;

--- a/themes/default/theme/src/scss/_lists.scss
+++ b/themes/default/theme/src/scss/_lists.scss
@@ -41,7 +41,7 @@ dl {
         dd {
             @apply bg-white rounded-none text-base font-normal leading-6 break-words;
 
-            font-family: "Inter";
+            font-family: var(--font-body);
             color: map-get($gray, 950);
 
             p {

--- a/themes/default/theme/src/scss/_notes.scss
+++ b/themes/default/theme/src/scss/_notes.scss
@@ -49,7 +49,7 @@
     }
 
     div.content {
-        font-family: 'Inter';
+        font-family: var(--font-body);
         font-weight: 400;
         font-size: 14px;
         color: #131314;

--- a/themes/default/theme/src/scss/_theme.scss
+++ b/themes/default/theme/src/scss/_theme.scss
@@ -97,7 +97,7 @@
   --color-green-900: #155148;
   --font-display: Gilroy, ui-sans-serif, system-ui, sans-serif;
   --font-body: Inter, ui-sans-serif, system-ui, sans-serif;
-  --font-mono: Roboto Mono, ui-monospace, SFMono-Regular, monospace;
+  --font-mono: Iosevka, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --breakpoint-sm: 640px;
   --breakpoint-md: 768px;
   --breakpoint-lg: 1024px;

--- a/themes/default/theme/src/scss/docs/_cloud-overview.scss
+++ b/themes/default/theme/src/scss/docs/_cloud-overview.scss
@@ -15,7 +15,7 @@ $box-shadow: #5f606524;
                 padding-top: 12px;
                 border-radius: 4px;
                 display: flex;
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 500;
                 font-size: 16px;
                 color: $text-color-inner-card;
@@ -86,7 +86,7 @@ $box-shadow: #5f606524;
         }
 
         h1, h2 {
-            font-family: 'Gilroy';
+            font-family: var(--font-display);
         }
 
         h1 {
@@ -104,7 +104,7 @@ $box-shadow: #5f606524;
         }
 
         p {
-            font-family: Inter;
+            font-family: var(--font-body);
             font-size: 16px;
             padding: 0;
             margin: 16px 0;
@@ -220,7 +220,7 @@ $box-shadow: #5f606524;
 
             p {
                 color: $text-color-inner-card;
-                font-family: Gilroy;
+                font-family: var(--font-display);
                 font-size: 18px;
                 margin: 0;
             }
@@ -245,7 +245,7 @@ $box-shadow: #5f606524;
             }
 
             p.inner-card-description {
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 400;
                 font-size: 14px;
                 color: $text-color;
@@ -306,7 +306,7 @@ $box-shadow: #5f606524;
                 }
 
                 p {
-                    font-family: 'Gilroy';
+                    font-family: var(--font-display);
                     font-weight: 500;
                     font-size: 21px;
                     margin: 0;
@@ -346,7 +346,7 @@ $box-shadow: #5f606524;
                 flex-basis: 50%;
             
                 div.heading p {
-                    font-family: 'Gilroy';
+                    font-family: var(--font-display);
                     font-weight: 500;
                     font-size: 21px;
                 }
@@ -370,7 +370,7 @@ $box-shadow: #5f606524;
                     }
 
                     div.heading p.content-name {
-                        font-family: 'Gilroy';
+                        font-family: var(--font-display);
                         font-weight: 500;
                         font-size: 18px;
                         color: $text-color-inner-card;
@@ -390,7 +390,7 @@ $box-shadow: #5f606524;
                     align-items: flex-start;
 
                     p.provider-label {
-                        font-family: 'Inter';
+                        font-family: var(--font-body);
                         font-size: 14px;
                         text-align: right;
                         margin-top: 4px;

--- a/themes/default/theme/src/scss/docs/_docs-home.scss
+++ b/themes/default/theme/src/scss/docs/_docs-home.scss
@@ -13,7 +13,7 @@ section.docs-home {
     }
 
     h3 {
-        font-family: 'Gilroy';
+        font-family: var(--font-display);
         font-weight: 500;
         font-size: 21px;
         color: map-get($gray, 950);
@@ -31,7 +31,7 @@ section.docs-home {
         flex: 1;
 
         h1 {
-            font-family: 'Gilroy';
+            font-family: var(--font-display);
             font-size: 36px;
             line-height: 36px;
             color: #2f3032;
@@ -68,7 +68,7 @@ section.docs-home {
                 border-radius: 4px;
                 border: 1px map-get($brand, "blue") solid;
                 background: $white;
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 400;
                 font-size: 14px;
                 color: $white;
@@ -94,7 +94,7 @@ section.docs-home {
     }
 
     h2 {
-        font-family: 'Gilroy';
+        font-family: var(--font-display);
         font-weight: 500;
         font-size: 24px;
         color: map-get($gray, 950);
@@ -206,7 +206,7 @@ section.docs-home {
             div.label {
                 background: $white;
                 border-radius: 0px 0px 4px 4px;
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 400;
                 font-size: 18px;
                 color: map-get($gray, 950);

--- a/themes/default/theme/src/scss/docs/_docs-main.scss
+++ b/themes/default/theme/src/scss/docs/_docs-main.scss
@@ -1,7 +1,7 @@
 .docs-list-main .docs-main-content,
 body.section-registry {
     h1 {
-        font-family: Gilroy;
+        font-family: var(--font-display);
         line-height: 1.5;
         font-weight: 400;
         font-size: 30px;
@@ -49,7 +49,7 @@ body.section-registry {
 
     section.docs-content {
         h1, h2, h3, h4, h5, h6 {
-            font-family: Gilroy;
+            font-family: var(--font-display);
             line-height: 1.5;
         }
 
@@ -108,7 +108,7 @@ body.section-registry {
         }
 
         p {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-weight: 400;
             font-size: 16px;
             color: map-get($gray, 950);
@@ -142,7 +142,7 @@ body.section-registry {
         div.highlight pre,
         code,
         .font-mono {
-            font-family: 'Iosevka';
+            font-family: var(--font-mono);
             font-weight: 400;
         }
     }
@@ -208,7 +208,7 @@ body.section-registry {
 
             h2,
             ul h2 {
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 500;
                 font-size: 16px;
                 line-height: 14px;
@@ -242,7 +242,7 @@ body.section-registry {
 
             div.all-packages-icon-link {
                 a.all-packages {
-                    font-family: 'Inter';
+                    font-family: var(--font-body);
                     font-weight: 500;
                     font-size: 16px;
                     color: #2f3032;
@@ -574,7 +574,7 @@ body.section-registry {
         justify-content: space-between;
         align-items: center;
         display: flex;
-        font-family: 'Inter';
+        font-family: var(--font-body);
         font-weight: 400;
         font-size: 12px;
         color: #5a5a5a;
@@ -616,7 +616,7 @@ body.section-registry {
 
         div.version-info,
         .note {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-weight: 400;
             font-size: 12px;
             color: #131314;
@@ -629,7 +629,7 @@ body.section-registry {
             a {
                 display: flex;
                 gap: 4px;
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 500;
                 font-size: 12px;
                 color: #4D5BD9;
@@ -723,7 +723,7 @@ body.section-registry {
             align-items: center;
 
             h2 {
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 600;
                 font-size: 12px;
                 color: #8e8f97;
@@ -743,7 +743,7 @@ body.section-registry {
             }
 
             li a {
-                font-family: 'Inter';
+                font-family: var(--font-body);
                 font-weight: 400;
                 font-size: 14px;
                 color: #364098;
@@ -829,7 +829,7 @@ body.section-registry {
         align-items: center;
 
         .version-selector {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-size: 12px;
             padding: 4px 8px;
             border: 1px solid #dcdcdc;

--- a/themes/default/theme/src/scss/docs/_docs-top-nav.scss
+++ b/themes/default/theme/src/scss/docs/_docs-top-nav.scss
@@ -74,11 +74,11 @@ nav.actually-docs {
             width: auto;
             margin-left: 0;
             padding: 0;
-            font-family: Inter;
+            font-family: var(--font-body);
             z-index: 100;
 
             li {
-                font-family: Inter;
+                font-family: var(--font-body);
                 font-size: 16px;
             }
         }

--- a/themes/default/theme/src/scss/docs/_footer.scss
+++ b/themes/default/theme/src/scss/docs/_footer.scss
@@ -18,7 +18,7 @@ footer.docs-footer {
         }
 
         p.open-source {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-weight: 600;
             font-size: 16px;       
             color: #5f6065;
@@ -26,7 +26,7 @@ footer.docs-footer {
         }
 
         p.copyright {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-weight: 400;
             font-size: 14px;
             color: #808080;
@@ -41,7 +41,7 @@ footer.docs-footer {
         text-align: right;
 
         li {
-            font-family: 'Inter';
+            font-family: var(--font-body);
             font-weight: 400;
             font-size: 14px;
             color: #5f6065;

--- a/themes/default/theme/src/scss/docs/_packages.scss
+++ b/themes/default/theme/src/scss/docs/_packages.scss
@@ -149,7 +149,7 @@ div.packages {
     section.featured-packages,
     section.all-packages {
         h2 {
-            font-family: Gilroy;
+            font-family: var(--font-display);
             font-weight: 400;
             font-size: 30px;
             color: #131314;
@@ -199,7 +199,7 @@ div.packages section.featured-packages {
 
             .package-title {
                 flex-grow: 1;
-                font-family: 'Gilroy';
+                font-family: var(--font-display);
                 font-weight: 500;
                 font-size: 24px;
                 color: #131314;
@@ -209,7 +209,7 @@ div.packages section.featured-packages {
             }
 
             .package-version {
-                font-family: 'Gilroy';
+                font-family: var(--font-display);
                 font-weight: 500;
                 font-size: 14px;
                 text-align: center;

--- a/themes/default/theme/src/scss/marketing/_dismissable-banner.scss
+++ b/themes/default/theme/src/scss/marketing/_dismissable-banner.scss
@@ -33,7 +33,7 @@ a.dismissable-banner {
             }
     
             p {
-                font-family: Gilroy;
+                font-family: var(--font-display);
                 font-size: 20px;
                 font-weight: 600;
                 color: #131314;

--- a/themes/default/theme/src/scss/marketing/_pulumi-up.scss
+++ b/themes/default/theme/src/scss/marketing/_pulumi-up.scss
@@ -22,7 +22,7 @@ body.section-pulumi-up {
     }
 
     .yellow-header-text {
-        font-family: 'Gilroy';
+        font-family: var(--font-display);
         font-style: normal;
         font-weight: 500;
         font-size: 48px;
@@ -30,7 +30,7 @@ body.section-pulumi-up {
     }
 
     .banner-description p {
-        font-family: 'Inter';
+        font-family: var(--font-body);
         font-size: 18px;
         line-height: 27px;
 


### PR DESCRIPTION
Replace hardcoded 'Inter', 'Gilroy', and 'Iosevka' font-family declarations
across SCSS files with the existing --font-body, --font-display, and
--font-mono CSS variables defined in _theme.scss. This restores the system
font fallbacks so the registry remains legible when Iosevka, Inter, or
Gilroy fail to load.

Also fix --font-mono, which previously listed Roboto Mono (not loaded by
the site) instead of Iosevka.

Reference: https://pulumi.slack.com/archives/C85BS3LJZ/p1778525759901189

## Test plan

- `make build-assets` compiles without new warnings
- Disable custom fonts in DevTools and confirm code blocks fall back to
  system monospace, body text to system sans, headings to system sans
