### PR TITLE
Harden the package-publish pipeline against stuck/corrupted PRs

### DIFF
--- a/.github/actions/new-provider-version-pr/action.yml
+++ b/.github/actions/new-provider-version-pr/action.yml
@@ -25,11 +25,8 @@ runs:
           commit-message: "Publish Package Metadata for ${{ inputs.provider_short_name }}@${{ inputs.provider_version }}"
           title: "Publish Package Metadata ${{ inputs.provider_short_name }}@${{ inputs.provider_version }}"
           body: ""
-          # Stable, per-provider branch so each run UPDATES the existing PR instead
-          # of opening a new one. Previously this embedded ${{ github.run_id }}, which
-          # produced a fresh branch+PR every run and let failing publishes pile up
-          # (e.g. 24 stacked megaport PRs). One open PR per provider, auto-replaced
-          # when a newer (or fixed) render is generated.
+          # Stable per-provider branch so create-pull-request updates one PR per
+          # provider instead of opening a new one each run.
           branch: "${{ inputs.provider_short_name }}/publish-metadata"
       - if: steps.create-pr.outputs.pull-request-operation == 'created'
         name: Set Automerge

--- a/.github/actions/new-provider-version-pr/action.yml
+++ b/.github/actions/new-provider-version-pr/action.yml
@@ -25,7 +25,12 @@ runs:
           commit-message: "Publish Package Metadata for ${{ inputs.provider_short_name }}@${{ inputs.provider_version }}"
           title: "Publish Package Metadata ${{ inputs.provider_short_name }}@${{ inputs.provider_version }}"
           body: ""
-          branch: "${{ inputs.provider_short_name }}/${{ github.run_id }}-${{ github.run_number }}"
+          # Stable, per-provider branch so each run UPDATES the existing PR instead
+          # of opening a new one. Previously this embedded ${{ github.run_id }}, which
+          # produced a fresh branch+PR every run and let failing publishes pile up
+          # (e.g. 24 stacked megaport PRs). One open PR per provider, auto-replaced
+          # when a newer (or fixed) render is generated.
+          branch: "${{ inputs.provider_short_name }}/publish-metadata"
       - if: steps.create-pr.outputs.pull-request-operation == 'created'
         name: Set Automerge
         uses: peter-evans/enable-pull-request-automerge@v3

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,15 @@ lint: lint-go lint-markdown
 	yarn run lint
 
 .PHONY: lint-markdown
-lint-markdown:
+lint-markdown: lint-shortcode-delimiters
 	./scripts/lint/lint-markdown.js
+
+# Fails fast on malformed Hugo shortcode delimiters ("{{ <" / "{{ %") in any
+# content file, including the auto-generated provider _index.md pages that the
+# front-matter linter skips. A single malformed delimiter fails the whole site build.
+.PHONY: lint-shortcode-delimiters
+lint-shortcode-delimiters:
+	./scripts/lint/check-shortcode-delimiters.js
 
 .PHONY: lint-go
 lint-go: lint-resourcedocsgen lint-mktutorial

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,8 @@ lint: lint-go lint-markdown
 lint-markdown: lint-shortcode-delimiters
 	./scripts/lint/lint-markdown.js
 
-# Fails fast on malformed Hugo shortcode delimiters ("{{ <" / "{{ %") in any
-# content file, including the auto-generated provider _index.md pages that the
-# front-matter linter skips. A single malformed delimiter fails the whole site build.
+# The auto-generated provider _index.md pages are skipped by the front-matter
+# linter, yet a single malformed shortcode delimiter there fails the whole site build.
 .PHONY: lint-shortcode-delimiters
 lint-shortcode-delimiters:
 	./scripts/lint/check-shortcode-delimiters.js

--- a/scripts/lint/check-shortcode-delimiters.js
+++ b/scripts/lint/check-shortcode-delimiters.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Fails if any registry content contains a malformed Hugo shortcode opening
+ * delimiter, e.g. "{{ < chooser" or "{{ % choosable" instead of "{{<" / "{{%".
+ *
+ * Hugo requires the marker ("<" for HTML/block shortcodes, "%" for markdown
+ * shortcodes) to immediately follow "{{". A stray space makes Hugo stop
+ * recognizing the opening tag while still recognizing the paired closing tag,
+ * which aborts the ENTIRE site build:
+ *
+ *     shortcode "X" does not evaluate .Inner or .InnerDeindent, yet a closing
+ *     tag was provided
+ *
+ * Because a single malformed page is fatal, and because the auto-generated
+ * provider `_index.md` files (which carry the "fetched from" header) are skipped
+ * by the front-matter linter, this dedicated check scans every markdown file so
+ * the failure surfaces as a clear, local lint error instead of a cryptic
+ * whole-site build abort. The matching mirrors resourcedocsgen's
+ * sanitizeShortcodeDelimiters guard.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// Matches "{{" followed by one or more spaces/tabs and then a "<" or "%" marker.
+// Narrow on purpose: a space after "{{" followed by anything else (e.g. a Go
+// template expression "{{ .Value }}") is not matched, and the closing side
+// (the legitimate space in `... >}}`) is never touched.
+const MALFORMED_DELIMITER = /\{\{[ \t]+[<%]/;
+
+/**
+ * Returns the malformed shortcode delimiters found in the given file content.
+ * @param {string} content
+ * @returns {{line: number, text: string}[]}
+ */
+function findMalformedShortcodeDelimiters(content) {
+    const hits = [];
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        if (MALFORMED_DELIMITER.test(lines[i])) {
+            hits.push({ line: i + 1, text: lines[i].trim() });
+        }
+    }
+    return hits;
+}
+
+/**
+ * Recursively collects all `.md` files under a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collectMarkdownFiles(dir) {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            out.push(...collectMarkdownFiles(full));
+        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+function main() {
+    const contentDir = path.resolve(__dirname, "../../themes/default/content");
+    const files = collectMarkdownFiles(contentDir);
+
+    const problems = [];
+    for (const file of files) {
+        const hits = findMalformedShortcodeDelimiters(fs.readFileSync(file, "utf8"));
+        for (const hit of hits) {
+            problems.push(`${file}:${hit.line}: ${hit.text}`);
+        }
+    }
+
+    if (problems.length > 0) {
+        console.error(
+            `\nMalformed Hugo shortcode delimiter check:\n` +
+                `    - ${files.length} files scanned.\n` +
+                `    - ${problems.length} malformed delimiter(s) found ` +
+                `(expected "{{<" / "{{%", not "{{ <" / "{{ %"):\n\n` +
+                problems.map((p) => `  ${p}`).join("\n") +
+                `\n`,
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `\nMalformed Hugo shortcode delimiter check:\n` +
+            `    - ${files.length} files scanned.\n` +
+            `    - 0 malformed delimiters found.\n`,
+    );
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = { findMalformedShortcodeDelimiters };

--- a/scripts/lint/check-shortcode-delimiters.js
+++ b/scripts/lint/check-shortcode-delimiters.js
@@ -2,39 +2,17 @@
 "use strict";
 
 /**
- * Fails if any registry content contains a malformed Hugo shortcode opening
- * delimiter, e.g. "{{ < chooser" or "{{ % choosable" instead of "{{<" / "{{%".
- *
- * Hugo requires the marker ("<" for HTML/block shortcodes, "%" for markdown
- * shortcodes) to immediately follow "{{". A stray space makes Hugo stop
- * recognizing the opening tag while still recognizing the paired closing tag,
- * which aborts the ENTIRE site build:
- *
- *     shortcode "X" does not evaluate .Inner or .InnerDeindent, yet a closing
- *     tag was provided
- *
- * Because a single malformed page is fatal, and because the auto-generated
- * provider `_index.md` files (which carry the "fetched from" header) are skipped
- * by the front-matter linter, this dedicated check scans every markdown file so
- * the failure surfaces as a clear, local lint error instead of a cryptic
- * whole-site build abort. The matching mirrors resourcedocsgen's
- * sanitizeShortcodeDelimiters guard.
+ * A stray space in a shortcode delimiter ("{{ <" instead of "{{<") aborts the
+ * entire Hugo build. The front-matter linter skips the auto-generated provider
+ * `_index.md` files where this tends to appear, so scan every markdown file.
+ * Mirrors resourcedocsgen's sanitizeShortcodeDelimiters guard.
  */
 
 const fs = require("fs");
 const path = require("path");
 
-// Matches "{{" followed by one or more spaces/tabs and then a "<" or "%" marker.
-// Narrow on purpose: a space after "{{" followed by anything else (e.g. a Go
-// template expression "{{ .Value }}") is not matched, and the closing side
-// (the legitimate space in `... >}}`) is never touched.
 const MALFORMED_DELIMITER = /\{\{[ \t]+[<%]/;
 
-/**
- * Returns the malformed shortcode delimiters found in the given file content.
- * @param {string} content
- * @returns {{line: number, text: string}[]}
- */
 function findMalformedShortcodeDelimiters(content) {
     const hits = [];
     const lines = content.split("\n");
@@ -46,11 +24,6 @@ function findMalformedShortcodeDelimiters(content) {
     return hits;
 }
 
-/**
- * Recursively collects all `.md` files under a directory.
- * @param {string} dir
- * @returns {string[]}
- */
 function collectMarkdownFiles(dir) {
     const out = [];
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/scripts/lint/check-shortcode-delimiters.js
+++ b/scripts/lint/check-shortcode-delimiters.js
@@ -70,7 +70,9 @@ function main() {
 
     const problems = [];
     for (const file of files) {
-        const hits = findMalformedShortcodeDelimiters(fs.readFileSync(file, "utf8"));
+        const hits = findMalformedShortcodeDelimiters(
+            fs.readFileSync(file, "utf8"),
+        );
         for (const hit of hits) {
             problems.push(`${file}:${hit.line}: ${hit.text}`);
         }

--- a/scripts/lint/check-shortcode-delimiters.test.js
+++ b/scripts/lint/check-shortcode-delimiters.test.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { findMalformedShortcodeDelimiters } = require("./check-shortcode-delimiters.js");
+
+test("flags a malformed opening chooser delimiter", () => {
+    const content = 'intro\n\n{{ < chooser language "typescript" >}}\nbody\n';
+    const hits = findMalformedShortcodeDelimiters(content);
+    assert.deepStrictEqual(hits, [
+        { line: 3, text: '{{ < chooser language "typescript" >}}' },
+    ]);
+});
+
+test("flags a malformed opening choosable delimiter", () => {
+    const hits = findMalformedShortcodeDelimiters("{{ % choosable language go %}}\n");
+    assert.strictEqual(hits.length, 1);
+    assert.strictEqual(hits[0].line, 1);
+});
+
+test("flags multiple malformed delimiters with correct line numbers", () => {
+    const content =
+        "{{< chooser language \"typescript\" >}}\n" +
+        "{{ < chooser language \"go\" >}}\n" +
+        "ok\n" +
+        "{{ % choosable language python %}}\n";
+    const hits = findMalformedShortcodeDelimiters(content);
+    assert.deepStrictEqual(
+        hits.map((h) => h.line),
+        [2, 4],
+    );
+});
+
+test("does not flag well-formed delimiters", () => {
+    const content =
+        '{{< chooser language "typescript,python,go,csharp,java,yaml" >}}\n' +
+        "{{% choosable language typescript %}}\n" +
+        "{{% /choosable %}}\n" +
+        "{{< /chooser >}}\n";
+    assert.deepStrictEqual(findMalformedShortcodeDelimiters(content), []);
+});
+
+test("does not flag a Go template expression in prose", () => {
+    assert.deepStrictEqual(
+        findMalformedShortcodeDelimiters("Use {{ .Value }} in your template.\n"),
+        [],
+    );
+});
+
+test("flags a malformed closing delimiter", () => {
+    const hits = findMalformedShortcodeDelimiters("{{ < /chooser >}}\n");
+    assert.strictEqual(hits.length, 1);
+});

--- a/scripts/lint/check-shortcode-delimiters.test.js
+++ b/scripts/lint/check-shortcode-delimiters.test.js
@@ -3,7 +3,9 @@
 
 const { test } = require("node:test");
 const assert = require("node:assert");
-const { findMalformedShortcodeDelimiters } = require("./check-shortcode-delimiters.js");
+const {
+    findMalformedShortcodeDelimiters,
+} = require("./check-shortcode-delimiters.js");
 
 test("flags a malformed opening chooser delimiter", () => {
     const content = 'intro\n\n{{ < chooser language "typescript" >}}\nbody\n';
@@ -14,15 +16,17 @@ test("flags a malformed opening chooser delimiter", () => {
 });
 
 test("flags a malformed opening choosable delimiter", () => {
-    const hits = findMalformedShortcodeDelimiters("{{ % choosable language go %}}\n");
+    const hits = findMalformedShortcodeDelimiters(
+        "{{ % choosable language go %}}\n",
+    );
     assert.strictEqual(hits.length, 1);
     assert.strictEqual(hits[0].line, 1);
 });
 
 test("flags multiple malformed delimiters with correct line numbers", () => {
     const content =
-        "{{< chooser language \"typescript\" >}}\n" +
-        "{{ < chooser language \"go\" >}}\n" +
+        '{{< chooser language "typescript" >}}\n' +
+        '{{ < chooser language "go" >}}\n' +
         "ok\n" +
         "{{ % choosable language python %}}\n";
     const hits = findMalformedShortcodeDelimiters(content);
@@ -43,7 +47,9 @@ test("does not flag well-formed delimiters", () => {
 
 test("does not flag a Go template expression in prose", () => {
     assert.deepStrictEqual(
-        findMalformedShortcodeDelimiters("Use {{ .Value }} in your template.\n"),
+        findMalformedShortcodeDelimiters(
+            "Use {{ .Value }} in your template.\n",
+        ),
         [],
     );
 });

--- a/tools/resourcedocsgen/cmd/cache_test.go
+++ b/tools/resourcedocsgen/cmd/cache_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// readRemoteFile should ask intermediary caches/CDNs to revalidate, so the
-// publish pipeline is less likely to fetch a stale (e.g. corrupted) edge object.
 func TestReadRemoteFileSendsNoCacheHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/tools/resourcedocsgen/cmd/cache_test.go
+++ b/tools/resourcedocsgen/cmd/cache_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readRemoteFile should ask intermediary caches/CDNs to revalidate, so the
+// publish pipeline is less likely to fetch a stale (e.g. corrupted) edge object.
+func TestReadRemoteFileSendsNoCacheHeaders(t *testing.T) {
+	t.Parallel()
+
+	var gotCacheControl, gotPragma string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCacheControl = r.Header.Get("Cache-Control")
+		gotPragma = r.Header.Get("Pragma")
+		_, err := w.Write([]byte("ok"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	_, err := readRemoteFile(server.URL, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "no-cache", gotCacheControl)
+	assert.Equal(t, "no-cache", gotPragma)
+}

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -425,7 +425,6 @@ func readRemoteFile(url, repoOwner string) ([]byte, error) {
 		return nil, errors.Wrapf(err, "creating request for %q", url)
 	}
 
-	// Ask intermediary caches/CDNs to revalidate rather than serve a stale copy.
 	// Mirror-hosted docs are occasionally re-rendered upstream; without this we can
 	// fetch a stale (e.g. corrupted) edge object even after the origin is fixed.
 	req.Header.Set("Cache-Control", "no-cache")

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -425,6 +425,12 @@ func readRemoteFile(url, repoOwner string) ([]byte, error) {
 		return nil, errors.Wrapf(err, "creating request for %q", url)
 	}
 
+	// Ask intermediary caches/CDNs to revalidate rather than serve a stale copy.
+	// Mirror-hosted docs are occasionally re-rendered upstream; without this we can
+	// fetch a stale (e.g. corrupted) edge object even after the origin is fixed.
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Pragma", "no-cache")
+
 	pkg.AddGitHubAuthHeaders(req)
 
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
Follow-up to #11410. After megaport@1.10.1 stacked **24 failing publish PRs** (and ~25 auto-filed failure issues) over two weeks from a single malformed Hugo shortcode delimiter, these three independent changes harden the pipeline so it can't happen the same way again. Each is small and self-contained.

## P1 — One PR per provider instead of one per run
`new-provider-version-pr` embedded `${{ github.run_id }}` in the branch name, so **every** publish run opened a fresh branch + PR. A persistently failing publish therefore piled up indefinitely (24 megaport PRs).

Switch to a **stable per-provider branch** (`<provider>/publish-metadata`). `peter-evans/create-pull-request` then *updates* the existing PR each run, so there's at most one open publish PR per provider and a fixed/newer render auto-replaces a broken one.

## P2 — Fail fast on malformed delimiters, everywhere
A single `{{ <` / `{{ %` (stray space) aborts the **entire** Hugo site build with a cryptic shortcode error — and the existing front-matter linter *skips* the auto-generated provider `_index.md` files (those carrying the `# WARNING: this file was fetched from` header), which are exactly the ones that get corrupted.

New `scripts/lint/check-shortcode-delimiters.js` scans every content markdown file for malformed opening delimiters and fails with a clear `file:line` message. Wired into `make lint-markdown`, so the existing **Lint Markdown** CI job runs it on every PR. The matcher mirrors `resourcedocsgen`'s `sanitizeShortcodeDelimiters` and is unit-tested with `node:test` (6 cases, incl. a Go-template `{{ .Value }}` negative case).

## P3 — Avoid stale CDN edges on fetch
The original corruption reached us via a **stale CloudFront edge** serving a pre-re-render object even after the origin was fixed. `readRemoteFile` now sends `Cache-Control: no-cache` / `Pragma: no-cache` so intermediary caches revalidate. (CloudFront may ignore client no-cache depending on config, so this is a low-cost mitigation on top of the #11410 guard, not a guarantee.)

## Tests
- `cmd`: `TestReadRemoteFileSendsNoCacheHeaders` (httptest asserts the request headers) + existing guard tests — full `resourcedocsgen` suite green; `go vet`/`gofmt` clean.
- `scripts/lint`: `node --test check-shortcode-delimiters.test.js` → 6/6; `make lint-shortcode-delimiters` green on the current tree (819 files, 0 malformed) and exits 1 on an injected malformed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)