### PR TITLE
Point docs top-nav Get Started CTA at app.pulumi.com/signup

### DIFF
--- a/themes/default/data/docs_nav.yaml
+++ b/themes/default/data/docs_nav.yaml
@@ -39,5 +39,5 @@ cta:
   dashboard: { label: Dashboard,  href: https://app.pulumi.com,        track: header-dashboard             }
   getStarted:
     label: Get started
-    href: /docs/get-started/
+    href: https://app.pulumi.com/signup
     track: get-started-practitioner-nav


### PR DESCRIPTION
## What

Updates the **Get started** CTA in the docs top nav to point at `https://app.pulumi.com/signup` instead of `/docs/get-started/`.

## Why

`https://app.pulumi.com/signup` is the conversion target used on pulumi.com, so the registry/docs top nav should match it and send practitioners straight into signup.

## How

The docs top nav is data-driven — `themes/default/layouts/partials/docs-top-nav.html` renders the CTA from `$nav.cta.getStarted.href` in `site.Data.docs_nav`. So the change is a single edit in `themes/default/data/docs_nav.yaml`:

```diff
   getStarted:
     label: Get started
-    href: /docs/get-started/
+    href: https://app.pulumi.com/signup
     track: get-started-practitioner-nav
```

The `data-track="get-started-practitioner-nav"` attribute is unchanged, so analytics tracking continues uninterrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)