### PR TITLE
Fix mobile accordion behavior and registry visual polish

### DIFF
--- a/themes/default/layouts/partials/docs/right-nav-ad.html
+++ b/themes/default/layouts/partials/docs/right-nav-ad.html
@@ -1,5 +1,5 @@
 <div class="docs-marketing-ad w-full">
-    <div class="card card-hover w-full block p-6">
+    <div class="card card-hover w-full block p-4">
         <h4 class="no-anchor">
             Try Pulumi Cloud free. <br />Your team will thank you.
         </h4>

--- a/themes/default/layouts/partials/docs/table-of-contents.html
+++ b/themes/default/layouts/partials/docs/table-of-contents.html
@@ -24,7 +24,7 @@
                         <div class="icon icon-18-18 expand-more-18-18"></div>
                     </div>
                 </label>
-                <div class="accordion-content flex">
+                <div class="accordion-content">
                     <div class="content">
                         <ul class="table-of-contents-list">
                             {{/* This will be populated dynamically with all H2s and H3s on the page; see ts/misc.ts */}}

--- a/themes/default/layouts/partials/registry/package-list.html
+++ b/themes/default/layouts/partials/registry/package-list.html
@@ -112,9 +112,9 @@ append . }} {{ end }} {{ end }}
                 </template>
             </div>
         </div>
-        <div class="flex justify-between items-center mb-4 px-4">
-            <h2 class="inline-flex items-center mt-8 md:mt-0">
-                A&ndash;Z packages
+        <div class="flex justify-between flex-col md:flex-row gap-4 items-start md:items-center mb-4 px-4">
+            <h2 class="flex items-center mt-8 md:mt-0">
+                <span>A&ndash;Z packages</span>
                 <span
                     class="all-count ml-4 py-0.5 px-3 rounded-full bg-gray-100 text-lg"
                 >
@@ -124,7 +124,7 @@ append . }} {{ end }} {{ end }}
 
             <a
                 href="/docs/iac/packages-and-automation/pulumi-packages/authoring/"
-                class="btn btn-outline btn-lg"
+                class="btn btn-outline btn-lg w-full md:w-auto"
                 >Contribute your own packages</a
             >
         </div>

--- a/themes/default/layouts/partials/registry/package/package-alert.html
+++ b/themes/default/layouts/partials/registry/package/package-alert.html
@@ -68,14 +68,14 @@
     <div class="text-xs mt-4 note note-info">
         {{ partial "icon" (dict "name" "info" "weight" "fill" "class" "text-blue-600 mr-1 my-1") }}
         <span>
-            This is the latest version of Azure Native. Use the <a class="text-blue-600 underline" href="/registry/packages/azure-native-v2/">Azure Native v2</a> docs if using the v2 version of this package.
+            This is the latest version of Azure Native. Use the <a class="text-violet-primary hover:underline" href="/registry/packages/azure-native-v2/">Azure Native v2</a> docs if using the v2 version of this package.
         </span>
     </div>
 {{ else if (eq $package "azure-native-v2") }}
     <div class="text-xs mt-4 note note-warning">
         {{ partial "icon" (dict "name" "info" "weight" "fill" "class" "text-blue-600 mr-1 my-1") }}
         <span>
-            These are the docs for Azure Native v2. We recommenend using the latest version, <a class="text-blue-600 underline" href="/registry/packages/azure-native/">Azure Native v3</a>.
+            These are the docs for Azure Native v2. We recommenend using the latest version, <a class="text-violet-primary hover:underline" href="/registry/packages/azure-native/">Azure Native v3</a>.
         </span>
     </div>
     {{ else if (eq $package "pulumiservice") }}

--- a/themes/default/layouts/partials/registry/package/package-alert.html
+++ b/themes/default/layouts/partials/registry/package/package-alert.html
@@ -75,7 +75,7 @@
     <div class="text-xs mt-4 note note-warning">
         {{ partial "icon" (dict "name" "info" "weight" "fill" "class" "text-blue-600 mr-1 my-1") }}
         <span>
-            These are the docs for Azure Native v2. We recommenend using the latest version, <a class="text-violet-primary hover:underline" href="/registry/packages/azure-native/">Azure Native v3</a>.
+            These are the docs for Azure Native v2. We recommend using the latest version, <a class="text-violet-primary hover:underline" href="/registry/packages/azure-native/">Azure Native v3</a>.
         </span>
     </div>
     {{ else if (eq $package "pulumiservice") }}

--- a/themes/default/layouts/partials/registry/package/package-card-top-of-page.html
+++ b/themes/default/layouts/partials/registry/package/package-card-top-of-page.html
@@ -8,11 +8,11 @@ index site.Data.registry.package_versions $rawPackageName }} {{ $packageData = .
 }} {{ end }} {{ end }} {{ $iconData := index site.Data.registry.packages
 $basePackageName }}
 
-<div id="accordion-package-card" class="accordion">
+<div id="accordion-package-card" class="accordion card p-4">
     <div>
         <input type="checkbox" id="accordion-checkbox-package-card" />
         <label for="accordion-checkbox-package-card" class="show">
-            <div class="package-card-top-of-page card">
+            <div class="package-card-top-of-page">
                 <div class="img-name-version">
                     {{ with $iconData }}
                     <div>
@@ -31,7 +31,7 @@ $basePackageName }}
             </div>
         </label>
         <label for="accordion-checkbox-package-card" class="hide">
-            <div class="package-card-top-of-page card">
+            <div class="package-card-top-of-page">
                 <div class="img-name-version">
                     {{ with $iconData }}
                     <div>
@@ -49,7 +49,7 @@ $basePackageName }}
                 <div class="icon icon-16-16 keyboard-arrow-up-gray"></div>
             </div>
         </label>
-        <div class="accordion-content flex">
+        <div class="accordion-content">
             <div class="content">
                 <div class="package-card card">
                     {{ .Scratch.Set "package" $basePackageName }} {{ partial

--- a/themes/default/layouts/partials/registry/packages/how-to-language-index.html
+++ b/themes/default/layouts/partials/registry/packages/how-to-language-index.html
@@ -1,6 +1,6 @@
 {{ range where .package.Pages "Params.language" .language }}
     <div class="pb-4">
-        <a class="text-blue-600 underline" href="{{ relref . .Path }}">{{ .Params.h1 }}</a>
+        <a class="text-violet-primary hover:underline" href="{{ relref . .Path }}">{{ .Params.h1 }}</a>
     </div>
 {{ end }}
 

--- a/themes/default/layouts/registry/api.html
+++ b/themes/default/layouts/registry/api.html
@@ -59,7 +59,7 @@
 
                 {{ range where .Pages "Params.language" "==" nil }}
                 <div class="pb-4">
-                    <a class="text-blue-600 underline" href="{{ relref . .Path }}">{{ .Title }}</a>
+                    <a class="text-violet-primary hover:underline" href="{{ relref . .Path }}">{{ .Title }}</a>
                 </div>
                 {{ end }}
 

--- a/themes/default/layouts/registry/installation.html
+++ b/themes/default/layouts/registry/installation.html
@@ -68,7 +68,7 @@ $packageName := index $directories 2 }} {{ $packageHome := path.Join
                 {{ range where .Pages "Params.language" "==" nil }}
                 <div class="pb-4">
                     <a
-                        class="text-blue-600 underline"
+                        class="text-violet-primary hover:underline"
                         href="{{ relref . .Path }}"
                         >{{ .Title }}</a
                     >

--- a/themes/default/layouts/registry/overview.html
+++ b/themes/default/layouts/registry/overview.html
@@ -78,7 +78,7 @@ $packageName := index $directories 2 }} {{ $packageHome := path.Join
                 {{ range where .Pages "Params.language" "==" nil }}
                 <div class="pb-4">
                     <a
-                        class="text-blue-600 underline"
+                        class="text-violet-primary hover:underline"
                         href="{{ relref . .Path }}"
                         >{{ .Title }}</a
                     >

--- a/themes/default/layouts/registry/package.html
+++ b/themes/default/layouts/registry/package.html
@@ -76,7 +76,7 @@ $packageName := index $directories 2 }} {{ $packageHome := path.Join
                 {{ range where .Pages "Params.language" "==" nil }}
                 <div class="pb-4">
                     <a
-                        class="text-blue-600 underline"
+                        class="text-violet-primary hover:underline"
                         href="{{ relref . .Path }}"
                         >{{ .Title }}</a
                     >

--- a/themes/default/theme/src/scss/_button.scss
+++ b/themes/default/theme/src/scss/_button.scss
@@ -8,7 +8,7 @@
 .btn {
     @apply inline-flex items-center justify-center gap-1 shrink-0 max-w-full
            overflow-hidden text-ellipsis text-sm font-normal border border-transparent
-           bg-clip-padding rounded-lg transition-all outline-none cursor-pointer select-none
+           bg-clip-padding rounded-lg transition outline-none cursor-pointer select-none
            focus-visible:border-violet-primary focus-visible:ring-3 focus-visible:ring-violet-primary/50
            active:not-aria-[haspopup]:translate-y-px
            disabled:pointer-events-none disabled:opacity-50

--- a/themes/default/theme/src/scss/docs/_docs-main.scss
+++ b/themes/default/theme/src/scss/docs/_docs-main.scss
@@ -579,8 +579,6 @@ body.section-registry {
 .docs-list-main,
 body.section-registry {
     div#accordion-package-card {
-        padding: 18px;
-        background: #f9f9f9;
         margin-top: 24px;
     }
 
@@ -612,7 +610,7 @@ body.section-registry {
     div.table-of-contents div.package-card,
     div#accordion-package-card div.package-card {
         background: #fff;
-        padding: 18px;
+        padding: 16px;
         display: flex;
         flex-direction: column;
         gap: 18px;

--- a/themes/default/theme/src/scss/docs/_main-nav.scss
+++ b/themes/default/theme/src/scss/docs/_main-nav.scss
@@ -16,7 +16,7 @@ nav.main-nav {
         &.active {
             background-color: var(--color-violet-100);
             border-left: var(--color-violet-primary) 3px solid;
-            width: fit-content;
+            width: 100%;
 
             &:hover {
                 text-decoration: none;
@@ -26,7 +26,7 @@ nav.main-nav {
     }
 
     a {
-        @apply py-0.5 px-1.5 rounded-sm;
+        @apply py-1 px-1.5 rounded-sm w-full;
         color: var(--color-violet-primary);
 
         &:hover {
@@ -70,9 +70,6 @@ nav.main-nav {
         display: flex;
         align-items: center;
         font-size: 15px;
-        margin-left: 8px;
-        margin-bottom: 16px;
-        margin-top: 16px;
     }
 
     .sidenav-subsection {

--- a/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-tree/pulumi-api-doc-nav-tree.scss
+++ b/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-tree/pulumi-api-doc-nav-tree.scss
@@ -132,7 +132,7 @@ details {
         }
 
         &[data-selected="true"] {
-            background-color: #e0e0e0;
+            background-color: var(--color-violet-100);
             color: var(--color-service-black);
             font-weight: bold;
 


### PR DESCRIPTION
Just some minor tweaks and fixes!

---
**Generated description of changes:**

The mobile `#accordion-package-card` and `#accordion-table-of-contents` were stuck open because `<div class="accordion-content flex">` applied Tailwind's `.flex` utility (in `@layer utilities`), which wins over the `display: none` rule from `docs/_docs-main.scss` — that file is imported inside `@layer components` in `main.scss`. Dropping the `flex` class from both partials lets the SCSS cascade control show/hide again.

## Other changes bundled in

- A–Z packages header stacks vertically on mobile.
- Replace `text-blue-600`/underline links with `text-violet-primary` + hover underline across package-alert, language indexes, and registry page templates.
- Move package-card padding/background onto the `.card` utility; trim inner padding to 16px.
- Docs main-nav active item goes full-width with a larger hit area; drop stray `sidenav-section` margins.
- Selected api-doc nav tree row uses `violet-100` instead of `#e0e0e0`.
- Right-nav ad `p-6` → `p-4`.