### PR TITLE
Fix API docs nav collapse

### DIFF
--- a/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-node/pulumi-api-doc-nav-node.tsx
+++ b/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-node/pulumi-api-doc-nav-node.tsx
@@ -117,30 +117,13 @@ export class PulumiApiDocNavNode {
             const nodeLinkLastChar = node.link.charAt(node.link.length - 1);
             const nodeLink = nodeLinkLastChar === "/" ? node.link : `${node.link}/`;
             const nodeHref = `${linkBase}${nodeLink}`;
-            const hasChildren = node.children ? node.children.length === 0 : false;
 
             return (
-                            <details
-                    open={this.isExpanded}
-                    data-expandable={
-                        node.children && node.children.length > 0
-                            ? "true"
-                            : "false"
-                    }
-                    
-                    class="nav-tree-item nested"
-                                    id={this.getNodeId(node.name)}
-                title={node.name}
-                onClick={() => this.onExpansionChange(nodeHref, !hasChildren)}
-                >
-                    <summary class={`content-container ${hasChildren ? "" : "is-link"}`} data-selected={this.shouldNodeBeSelected(nodeHref) ? "true" : "false"}>
-                     <a class={`depth-${depth}`} href={nodeHref} onClick={(e) => this.handleLinkClick(e, nodeHref)}>
-                         {this.getIcon(node.type)}
-                         <span class="link-container">{node.name}</span>
-                     </a>
-                    </summary>
-                    {this.getChildNodes(node.children, this.isExpanded, depth + 1, nodeHref)}
-                </details>
+                <pulumi-api-doc-nav-node
+                    node={node}
+                    href={nodeHref}
+                    depth={depth}
+                ></pulumi-api-doc-nav-node>
             );
         });
     }

--- a/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-node/pulumi-api-doc-nav-node.tsx
+++ b/themes/default/theme/stencil/src/components/pulumi-api-doc-nav-node/pulumi-api-doc-nav-node.tsx
@@ -149,7 +149,7 @@ export class PulumiApiDocNavNode {
                          <span class="link-container">{this.node.name}</span>
                      </a>
                     </summary>
-                    {this.getChildNodes(this.node.children, this.isExpanded)}
+                    {this.getChildNodes(this.node.children, this.isExpanded, this.depth + 1)}
                 </details>
         );
     }


### PR DESCRIPTION
Resolves #11164

**Generated description of changes:**

Nested modules in `pulumi-api-doc-nav-node.tsx` shared the parent's `isExpanded` state, so clicking any child toggled the root node instead of itself.

Fixed by rendering each child in `getChildNodes` as a `<pulumi-api-doc-nav-node>` component — giving it its own state, matching the pattern used by `pulumi-api-doc-nav-tree`. 22 lines → 5.
