### PR TITLE
Onboard atensecurity/pulumi-thoth at v0.1.14

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -395,6 +395,10 @@
     {
       "repoSlug": "DefangLabs/pulumi-defang",
       "schemaFile": "provider/cmd/pulumi-resource-defang-azure/schema.json"
+    },
+    {
+      "repoSlug": "atensecurity/pulumi-thoth",
+      "schemaFile": "provider/cmd/pulumi-resource-thoth/schema.json"
     }
   ]
 }

--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -47,6 +47,7 @@
     "airbytehq": "airbytehq",
     "akeyless-community": "akeyless-community",
     "aptible": "aptible",
+    "Aten Security": "atensecurity",
     "athenz": "athenz",
     "azaurus1": "azaurus1",
     "Byteplus": "Byteplus",


### PR DESCRIPTION
Continues #11056 by re-applying @ch3ck / Aten Security's package-list entry on a maintainer branch (fork PRs can't run our publish/preview CI) and bundling the generated metadata.

thoth is a bridged provider, onboarded at v0.1.14. Full review passed:
- SDKs published and matching the schema: npm `@atensec/pulumi-thoth`, PyPI `pulumi-thoth`, NuGet `AtenSecurity.Pulumi.Thoth` (all 0.1.14)
- Plugin archives named correctly; `pulumi plugin install resource thoth v0.1.14` succeeds in a clean sandbox
- Both `docs/_index.md` and `docs/installation-configuration.md` carry front-matter, so metadata bundles cleanly (the last blocker on #11056, fixed upstream in v0.1.14)
- Added `Aten Security` to the publisher allowlist

Closes #11056.

Non-blocking follow-up: the schema declares no `logoUrl`, so the package page shows a placeholder until Aten Security adds one.
