### PR TITLE
Delist providers whose upstream repos are archived

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -85,10 +85,6 @@
       "schemaFile": "provider/cmd/pulumi-resource-grafana/schema.json"
     },
     {
-      "repoSlug": "lbrlabs/pulumi-launchdarkly",
-      "schemaFile": "provider/cmd/pulumi-resource-launchdarkly/schema.json"
-    },
-    {
       "repoSlug": "lbrlabs/pulumi-harness",
       "schemaFile": "provider/cmd/pulumi-resource-harness/schema.json"
     },
@@ -103,10 +99,6 @@
     {
       "repoSlug": "pulumiverse/pulumi-dynatrace",
       "schemaFile": "provider/cmd/pulumi-resource-dynatrace/schema.json"
-    },
-    {
-      "repoSlug": "pulumiverse/pulumi-aquasec",
-      "schemaFile": "provider/cmd/pulumi-resource-aquasec/schema.json"
     },
     {
       "repoSlug": "pulumiverse/pulumi-exoscale",
@@ -155,10 +147,6 @@
     {
       "repoSlug": "twingate/pulumi-twingate",
       "schemaFile": "provider/cmd/pulumi-resource-twingate/schema.json"
-    },
-    {
-      "repoSlug": "dirien/pulumi-azapi",
-      "schemaFile": "provider/cmd/pulumi-resource-azapi/schema.json"
     },
     {
       "repoSlug": "equinix/pulumi-equinix",
@@ -255,10 +243,6 @@
     {
       "repoSlug": "pulumiverse/pulumi-talos",
       "schemaFile": "provider/cmd/pulumi-resource-talos/schema.json"
-    },
-    {
-      "repoSlug": "dirien/pulumi-qovery",
-      "schemaFile": "provider/cmd/pulumi-resource-qovery/schema.json"
     },
     {
       "repoSlug": "littlejo/pulumi-cilium",

--- a/themes/default/data/registry/packages/aquasec.yaml
+++ b/themes/default/data/registry/packages/aquasec.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: aquasec
 native: false
 package_status: public_preview
-publisher: Pulumiverse
+publisher: DEPRECATED
 repo_url: https://github.com/pulumiverse/pulumi-aquasec
 schema_file_path: provider/cmd/pulumi-resource-aquasec/schema.json
 title: Aquasec

--- a/themes/default/data/registry/packages/azapi.yaml
+++ b/themes/default/data/registry/packages/azapi.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: azapi
 native: false
 package_status: ga
-publisher: dirien
+publisher: DEPRECATED
 repo_url: https://github.com/dirien/pulumi-azapi
 schema_file_url: https://raw.githubusercontent.com/dirien/pulumi-azapi/v1.12.2/provider/cmd/pulumi-resource-azapi/schema.json
 title: AzAPI

--- a/themes/default/data/registry/packages/google-native.yaml
+++ b/themes/default/data/registry/packages/google-native.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: google-native
 native: true
 package_status: public_preview
-publisher: Pulumi
+publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-google-native
 schema_file_path: provider/cmd/pulumi-resource-google-native/schema.json
 title: Google Cloud Native

--- a/themes/default/data/registry/packages/googleworkspace.yaml
+++ b/themes/default/data/registry/packages/googleworkspace.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: googleworkspace
 native: false
 package_status: public_preview
-publisher: hashicorp
+publisher: DEPRECATED
 repo_url: https://github.com/hashicorp/terraform-provider-googleworkspace
 schema_file_url: https://djoiyj6oj2oxz.cloudfront.net/schemas/registry.opentofu.org/hashicorp/googleworkspace/0.7.0/schema.json
 title: googleworkspace

--- a/themes/default/data/registry/packages/launchdarkly.yaml
+++ b/themes/default/data/registry/packages/launchdarkly.yaml
@@ -6,7 +6,7 @@ logo_url: https://raw.githubusercontent.com/lbrlabs/pulumi-launchdarkly/master/a
 name: launchdarkly
 native: false
 package_status: public_preview
-publisher: lbrlabs
+publisher: DEPRECATED
 repo_url: https://github.com/lbrlabs/pulumi-launchdarkly
 schema_file_path: provider/cmd/pulumi-resource-launchdarkly/schema.json
 title: Launch Darkly

--- a/themes/default/data/registry/packages/octopusdeploy.yaml
+++ b/themes/default/data/registry/packages/octopusdeploy.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: octopusdeploy
 native: false
 package_status: public_preview
-publisher: octopusdeploylabs
+publisher: DEPRECATED
 repo_url: https://github.com/octopusdeploylabs/terraform-provider-octopusdeploy
 schema_file_url: https://djoiyj6oj2oxz.cloudfront.net/schemas/registry.opentofu.org/octopusdeploylabs/octopusdeploy/0.43.3/schema.json
 title: octopusdeploy

--- a/themes/default/data/registry/packages/qovery.yaml
+++ b/themes/default/data/registry/packages/qovery.yaml
@@ -6,7 +6,7 @@ logo_url: ""
 name: qovery
 native: false
 package_status: public_preview
-publisher: dirien
+publisher: DEPRECATED
 repo_url: https://github.com/dirien/pulumi-qovery
 schema_file_path: provider/cmd/pulumi-resource-qovery/schema.json
 title: Qovery

--- a/themes/default/data/registry/packages/sql.yaml
+++ b/themes/default/data/registry/packages/sql.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: sql
 native: false
 package_status: public_preview
-publisher: paultyng
+publisher: DEPRECATED
 repo_url: https://github.com/paultyng/terraform-provider-sql
 schema_file_url: https://djoiyj6oj2oxz.cloudfront.net/schemas/registry.opentofu.org/paultyng/sql/0.5.0/schema.json
 title: sql

--- a/themes/default/data/registry/packages/turso.yaml
+++ b/themes/default/data/registry/packages/turso.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: turso
 native: false
 package_status: public_preview
-publisher: celest-dev
+publisher: DEPRECATED
 repo_url: https://github.com/celest-dev/terraform-provider-turso
 schema_file_url: https://djoiyj6oj2oxz.cloudfront.net/schemas/registry.opentofu.org/celest-dev/turso/0.2.3/schema.json
 title: turso

--- a/themes/default/data/registry/packages/wavefront.yaml
+++ b/themes/default/data/registry/packages/wavefront.yaml
@@ -8,7 +8,7 @@ logo_url: ""
 name: wavefront
 native: false
 package_status: ga
-publisher: vmware
+publisher: DEPRECATED
 repo_url: https://github.com/vmware/terraform-provider-wavefront
 schema_file_url: https://djoiyj6oj2oxz.cloudfront.net/schemas/registry.opentofu.org/vmware/wavefront/5.1.0/schema.json
 title: wavefront


### PR DESCRIPTION
Sets `publisher: DEPRECATED` on 10 packages whose `repo_url` points at archived upstream repositories, and removes the four that appear in `community-packages/package-list.json` so the nightly metadata workflow no longer tries to update them.

### Delisted

- `aquasec` — also removed from community-packages list
- `azapi` — also removed from community-packages list
- `google-native`
- `googleworkspace`
- `launchdarkly` — also removed from community-packages list
- `octopusdeploy`
- `qovery` — also removed from community-packages list
- `sql`
- `turso`
- `wavefront`

Closes #11043

Generated with [Claude Code](https://claude.ai/code)