### PR TITLE
Fix long package page titles wrapping behind sidebar card

### DIFF
--- a/themes/default/theme/src/scss/docs/_registry.scss
+++ b/themes/default/theme/src/scss/docs/_registry.scss
@@ -6,7 +6,7 @@
     row-gap: 8px;
 
     .special-h1 {
-        flex: 0 0 auto;
+        flex: 0 1 auto;
     }
 }
 


### PR DESCRIPTION
The title flex item used flex-shrink 0, so long titles could not wrap and overflowed under the right-hand sidebar card. Allow it to shrink.

Closes #11389

| Before | After |
| --- | --- |
| <img width="1191" height="383" alt="Screenshot 2026-06-15 at 2 54 42 PM" src="https://github.com/user-attachments/assets/4d333514-cba5-4ebe-bb76-70e230dd3736" /> | <img width="1191" height="383" alt="Screenshot 2026-06-15 at 2 53 31 PM" src="https://github.com/user-attachments/assets/1918541e-8db7-41b4-8823-1f18f21ff734" /> |
| <img width="1191" height="383" alt="Screenshot 2026-06-15 at 2 54 46 PM" src="https://github.com/user-attachments/assets/74f9ca1a-3364-4859-b5e6-66dbd238ece3" /> | <img width="1191" height="383" alt="Screenshot 2026-06-15 at 2 53 23 PM" src="https://github.com/user-attachments/assets/1c7ac51c-da95-4b0a-9cc0-f3f3b123f355" /> |
| <img width="1191" height="383" alt="Screenshot 2026-06-15 at 2 54 51 PM" src="https://github.com/user-attachments/assets/0308173d-3415-469b-9422-6ab6555e4565" /> | <img width="1191" height="383" alt="Screenshot 2026-06-15 at 2 53 09 PM" src="https://github.com/user-attachments/assets/80ead1cd-9b53-42f5-9a1a-5eab5608fea5" /> |
