### PR TITLE
Add on-demand site previews for community-package PRs

### DIFF
--- a/.github/actions/build-and-deploy-preview/action.yml
+++ b/.github/actions/build-and-deploy-preview/action.yml
@@ -1,0 +1,127 @@
+name: Build and deploy registry preview
+description: >-
+  Build the registry site and deploy a preview to S3. Shared by the pull_request preview job
+  and the community-package /preview command. Pass `pr` to first materialize that PR's
+  community-package entry (used for fork PRs, whose own pull_request build gets no secrets).
+
+inputs:
+  github_token:
+    required: true
+  pulumi_stack_name:
+    required: true
+  algolia_app_id:
+    required: true
+  algolia_app_search_key:
+    required: true
+  pr:
+    description: Community-package PR to materialize before building (fork previews).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
+
+    - name: Install Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24.x"
+        cache: 'yarn'
+        cache-dependency-path: |
+          yarn.lock
+          infrastructure/yarn.lock
+          themes/default/yarn.lock
+          themes/default/theme/yarn.lock
+          themes/default/theme/stencil/yarn.lock
+
+    - name: Install Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: 1.26.x
+
+    - name: Install Hugo
+      uses: peaceiris/actions-hugo@v3
+      with:
+        hugo-version: "0.157.0"
+        extended: true
+
+    - name: Materialize the community-package PR entry
+      if: inputs.pr != ''
+      shell: bash
+      env:
+        PR: ${{ inputs.pr }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        REPO: ${{ github.repository }}
+      run: |
+        # Bring the PR's package-list entry and generated metadata into the tree, and shim the
+        # event so `make ci-pull-request` keys the bucket, URL and PR comment to this PR.
+        gh api "repos/$REPO/pulls/$PR" > /tmp/pr.json
+        jq -n --slurpfile pr /tmp/pr.json '{number: $pr[0].number, pull_request: $pr[0]}' > /tmp/pr-event.json
+        echo "GITHUB_EVENT_NAME=pull_request" >> "$GITHUB_ENV"
+        echo "GITHUB_EVENT_PATH=/tmp/pr-event.json" >> "$GITHUB_ENV"
+        python3 scripts/ci/community-package/cli.py preview --pr "$PR"
+
+    - name: Validate JSON file syntax
+      uses: limitusus/json-syntax-check@v2
+      with:
+        pattern: "community-packages/package-list.json"
+
+    - name: Yarn Install
+      shell: bash
+      run: yarn install
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: us-west-2
+        role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
+        role-duration-seconds: 7200
+        role-session-name: RegistryPreviewSession
+
+    - name: Install s5cmd for fast S3 uploads
+      shell: bash
+      run: |
+        S5CMD_VERSION="2.3.0"
+        S5CMD_SHA256="de0fdbfa3aceae55e069ba81a0fc17b2026567637603734a387b2fca06c299b4"
+        curl -fsSL -o /tmp/s5cmd.tar.gz "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz"
+        echo "${S5CMD_SHA256}  /tmp/s5cmd.tar.gz" | sha256sum --check --strict
+        sudo tar -xz -C /usr/local/bin s5cmd < /tmp/s5cmd.tar.gz
+
+    - name: Configure git for private Go modules
+      shell: bash
+      run: git config --global url."https://${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/registry-mirror-tools".insteadOf "https://github.com/pulumi/registry-mirror-tools"
+
+    - name: Cache provider schemas and generated docs
+      uses: actions/cache@v6
+      with:
+        path: |
+          .cache/schemas
+          .cache/versioned-docs
+          .cache/api-docs
+        key: docs-cache-${{ github.run_id }}
+        restore-keys: docs-cache-
+
+    - name: Get registry-mirror-discover version
+      id: mirror-version
+      shell: bash
+      run: echo "hash=$(grep 'REGISTRY_MIRROR_TOOLS_COMMIT=' scripts/generate-versioned-docs.sh | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache registry-mirror-discover binary
+      uses: actions/cache@v6
+      with:
+        path: bin/registry-mirror-discover
+        key: registry-mirror-discover-${{ steps.mirror-version.outputs.hash }}
+
+    - name: Build and deploy preview
+      shell: bash
+      run: make ci-pull-request
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+        PULUMI_STACK_NAME: ${{ inputs.pulumi_stack_name }}
+        NODE_OPTIONS: "--max_old_space_size=8192"
+        ALGOLIA_APP_ID: ${{ inputs.algolia_app_id }}
+        ALGOLIA_APP_SEARCH_KEY: ${{ inputs.algolia_app_search_key }}

--- a/.github/workflows/community-package-preview-command.yml
+++ b/.github/workflows/community-package-preview-command.yml
@@ -1,0 +1,47 @@
+# On-demand site preview for a community-package PR, including fork PRs. A fork's own
+# pull_request build gets no secrets, so a maintainer triggers this instead (a /preview comment
+# or a manual run). It reuses the registry's preview build (the build-and-deploy-preview
+# action), materializing the fork's entry as data first, and never runs the fork's code.
+name: Community package /preview command
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to build a preview for
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: community-package-preview-${{ github.event.issue.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != null &&
+       (github.event.comment.body == '/preview' || startsWith(github.event.comment.body, '/preview ')) &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: pulumi-service-ubuntu-24.04-16core
+    environment: testing
+    env:
+      GOPATH: ${{ github.workspace }}/go
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/build-and-deploy-preview
+        with:
+          pr: ${{ github.event.issue.number || inputs.pr }}
+          github_token: ${{ github.token }}
+          pulumi_stack_name: ${{ vars.PULUMI_STACK_NAME }}
+          algolia_app_id: ${{ vars.ALGOLIA_APP_ID }}
+          algolia_app_search_key: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -168,94 +168,18 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     steps:
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
       - name: Check out branch
         uses: actions/checkout@v7
         with:
           # Full history needed for registry-mirror-discover to find package versions
           fetch-depth: 0
 
-      - name: Install Node
-        uses: actions/setup-node@v6
+      - uses: ./.github/actions/build-and-deploy-preview
         with:
-          node-version: "24.x"
-          cache: 'yarn'
-          cache-dependency-path: |
-            yarn.lock
-            infrastructure/yarn.lock
-            themes/default/yarn.lock
-            themes/default/theme/yarn.lock
-            themes/default/theme/stencil/yarn.lock
-
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.26.x
-
-      - name: Install Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: "0.157.0"
-          extended: true
-
-      - name: Validate JSON file syntax
-        uses: limitusus/json-syntax-check@v2
-        with:
-          pattern: "community-packages/package-list.json"
-
-      - name: Yarn Install
-        run: yarn install
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::571684982431:role/ContinuousDelivery
-          role-duration-seconds: 7200
-          role-session-name: PullRequestPreviewSession
-
-      - name: Install s5cmd for fast S3 uploads
-        run: |
-          S5CMD_VERSION="2.3.0"
-          S5CMD_SHA256="de0fdbfa3aceae55e069ba81a0fc17b2026567637603734a387b2fca06c299b4"
-          curl -fsSL -o /tmp/s5cmd.tar.gz "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz"
-          echo "${S5CMD_SHA256}  /tmp/s5cmd.tar.gz" | sha256sum --check --strict
-          sudo tar -xz -C /usr/local/bin s5cmd < /tmp/s5cmd.tar.gz
-
-      - name: Configure git for private Go modules
-        run: git config --global url."https://${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/registry-mirror-tools".insteadOf "https://github.com/pulumi/registry-mirror-tools"
-
-      - name: Cache provider schemas and generated docs
-        uses: actions/cache@v6
-        with:
-          path: |
-            .cache/schemas
-            .cache/versioned-docs
-            .cache/api-docs
-          key: docs-cache-${{ github.run_id }}
-          restore-keys: docs-cache-
-
-      - name: Get registry-mirror-discover version
-        id: mirror-version
-        run: echo "hash=$(grep 'REGISTRY_MIRROR_TOOLS_COMMIT=' scripts/generate-versioned-docs.sh | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache registry-mirror-discover binary
-        uses: actions/cache@v6
-        with:
-          path: bin/registry-mirror-discover
-          key: registry-mirror-discover-${{ steps.mirror-version.outputs.hash }}
-
-      - name: Build and deploy preview
-        run: make ci-pull-request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-          PULUMI_STACK_NAME: ${{ vars.PULUMI_STACK_NAME }}
-          NODE_OPTIONS: "--max_old_space_size=8192"
-          ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
-          ALGOLIA_APP_SEARCH_KEY: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pulumi_stack_name: ${{ vars.PULUMI_STACK_NAME }}
+          algolia_app_id: ${{ vars.ALGOLIA_APP_ID }}
+          algolia_app_search_key: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
 
   notify:
     if: (github.event.pull_request.user.login == 'pulumi-bot') && failure()

--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -2,6 +2,7 @@
 """Command-line entry point for the community package tooling. Each subcommand is one CI step:
 
     check           verify the added entry and write a fact-sheet (runs on the PR)
+    preview         materialize a fork PR's entry so its site preview can be built
     report          post the fact-sheet as a sticky PR comment
     check-command   handle a /check comment
 
@@ -18,6 +19,7 @@ from pathlib import Path
 
 import comment_commands
 import fact_sheet
+import github_api
 import package_list
 import resourcedocsgen
 import verify_entry
@@ -76,6 +78,25 @@ def run_check(args: argparse.Namespace) -> int:
     return 1 if failed else 0
 
 
+def run_preview(args: argparse.Namespace) -> int:
+    _, head_sha = github_api.pull_request_head(args.pr)
+    base = package_list.current()
+    head = github_api.file_content_at(github_api.repo(), str(package_list.PATH), head_sha)
+    package_list.PATH.write_text(head)  # bring the fork's entry into the tree so the site build sees it
+    entries = package_list.added_entries(base, head)
+    if not entries:
+        print("no added entries to preview")
+        return 0
+    resourcedocsgen.ensure_built()
+    for entry in entries:
+        tag = github_api.latest_release_tag(entry.repoSlug)
+        if tag is None:
+            print(f"no published release for {entry.repoSlug}; skipping its preview metadata")
+            continue
+        resourcedocsgen.generate_metadata(entry.repoSlug, entry.schemaFile, tag)
+    return 0
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="community-package")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -84,6 +105,10 @@ def main(argv: list[str]) -> int:
     check.add_argument("--diff", metavar="BASEREF", required=True)
     check.add_argument("--out", default=".")
     check.set_defaults(run=run_check)
+
+    preview = sub.add_parser("preview")
+    preview.add_argument("--pr", type=int, required=True)
+    preview.set_defaults(run=run_preview)
 
     sub.add_parser("report").set_defaults(run=lambda _: comment_commands.report())
     sub.add_parser("check-command").set_defaults(run=lambda _: comment_commands.check_command())


### PR DESCRIPTION
Follow-up to the community-package verified check pipeline (#11689, merged): adds an on-demand site preview for community-package PRs, including forks.

A fork's own `pull_request` build gets no secrets, so it can't deploy a preview. This adds a maintainer-triggered `/preview` command (or `workflow_dispatch`) that builds one. It materializes the fork's package-list entry as data and regenerates its docs metadata before building, and never runs the fork's code, so the secret-bearing preview plane stays free of contributor code.

## What's here

- **`.github/actions/build-and-deploy-preview`**: the registry preview build (ESC secrets, toolchain, `make ci-pull-request`) extracted into a reusable composite action. An optional `pr` input first materializes that PR's entry, for fork previews.
- **`.github/workflows/community-package-preview-command.yml`**: the maintainer-gated `/preview` command (and manual `workflow_dispatch`), reusing the composite action.
- **`.github/workflows/pull-request.yml`**: the existing preview job now calls the composite action instead of inlining the steps.
- **`scripts/ci/community-package/cli.py`**: a `preview` subcommand that pulls the PR's entry into the tree and generates its docs metadata, skipping an entry with no published release rather than failing the build.
