### PR TITLE
Replace hardcoded #1f2557 with var(--color-violet-950) in code styles

### DIFF
--- a/themes/default/theme/src/scss/_code.scss
+++ b/themes/default/theme/src/scss/_code.scss
@@ -30,11 +30,11 @@ pre,
 }
 
 pre {
-    background: #1F2557;
+    background: var(--color-violet-950);
     @apply text-gray-400 py-4 px-5 pr-8 overflow-x-auto leading-normal;
 
     .code-mode-dark & {
-        background: #1f2557;
+        background: var(--color-violet-950);
         @apply border-none shadow-md;
     }
 
@@ -119,7 +119,7 @@ div.highlight.line-numbers {
     @apply shadow-lg;
 
     .code-tabbed-tabs {
-        background: #1f2557;
+        background: var(--color-violet-950);
         @apply shadow-md p-0 flex items-center overflow-hidden;
 
         .code-tabbed-tab {
@@ -149,7 +149,7 @@ div.highlight.line-numbers {
             }
 
             &.active {
-                background: #1f2557;
+                background: var(--color-violet-950);
 
                 .code-tabbed-tab-label {
                     @apply text-white;
@@ -168,7 +168,7 @@ div.highlight.line-numbers {
 
     .code-tabbed-content {
         height: 440px;
-        background: #1f2557;
+        background: var(--color-violet-950);
         @apply overflow-auto relative p-4 text-sm;
 
         .code-tabbed-content-item {
@@ -202,7 +202,7 @@ div.highlight.line-numbers {
     }
 
     .code-tabbed-status {
-        background: #1f2557;
+        background: var(--color-violet-950);
         @apply h-3 rounded-b;
     }
 }


### PR DESCRIPTION
Human Jeff here: minor but was bugging me.

---

Replaces the hardcoded #1f2557 background in code block styles with the brand palette variable var(--color-violet-950), matching the Chroma syntax-highlight background already defined in _chroma.scss.

## Changes
- `pre` backgrounds (light and dark mode) now use `var(--color-violet-950)`
- `.code-tabbed` tabs, active tab, content, and status bar updated to the same variable for consistency