### PR TITLE
Fix Defang package logo 404 on /registry/ index

### DIFF
--- a/themes/default/data/registry/packages/defang.yaml
+++ b/themes/default/data/registry/packages/defang.yaml
@@ -5,7 +5,7 @@ component: false
 description: Take your app from Docker Compose to a secure and scalable cloud deployment
   with Pulumi.
 featured: false
-logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
+logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.svg
 name: defang
 native: true
 package_status: ga


### PR DESCRIPTION
## What

Points the Defang package `logo_url` at the existing `docs/logo.svg` instead of the missing `docs/logo.png`.

## Why

DocsBot flagged a broken image on `/registry/`. `defang.yaml`'s `logo_url` pointed at `.../docs/logo.png`, which returns **HTTP 404**. The upstream repo ships `docs/logo.svg` (valid SVG, accepted by the registry), so this points there.

## Will this regression-revert?

No. `logo_url` is regenerated from the provider schema's `logoUrl`, but:
- `defang` isn't in `community-packages/package-list.json`, so the nightly metadata job never touches it.
- Defang's **current** schema already uses `docs/logo.svg`, so the next real re-ingestion would keep `.svg`, not revert to `.png`.

The stale `.png` only survives in the pinned `v1.0.0` schema the registry still references; no upstream change is needed.

Fixes #11226

https://claude.ai/code/session_01UQHdNZBorBEdzL2RyrLXvz