### PR TITLE
Remove stale "in preview" notice for pulumiservice provider

### DIFF
--- a/themes/default/layouts/partials/registry/package/package-alert.html
+++ b/themes/default/layouts/partials/registry/package/package-alert.html
@@ -78,16 +78,4 @@
             These are the docs for Azure Native v2. We recommend using the latest version, <a class="text-violet-primary hover:underline" href="/registry/packages/azure-native/">Azure Native v3</a>.
         </span>
     </div>
-    {{ else if (eq $package "pulumiservice") }}
-    <div class="note note-info">
-        <div class="icon-and-line">
-            {{ partial "icon" (dict "name" "info" "weight" "fill") }}
-            <div class="line"></div>
-        </div>
-        <div>
-            <p>
-                This provider is currently in preview.
-            </p>
-        </div>
-    </div>
 {{ end }}


### PR DESCRIPTION
## Summary

The `pulumiservice` provider package page shows a banner stating "This provider is currently in preview." This is no longer accurate — the provider's YAML metadata lists `package_status: ga` (currently at `v1.3.0`), so it has graduated from preview.

This removes the `pulumiservice` branch from `package-alert.html` that renders the stale notice.

## Testing

- Verified `themes/default/data/registry/packages/pulumiservice.yaml` has `package_status: ga`.
- Confirmed no other references to the preview message exist elsewhere in the repo.

Closes https://github.com/pulumi/pulumi-pulumiservice/issues/962


---
*Created with [Eon](https://eon.corp.pulumi.com/session/ffad9a2966a247e34037035999c021cc)*