### PR TITLE
Neutralize Hugo shortcode delimiters in generated code examples

### DIFF
--- a/tools/resourcedocsgen/pkg/output.go
+++ b/tools/resourcedocsgen/pkg/output.go
@@ -17,11 +17,67 @@ package pkg
 import (
 	"os"
 	"path"
+	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
+
+// hugoShortcodeDelim matches Hugo's shortcode delimiters `{{%` and `{{<`.
+var hugoShortcodeDelim = regexp.MustCompile(`\{\{([%<])`)
+
+// neutralizeHugoShortcodes disarms Hugo shortcode delimiters inside fenced code
+// blocks, where Hugo would resolve them before Markdown rendering. Inline code
+// spans and indented code blocks are outside the current generator surface.
+func neutralizeHugoShortcodes(contents []byte) []byte {
+	lines := strings.Split(string(contents), "\n")
+	inFence := false
+	var fenceChar byte
+	var fenceLen int
+	for i, line := range lines {
+		if c, n, rest := fenceRun(line); n > 0 {
+			switch {
+			case !inFence:
+				inFence, fenceChar, fenceLen = true, c, n
+				continue
+			case c == fenceChar && n >= fenceLen && strings.TrimSpace(rest) == "":
+				inFence = false
+				continue
+			}
+		}
+		if inFence {
+			lines[i] = hugoShortcodeDelim.ReplaceAllString(line, "{{ $1")
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// fenceRun returns the fence char, run length, and trailing text if the line
+// starts with a CommonMark fence marker.
+func fenceRun(line string) (byte, int, string) {
+	indent := 0
+	for indent < len(line) && line[indent] == ' ' {
+		indent++
+	}
+	if indent > 3 {
+		return 0, 0, ""
+	}
+	line = line[indent:]
+	if len(line) < 3 || (line[0] != '`' && line[0] != '~') {
+		return 0, 0, ""
+	}
+	c := line[0]
+	n := 0
+	for n < len(line) && line[n] == c {
+		n++
+	}
+	if n < 3 {
+		return 0, 0, ""
+	}
+	return c, n, line[n:]
+}
 
 // EmitFile writes the file with the provided contents in the output
 // directory outDir.
@@ -29,6 +85,9 @@ func EmitFile(outDir, relPath string, contents []byte) error {
 	// Do not emit a file if there are no contents to write.
 	if contents == nil {
 		return nil
+	}
+	if strings.HasSuffix(relPath, ".md") {
+		contents = neutralizeHugoShortcodes(contents)
 	}
 	p := path.Join(outDir, relPath)
 	if err := os.MkdirAll(path.Dir(p), 0o700); err != nil {

--- a/tools/resourcedocsgen/pkg/output_test.go
+++ b/tools/resourcedocsgen/pkg/output_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNeutralizeHugoShortcodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "percent opener inside a code fence is disarmed",
+			input: "```java\nString.format(\"Bearer {{%s|token}}\", _id)\n```",
+			want:  "```java\nString.format(\"Bearer {{ %s|token}}\", _id)\n```",
+		},
+		{
+			name:  "angle opener inside a code fence is disarmed",
+			input: "```go\ncfg {{<ref \"x\">}} end\n```",
+			want:  "```go\ncfg {{ <ref \"x\">}} end\n```",
+		},
+		{
+			name: "legitimate shortcodes outside fences are preserved",
+			input: "{{< chooser language \"go\" >}}\n{{% choosable language go %}}\n" +
+				"```go\nx := 1\n```\n{{% /choosable %}}\n{{< /chooser >}}",
+			want: "{{< chooser language \"go\" >}}\n{{% choosable language go %}}\n" +
+				"```go\nx := 1\n```\n{{% /choosable %}}\n{{< /chooser >}}",
+		},
+		{
+			name:  "triple brace is not a Hugo opener and is left alone",
+			input: "```python\nf\"Bearer {{{id}|token}}\"\n```",
+			want:  "```python\nf\"Bearer {{{id}|token}}\"\n```",
+		},
+		{
+			name:  "opener in prose outside a fence is left for Hugo to resolve",
+			input: `See {{% notes %}} for details.`,
+			want:  `See {{% notes %}} for details.`,
+		},
+		{
+			name:  "idempotent: already-neutralized fence content is unchanged",
+			input: "```java\nBearer {{ %s|token}}\n```",
+			want:  "```java\nBearer {{ %s|token}}\n```",
+		},
+		{
+			name: "shorter inner fence does not end the outer fence",
+			input: "````markdown\n```\n{{%s|token}}\n```\nstill inside {{<ref>}}\n````\n" +
+				"out {{% notes %}}",
+			want: "````markdown\n```\n{{ %s|token}}\n```\nstill inside {{ <ref>}}\n````\n" +
+				"out {{% notes %}}",
+		},
+		{
+			name:  "tilde fence interior is disarmed",
+			input: "~~~go\n{{<ref>}}\n~~~",
+			want:  "~~~go\n{{ <ref>}}\n~~~",
+		},
+		{
+			name:  "shorter and sibling fence lines inside a longer fence are disarmed",
+			input: "````markdown\n``` {{%s|token}}\n~~~ {{<ref>}}\n````",
+			want:  "````markdown\n``` {{ %s|token}}\n~~~ {{ <ref>}}\n````",
+		},
+		{
+			name:  "four-space indented delimiter inside a fence does not close it",
+			input: "```markdown\n    ```\n{{%s|token}}\n```",
+			want:  "```markdown\n    ```\n{{ %s|token}}\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, string(neutralizeHugoShortcodes([]byte(tt.input))))
+		})
+	}
+}


### PR DESCRIPTION
Stop Hugo from misreading shortcode delimiters inside generated fenced code examples, which was aborting the entire site build.

resourcedocsgen now neutralizes Hugo shortcode delimiters ({{% and {{<) that appear inside fenced code blocks when emitting .md files. Hugo parses shortcodes even inside code fences, so an example snippet like {{%s|token}} (Dynatrace credential-vault syntax plus a Java String.format placeholder) was read as a call to a shortcode named "s", failing the build with 'template for shortcode "s" not found'.

The rewrite is restricted to fence interiors, so legitimate hand-authored shortcodes ({{< chooser >}} / {{% choosable %}}, which only wrap fences from the outside) are untouched. Inline code spans and 4-space-indented code blocks are intentionally outside this change because the current generator surface emits fenced examples.

Neutralization inserts a single space after {{. It needs no delimiter pairing (the offending text often has no matching %}}) and is idempotent. Tradeoff: the inserted space changes the rendered example, so a copied snippet carries an extra space (Bearer {{ %s|token}}). That is harmless to the Java String.format call, but Dynatrace would not accept the resulting vault reference if pasted verbatim. We accept this cosmetic cost over a failing build.

Surfaced by https://github.com/pulumi/registry/issues/11191 (auto-filed workflow failure for the dynatrace@v0.35.2 bump, PR https://github.com/pulumi/registry/pull/11190). The offending {{%s|token}} examples are new in that version (0 occurrences in v0.34.0, 8 in v0.35.2), so the build fails deterministically until this lands on master.

Closes https://github.com/pulumi/registry/issues/11205