### PR TITLE
Derive package short name from the schema name

### DIFF
--- a/.github/workflows/generate-package-metadata.yml
+++ b/.github/workflows/generate-package-metadata.yml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       prs: ${{ steps.list.outputs.titles }}
   check-for-package-update:
-    name: ${{ matrix.repoSlug }}
+    name: ${{ matrix.repoSlug }} (${{ matrix.schemaFile }})
     needs: generate-packages-list
     runs-on: ubuntu-latest
     strategy:
@@ -45,19 +45,32 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
-      - name: Get provider short name
-        id: regex-prov
+      - name: Read package name from its schema
+        id: package
+        # Read the name from the schema (its source of truth, and its
+        # <name>.yaml filename) rather than deriving it from the repo, so the
+        # several packages a single repo can publish get distinct update PRs.
         run: |
+          package_name_from_schema=""
+          if [[ "$SCHEMA_FILE" == *.json ]]; then
+            package_name_from_schema=$(curl -fsSL "https://raw.githubusercontent.com/${REPO_SLUG}/HEAD/${SCHEMA_FILE}" \
+              | jq -r '.name // empty' 2>/dev/null || true)
+          fi
+          package_name_from_repo=""
           if [[ "$REPO_SLUG" =~ (\/[^-]*-)(.*?$) ]]; then
-            echo "group2=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
-          else
-            echo "Regex pattern match error."
+            package_name_from_repo="${BASH_REMATCH[2]}"
+          fi
+          package_name="${package_name_from_schema:-$package_name_from_repo}"
+          if [[ -z "$package_name" ]]; then
+            echo "Could not determine package name from schema or repoSlug."
             exit 1
           fi
+          echo "name=$package_name" >> $GITHUB_OUTPUT
         env:
           REPO_SLUG: ${{ matrix.repoSlug }}
-      - name: Check if there is already an open PR
-        if: contains(needs.generate-packages-list.outputs.prs, steps.regex-prov.outputs.group2 )
+          SCHEMA_FILE: ${{ matrix.schemaFile }}
+      - name: Skip if this package already has an open update PR
+        if: contains(needs.generate-packages-list.outputs.prs, steps.package.outputs.name )
         id: skip-run
         run: echo "skip=1" >> $GITHUB_OUTPUT
       - name: Check out registry repo
@@ -93,7 +106,7 @@ jobs:
         uses: ./.github/actions/new-provider-version-pr
         with:
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          provider_short_name: ${{ steps.regex-prov.outputs.group2 }}
+          provider_short_name: ${{ steps.package.outputs.name }}
           provider_version: ${{ env.PROVIDER_VERSION }}
 
   notify:


### PR DESCRIPTION
Spun out of the [#11109](https://github.com/pulumi/registry/pull/11109) review (defang).

## Problem

The nightly `generate-package-metadata.yml` derives a provider short name from the repo slug (`pulumi-<name>`). When one repo publishes multiple packages, they all collapse to the same name. [`DefangLabs/pulumi-defang`](https://github.com/DefangLabs/pulumi-defang) ships `defang-aws`, `defang-gcp`, and `defang-azure`, all resolving to `defang`, which causes:

- the PR branch (`<short_name>/<run_id>-<run_number>`) to be identical for all siblings, so they overwrite each other,
- the PR title (`Publish Package Metadata <short_name>@<version>`) to be identical, and
- the open-PR check (`contains(prs, short_name)`) to skip siblings once any one PR is open.

No repo currently publishes more than one package, so this has not surfaced in production yet.

## Fix

Read the short name from the schema's own `name` field (which is also the registry YAML filename), falling back to the repo-slug regex only when the schema name cannot be read (non-JSON schema or fetch failure).

This is the only reliable source: the schema directory is not one (`pulumi-resource-kafkaconnect` -> name `kafka-connect`), and the repo slug is not one for multi-package repos.

### Scope of change (verified against the full list)

`group2` / `provider_short_name` only controls the nightly PR branch, title, and the open-PR skip check. It does not affect the published package name, which comes from the schema `name` via `metadata from-github` (writes `<name>.yaml`) and `push-registry.py` (publishes `{source}/{publisher}/{name}`). So no package is renamed or republished.

- Every existing package: derived name now equals its schema `name`, i.e. its existing `<name>.yaml`. No mislabels.
- `runpod`: corrects a pre-existing mislabel (repo-derived `runpod-native` never matched the real name `runpod`); the published name was and stays `runpod`.
- `defang-aws` / `defang-gcp` / `defang-azure`: now get distinct PRs instead of colliding.

Also includes the schema file in the matrix job name so sibling jobs are distinguishable in the Actions UI.

Validated with `actionlint` and a live `curl + jq` simulation of the derivation across the tricky cases and a sample of normal packages.