### PR TITLE
Add firstatlast/pulumi-exedev community package

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -379,6 +379,10 @@
     {
       "repoSlug": "rpothin/pulumi-powerplatform",
       "schemaFile": "schema.json"
+    },
+    {
+      "repoSlug": "firstatlast/pulumi-exedev",
+      "schemaFile": "provider/cmd/pulumi-resource-exedev/schema.json"
     }
   ]
 }


### PR DESCRIPTION
Adds the **exe.dev** provider to the community package list.

- **Repo:** https://github.com/firstatlast/pulumi-exedev
- **Publisher:** firstatlast
- **Latest release:** [v0.2.0](https://github.com/firstatlast/pulumi-exedev/releases/tag/v0.2.0) (multi-platform plugin binaries attached)
- **Schema:** `provider/cmd/pulumi-resource-exedev/schema.json` (committed on `main`)

A native (pulumi-go-provider) provider for managing [exe.dev](https://exe.dev) VMs — `exedev:index:Vm` and `exedev:index:Domain`. The schema sets `pluginDownloadURL` to the repo's GitHub Releases, and the repo includes the required `docs/_index.md` and `docs/installation-configuration.md`.

Checklist:
- [x] `docs/_index.md` with per-language examples
- [x] `docs/installation-configuration.md`
- [x] `vX.Y.Z` GitHub release (v0.2.0)
- [x] Committed schema referenced by `schemaFile`