### PR TITLE
Publish icon sprite under /registry/ so CloudFront serves it

### DIFF
--- a/themes/default/layouts/partials/icon-context.html
+++ b/themes/default/layouts/partials/icon-context.html
@@ -2,7 +2,13 @@
 icon-context.html — internal helper for icon.html.
 Returns sprite URL + manifest membership dicts. Called via partialCached.
 */ -}}
-{{- $sprite := resources.Get "icons/sprite.svg" | fingerprint -}}
+{{- /*
+The sprite is published under /registry/icons/ so the outer pulumi.com
+CloudFront routes the request to this site's S3 origin. A request to
+/icons/sprite.{hash}.svg would hit the pulumi/docs origin instead, which
+serves a different sprite at a different hash.
+*/ -}}
+{{- $sprite := resources.Get "icons/sprite.svg" | resources.Copy "registry/icons/sprite.svg" | fingerprint -}}
 {{- $manifestRes := resources.Get "icons/sprite-manifest.json" -}}
 {{- $manifest := $manifestRes.Content | transform.Unmarshal -}}
 {{- $phosphor := dict -}}


### PR DESCRIPTION
## Summary

Fixes a console error on /registry pages where the icon sprite 404s:

```
GET https://www.pulumi.com/icons/sprite.1a70d817…svg  (404)
```

pulumi.com's outer CloudFront routes `/registry/*` to this repo's S3 origin and `/icons/*` to the pulumi/docs origin. Hugo's `resources.Get` published the sprite to `/icons/sprite.{hash}.svg`, so the request hit the docs origin (which has a different sprite at a different hash) and 404'd.

This chains `resources.Copy "registry/icons/sprite.svg"` before `fingerprint` so the sprite is published at `/registry/icons/sprite.{hash}.svg` — matching the prefix `bundle-registry.{js,css}` already use.

Regression from #11099.

## Test plan

- [x] Local build: rendered HTML references `/registry/icons/sprite.{hash}.svg` and the file lands at `public/registry/icons/sprite.{hash}.svg`
- [x] On the preview URL, open an /api-docs/ page and confirm the top-nav icons render and the sprite request 200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)