### PR TITLE
Clarify which generated package content is committed

### DIFF
--- a/.claude/commands/_common/review-criteria.md
+++ b/.claude/commands/_common/review-criteria.md
@@ -101,5 +101,5 @@ If any of the following files change, flag whether `BUILD-AND-DEPLOY.md` needs u
 - **Spelling and grammar**: Check non-generated content for typos and grammatical errors
 - **Link validation**: Verify URLs are well-formed; flag broken or placeholder links
 - **Newline endings**: Files should end with a trailing newline
-- **No generated content commits**: Never commit files from `themes/default/content/registry/packages/` (these are generated)
+- **Generated content commits**: The `api-docs/` subdirectories under `themes/default/content/registry/packages/<pkg>/` are git-ignored build output — never committed. The `_index.md` and `installation-configuration.md` landing pages there are committed metadata, maintained by the `generate-package-metadata.yml` workflow and bundled when onboarding a package, so committing them is expected; they must be `resourcedocsgen` output, never hand-edited
 - **No secrets**: Flag any file that appears to contain API keys, tokens, or credentials

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Both are compiled to `bin/` by the Makefile. `mktutorial` is CI-only; it does no
 
 The CI build script (`scripts/ci/build.sh`) writes to **`themes/default/content/registry/packages/`**.
 
-This difference is intentional — local API doc generation stays out of the Hugo theme tree. Never commit generated content from `themes/default/content/registry/packages/`.
+This difference is intentional — local API doc generation stays out of the Hugo theme tree. Within `themes/default/content/registry/packages/<pkg>/`, the `api-docs/` subdirectory is regenerated on every build and is git-ignored, so never commit it. The `_index.md` and `installation-configuration.md` landing pages are different: they are committed and maintained by the `generate-package-metadata.yml` publish workflow, and are bundled when onboarding a package so it renders before the next nightly run. Do not hand-edit any of these files; regenerate them with `resourcedocsgen`.
 
 Additionally, `resourcedocsgen` writes **LLM docs** to **`llm-docs-out/registry/packages/`** (repo root, git-ignored). These are terminal-friendly markdown bundles (`llm-docs.json`) uploaded to S3 separately from the Hugo site. The LLM docs format is specified in `docs/llm-markdown-spec.md`.
 
@@ -110,5 +110,5 @@ The `push-registry.py` script publishes packages to the live Pulumi registry ser
 
 - **Package manager**: Yarn only. Do not use npm or pnpm.
 - **Go modules**: `tools/resourcedocsgen/` and `tools/mktutorial/` are separate Go modules. Run `go test ./...` and `golangci-lint run` from within those directories (or use the Makefile targets).
-- **Generated content**: `themes/default/content/registry/packages/` is generated — do not hand-edit files there.
+- **Generated content**: Files under `themes/default/content/registry/packages/` are generated — regenerate with `resourcedocsgen`, never hand-edit. The `api-docs/` subdirectories are git-ignored build output (never committed); the `_index.md` and `installation-configuration.md` pages are committed metadata maintained by the publish workflow.
 - **Branch naming**: Use `<GitHub Username>/<descriptive-name>` for branches in this repository.


### PR DESCRIPTION
## Problem

AGENTS.md and `_common:review-criteria` said, without qualification, to never commit content under `themes/default/content/registry/packages/`. That is inaccurate and caused a registry review on #11241 to flag a valid package onboarding as a convention violation.

## Reality

- `<pkg>/api-docs/` is regenerated by `make api-docs` on every build and is git-ignored. Never committed.
- `<pkg>/_index.md` and `<pkg>/installation-configuration.md` are committed metadata. `scripts/ci/build.sh` does not regenerate them; the `generate-package-metadata.yml` publish workflow does, and commits them (the recurring "Publish Package Metadata for ..." commits). They are bundled when onboarding a package so it renders before the next nightly (#10358 logfire, #11047 coreweave, and all ~300 committed packages have them).

## Change

Replace the blanket "never commit" guidance in AGENTS.md (two places) and `_common:review-criteria` with the accurate `api-docs/` vs landing-pages distinction.