### PR TITLE
resourcedocsgen: repair malformed Hugo shortcode delimiters on fetch

### DIFF
--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -676,6 +676,11 @@ func readDocsFile(url string) ([]byte, error) {
 	// Normalize end of line representation
 	content = bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 
+	// Defensively repair malformed Hugo shortcode delimiters (e.g. "{{ <" -> "{{<").
+	// Upstream-generated docs occasionally emit these, and a single malformed
+	// delimiter fails the entire Hugo site build. See sanitizeShortcodeDelimiters.
+	content = sanitizeShortcodeDelimiters(content)
+
 	rest, ok := bytes.CutPrefix(bytes.TrimLeft(content, "\n\t\r "), []byte("---\n"))
 	if !ok {
 		return nil, fmt.Errorf(`expected file %s to start with YAML front-matter ("---\n"), found leading %q`,

--- a/tools/resourcedocsgen/cmd/sanitize.go
+++ b/tools/resourcedocsgen/cmd/sanitize.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "regexp"
+
+// malformedShortcodeOpen matches a Hugo shortcode opening delimiter that has stray
+// whitespace between the braces and the directive marker, e.g. "{{ <" or "{{  %".
+//
+// Hugo requires the marker ("<" for HTML/block shortcodes, "%" for markdown
+// shortcodes) to immediately follow "{{" with no intervening whitespace. A space
+// there makes Hugo stop recognizing the opening tag while still recognizing the
+// paired closing tag, which aborts the entire site build with:
+//
+//	shortcode "X" does not evaluate .Inner or .InnerDeindent, yet a closing tag was provided
+//
+// We have observed upstream-generated docs occasionally emit this malformed form
+// (e.g. registry.opentofu.org-mirrored provider docs). Because a single bad page
+// fails the whole Hugo build, we defensively repair the delimiter on fetch.
+//
+// The pattern is intentionally narrow: it only collapses whitespace that sits
+// between "{{" and a following "<" or "%". A space after "{{" followed by anything
+// else (e.g. a Go template expression "{{ .Value }}") is left untouched, and the
+// closing side (e.g. the legitimate space in `... yaml" >}}`) is never modified.
+var malformedShortcodeOpen = regexp.MustCompile(`\{\{[ \t]+([<%])`)
+
+// sanitizeShortcodeDelimiters repairs malformed Hugo shortcode opening delimiters
+// of the form "{{ <" / "{{ %" back to the well-formed "{{<" / "{{%". It is a
+// no-op for content that is already well-formed.
+func sanitizeShortcodeDelimiters(content []byte) []byte {
+	return malformedShortcodeOpen.ReplaceAll(content, []byte("{{$1"))
+}

--- a/tools/resourcedocsgen/cmd/sanitize_test.go
+++ b/tools/resourcedocsgen/cmd/sanitize_test.go
@@ -1,0 +1,134 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadDocsFileSanitizesShortcodeDelimiters(t *testing.T) {
+	t.Parallel()
+
+	// A docs file whose body contains a malformed chooser block, as has been
+	// observed in upstream-generated (registry.opentofu.org-mirrored) provider docs.
+	body := "---\ntitle: Example\n---\n\n" +
+		"Examples:\n\n" +
+		"{{ < chooser language \"typescript,python\" >}}\n" +
+		"{{ % choosable language typescript %}}\n" +
+		"```typescript\nconst x = 1;\n```\n" +
+		"{{% /choosable %}}\n" +
+		"{{< /chooser >}}\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	got, err := readDocsFile(server.URL)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(got), "{{ <", "malformed opening delimiter must be repaired")
+	assert.NotContains(t, string(got), "{{ %", "malformed opening delimiter must be repaired")
+	assert.Contains(t, string(got), `{{< chooser language "typescript,python" >}}`)
+	assert.Contains(t, string(got), "{{% choosable language typescript %}}")
+	// Surrounding content must be preserved.
+	assert.Contains(t, string(got), "```typescript\nconst x = 1;\n```")
+}
+
+func TestSanitizeShortcodeDelimiters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "opening chooser with stray space",
+			input:    `{{ < chooser language "typescript,python" >}}`,
+			expected: `{{< chooser language "typescript,python" >}}`,
+		},
+		{
+			name:     "opening choosable with stray space",
+			input:    `{{ % choosable language typescript %}}`,
+			expected: `{{% choosable language typescript %}}`,
+		},
+		{
+			name:     "closing chooser with stray space",
+			input:    `{{ < /chooser >}}`,
+			expected: `{{< /chooser >}}`,
+		},
+		{
+			name:     "closing choosable with stray space",
+			input:    `{{ % /choosable %}}`,
+			expected: `{{% /choosable %}}`,
+		},
+		{
+			name:     "multiple stray spaces collapse",
+			input:    `{{   < chooser >}}`,
+			expected: `{{< chooser >}}`,
+		},
+		{
+			name:     "tab between braces and marker",
+			input:    "{{\t% choosable language go %}}",
+			expected: `{{% choosable language go %}}`,
+		},
+		{
+			name:     "already well-formed is unchanged (idempotent)",
+			input:    `{{< chooser language "typescript" >}}`,
+			expected: `{{< chooser language "typescript" >}}`,
+		},
+		{
+			name:     "legitimate trailing space before closing brace is preserved",
+			input:    `{{< chooser language "typescript,python,go,csharp,java,yaml" >}}`,
+			expected: `{{< chooser language "typescript,python,go,csharp,java,yaml" >}}`,
+		},
+		{
+			name: "real megaport-style corrupted block is repaired, code preserved",
+			input: "Examples:\n\n" +
+				"{{ < chooser language \"typescript,python,go,csharp,java,yaml\" >}}\n" +
+				"{{ % choosable language typescript %}}\n" +
+				"```typescript\nconst x = 1; // {{ not a delimiter }}\n```\n" +
+				"{{% /choosable %}}\n" +
+				"{{< /chooser >}}\n",
+			expected: "Examples:\n\n" +
+				"{{< chooser language \"typescript,python,go,csharp,java,yaml\" >}}\n" +
+				"{{% choosable language typescript %}}\n" +
+				"```typescript\nconst x = 1; // {{ not a delimiter }}\n```\n" +
+				"{{% /choosable %}}\n" +
+				"{{< /chooser >}}\n",
+		},
+		{
+			name:     "go template expression in prose is not a shortcode and untouched",
+			input:    "Use the syntax {{ .Value }} in your template.",
+			expected: "Use the syntax {{ .Value }} in your template.",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(sanitizeShortcodeDelimiters([]byte(tt.input)))
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Upstream-generated provider docs (registry.opentofu.org-mirrored packages) have occasionally emitted **malformed Hugo shortcode opening delimiters** — `{{ < chooser` / `{{ % choosable` instead of the well-formed `{{<` / `{{%`. Hugo stops recognizing the spaced opening tag while still recognizing the paired closing tag, aborting the **entire** site build:

```
ERROR error building site: assemble: failed to create page from pageMetaSource
/registry/packages/megaport: ".../megaport/_index.md:2139:1": failed to extract shortcode:
shortcode "choosable" does not evaluate .Inner or .InnerDeindent, yet a closing tag was provided
```

Because one malformed page fails the whole build (and the dev server, which fails the **Test Provider API Docs** browser tests with "Cypress failed to verify that your server is running"), this blocked every preview deploy. It recurred nightly — megaport@1.10.1 produced ~10 red *Publish Package Metadata* PRs (#11369, #11372, #11374, #11377, #11381, #11392, …).

The corruption is **not** present in megaport's repo and is gone from the live mirror today (it was re-rendered clean), i.e. it originated upstream as a transient and we copied it verbatim. Since a single bad page is fatal and we can't control the upstream generator, we guard at the fetch boundary.

## Fix

Repair the delimiter in `readDocsFile`, right after the existing CRLF normalization, so a malformed upstream render can never be committed or break the build.

The regex (`\{\{[ \t]+([<%])`) is intentionally narrow: it only collapses whitespace between `{{` and a following `<`/`%` marker. It leaves Go-template expressions like `{{ .Value }}` and the legitimate space in `... >}}` untouched.

## Tests

- `TestSanitizeShortcodeDelimiters` — 11 cases: both markers, opening/closing, multi-space, tab, idempotent, legitimate `>}}` space preserved, real megaport block, and a Go-template negative case.
- `TestReadDocsFileSanitizesShortcodeDelimiters` — httptest integration test proving fetched content is repaired end-to-end.

Full `resourcedocsgen` suite green; `go vet` + `gofmt` clean.

## Notes

Defense-in-depth at the doc generator (`pulumi/pulumi-terraform-bridge` `plainDocsParser`) is prepared separately; this PR is the guard that protects the registry build regardless of where a malformed delimiter originates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)