### PR TITLE
Fix nested resource tree nodes navigating instead of toggling

### DIFF
--- a/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-node/pulumi-api-doc-nav-node.tsx
+++ b/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-node/pulumi-api-doc-nav-node.tsx
@@ -117,7 +117,7 @@ export class PulumiApiDocNavNode {
             const nodeLinkLastChar = node.link.charAt(node.link.length - 1);
             const nodeLink = nodeLinkLastChar === "/" ? node.link : `${node.link}/`;
             const nodeHref = `${linkBase}${nodeLink}`;
-            const hasChildren = node.children ? node.children.length === 0 : false;
+            const hasChildren = node.children ? node.children.length > 0 : false;
 
             return (
                             <details


### PR DESCRIPTION
`hasChildren` in `getChildNodes` was defined as `length === 0`, the inverse of its name. That bool gets passed through `!hasChildren` to `onExpansionChange`'s `isLink` parameter, so nested nodes with children navigated via `window.location.href` on every click instead of toggling expansion. Flip the comparison to match the variable name and the top-level `render()` logic.

I've tested this locally.

Closes #11164