### PR TITLE
Stop link checker from flagging false-positive AI deep links

### DIFF
--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -258,7 +258,7 @@ function getDefaultExcludedKeywords() {
         "https://github.com/marketplace*",
 
         // API base URL referenced in the airbyte provider's upstream README; 401s without auth.
-        "https://api.airbyte.com/",
+        "https://api.airbyte.com/*",
     ];
 }
 

--- a/scripts/link-checker/check-links.js
+++ b/scripts/link-checker/check-links.js
@@ -247,6 +247,18 @@ function getDefaultExcludedKeywords() {
         "https://www.noaa.gov/information-technology/open-data-dissemination",
         "https://www.inc.com/inc5000/2023",
         "https://nodejs.org/en/download/package-manager",
+
+        // "Use with AI" deep links (copy-llm-prompt.html). These open a prefilled prompt in a
+        // browser chat session; the services reject the headless link checker with 403s.
+        "https://chatgpt.com/*",
+        "https://claude.ai/*",
+        "https://v0.dev/*",
+
+        // GitHub's own nav chrome on github.com/pulumi/pulumi, which the checker crawls directly.
+        "https://github.com/marketplace*",
+
+        // API base URL referenced in the airbyte provider's upstream README; 401s without auth.
+        "https://api.airbyte.com/",
     ];
 }
 
@@ -261,6 +273,16 @@ function excludeAcceptable(links) {
                     !(
                         b.reason === "HTTP_429" &&
                         b.destination.match(/github.com|npmjs.com/)
+                    ),
+            )
+
+            // Ignore npm 403s. npm bot-blocks the checker; a genuinely missing package returns
+            // 404 (still reported), not 403.
+            .filter(
+                (b) =>
+                    !(
+                        b.reason === "HTTP_403" &&
+                        b.destination.match(/npmjs.com/)
                     ),
             )
 


### PR DESCRIPTION
## What & why

The scheduled link checker (`.github/workflows/check-links.yml` → `scripts/link-checker/check-links.js`, built on `broken-link-checker`) posts reports to `#registry-ops`. The recent reports are dominated by **false positives**, not real breakage.

Root cause: the **"Use with AI"** dropdown (`themes/default/layouts/partials/registry/package/copy-llm-prompt.html`) renders crawlable `<a href>` deep links on **every** registry package page and `installation-configuration` page:

- `https://chatgpt.com/?q=…` → HTTP 403
- `https://claude.ai/new?q=…` → HTTP 403
- `https://v0.dev/chat?q=…` → HTTP 403

These links work fine in a real browser — the AI chat services simply reject the headless checker bot (`pulumi+blc/0.1`). Because the dropdown is on hundreds of pages, they flood the report.

The same report surfaces a few other bot-hostile false positives:

- `https://www.npmjs.com/package/@…` → 403 (npm blocks the bot; the script only suppressed npm **429** before)
- `https://github.com/marketplace` → 400 (GitHub's own page chrome, surfaced because the script explicitly crawls `github.com/pulumi/pulumi`)
- `https://api.airbyte.com/v1` → 401 (API base URL referenced in the airbyte provider's upstream README)

## Changes

All in `scripts/link-checker/check-links.js`:

1. Add `chatgpt.com`, `claude.ai`, `v0.dev`, `github.com/marketplace`, and `api.airbyte.com` to the existing `getDefaultExcludedKeywords()` allowlist (which already ignores YouTube, LinkedIn, Twitter, Vultr, Azure portal, etc.).
2. Treat npm **403** as acceptable in `excludeAcceptable()`, alongside the existing npm/github 429 handling. A genuinely missing package returns 404 (still reported), not 403.

**No template/UX changes** — the AI deep links are a wanted feature and stay as real `href`s for accessibility and open-in-new-tab. Real link breakage continues to be reported.

## Verification

- `node --check scripts/link-checker/check-links.js` passes.
- The checker only runs against the live deployed site, so the real validation is the next scheduled run (Mondays 15:00 UTC) or a manual dispatch: the chatgpt.com / claude.ai / v0.dev / npm-403 / github.com/marketplace entries should no longer appear in `#registry-ops`.
