### PR TITLE
Tint code chrome faint-violet across chooser and code panels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ go 1.23
 // will be considered a private Go module as well. We could configure an SSH key to get around
 // that but this is simpler for the time being.
 replace github.com/pulumi/registry/themes/default => ./themes/default
+
+require github.com/pulumi/registry/themes/default v0.0.0-20260717115645-eaef850b3a4b // indirect

--- a/themes/default/theme/src/scss/_theme.scss
+++ b/themes/default/theme/src/scss/_theme.scss
@@ -148,3 +148,16 @@
   --shadow-3xl: 0 35px 70px -20px rgba(0, 0, 0, 0.5);
   --leading-extra-tight: 1.1;
 }
+
+// Code-chrome tint — the single source for the faint-violet framing on code
+// surfaces (chooser toolbars, tab strips, code-block cards). Every consumer
+// references these, never the raw violet steps, so the tint flips in one place.
+// The registry is light-only, so unlike the docs site there's no dark override.
+// --chrome-dots is defined for parity with the docs token layer but isn't
+// consumed here (no terminal title bar); wire it up if dots are ever added.
+:root {
+  --chrome-bg: var(--color-violet-100); /* #ebebff */
+  --chrome-border: var(--color-violet-200); /* #dedbff */
+  --chrome-border-hover: var(--color-violet-300); /* #c3bdff */
+  --chrome-dots: var(--color-violet-400); /* #a697fc */
+}

--- a/themes/default/theme/src/scss/components/_chooser.scss
+++ b/themes/default/theme/src/scss/components/_chooser.scss
@@ -1,24 +1,24 @@
 pulumi-chooser {
-    // Standard (non-language) chooser: a gray strip of small tabs matching the
-    // language chooser's toolbar — surface background, rounded top, 1px bottom
-    // border that the active tab's underline sits on. --docs-* tokens (with
-    // non-docs fallbacks); the dark rule in _docs-theme.scss re-asserts the
-    // border colors the unlayered `*` border reset would otherwise override.
+    // Standard (non-language) chooser: a faint-violet strip of small tabs matching
+    // the language chooser's toolbar — --chrome-bg fill, rounded top, 1px --chrome-
+    // border bottom that the active tab's underline sits on. Chrome surfaces use the
+    // --chrome-* tint tokens (_theme.scss); tab *text* stays semantic gray and the
+    // active underline stays brand primary (--docs-link → violet-primary fallback).
     > ul {
         @apply m-0 mb-4 flex rounded-t-lg;
 
         padding: 0 !important;
         list-style-type: none !important;
 
-        background: var(--docs-surface, theme("colors.gray.100"));
-        border-bottom: 1px solid var(--docs-border, theme("colors.gray.200"));
+        background: var(--chrome-bg);
+        border-bottom: 1px solid var(--chrome-border);
 
         li {
             @apply font-display text-xs p-0 m-0 border-b-2 border-transparent transition text-center w-full;
             @include transition;
 
             &:hover {
-                border-bottom-color: var(--docs-border, theme("colors.gray.200"));
+                border-bottom-color: var(--chrome-border-hover);
             }
 
             &.active {
@@ -58,24 +58,24 @@ pulumi-chooser {
         }
     }
 
-    // Language chooser card: a bordered card wrapping a gray toolbar (active logo +
-    // name on the left, abbreviation tabs on the right) and the slotted code/prose.
-    // Skips headless choosers (option-style="none"). --docs-* tokens with literal
-    // fallbacks give dark mode on /docs and light defaults elsewhere. Padding lives
-    // on the card so all slotted content (including bare-text-node prose) is inset
-    // uniformly; the toolbar breaks out of it to stay flush at the top.
+    // Language chooser card: a --chrome-border card wrapping a --chrome-bg toolbar
+    // (active logo + name on the left, abbreviation tabs on the right) and the
+    // slotted code/prose. Skips headless choosers (option-style="none"). The card
+    // *body* keeps the page/card surface (white); only the frame carries the tint.
+    // Padding lives on the card so all slotted content (including bare-text-node
+    // prose) is inset uniformly; the toolbar breaks out of it to stay flush at top.
     &[type="language"]:not([option-style="none"]) {
         @apply block rounded-lg px-4 pb-4 mb-4 overflow-hidden;
 
         background: var(--docs-card, theme("colors.white"));
-        border: 1px solid var(--docs-border, theme("colors.gray.200"));
+        border: 1px solid var(--chrome-border);
 
         // Height comes from the label's padding; the tabs stretch to fill it so each
         // tab's bottom border sits flush with the toolbar's bottom edge.
         .chooser-toolbar {
             @apply -mx-4 mb-4 flex justify-between gap-2 px-4;
 
-            background: var(--docs-surface, theme("colors.gray.100"));
+            background: var(--chrome-bg);
 
             // On mobile the logo + name label is hidden and the tab row scrolls
             // horizontally; from md up the label returns and the tabs right-align.
@@ -108,7 +108,7 @@ pulumi-chooser {
                     @include transition;
 
                     &:hover {
-                        border-bottom-color: var(--docs-border, theme("colors.gray.200"));
+                        border-bottom-color: var(--chrome-border-hover);
                     }
 
                     &.active {
@@ -188,7 +188,7 @@ pulumi-chooser {
             .chooser-toolbar {
                 @apply mb-0;
 
-                border-bottom: 1px solid var(--docs-border, theme("colors.gray.200"));
+                border-bottom: 1px solid var(--chrome-border);
             }
         }
 

--- a/themes/default/theme/src/scss/docs/_code-light.scss
+++ b/themes/default/theme/src/scss/docs/_code-light.scss
@@ -1,21 +1,26 @@
 // Min Light code theme, site-wide — the light-mode counterpart to the global
-// Min Dark theme (_chroma.scss), on a Violet 50 background per the Pulumi brand
-// "Code highlighting" guideline. Ported from docs, where it's gated on
-// `html:not([data-theme="dark"]) body.section-docs`; the registry has no theme
-// toggle, so it's gated on `body` and applies everywhere. Imported unlayered so
-// it beats the layered component rules. Comments are bumped from Min Light's
-// #c2c3c5 (unreadable on violet-50) to #6e7781; the rest is the canonical
-// palette.
+// Min Dark theme (_chroma.scss), on a faint-violet card per the Pulumi brand
+// "Code highlighting" guideline: the fill is Violet 50 at 50% opacity (page
+// showing through), and a standalone block gets a --chrome-border frame (rule at
+// the foot of this file) so it reads as a bordered card like the chooser chrome.
+// Ported from docs, where it's gated on `html:not([data-theme="dark"])
+// body.section-docs`; the registry has no theme toggle, so it's gated on `body`
+// and applies everywhere. Imported unlayered so it beats the layered component
+// rules. Comments are bumped from Min Light's #c2c3c5 (unreadable on the tint) to
+// #6e7781; the rest is the canonical palette.
 body {
-    // Flip the dark code surface + text (set in _chroma.scss / _code.scss).
+    // Flip the dark code surface + text (set in _chroma.scss / _code.scss). The
+    // fill is the code-area violet step at 50% opacity so the page shows through
+    // the rest — the block reads as a faint-violet card (the standalone border
+    // rule at the bottom of this file supplies its frame).
     pre {
-        background: var(--color-violet-50);
+        background: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
         color: #212121;
     }
 
     .chroma,
     .bg {
-        background-color: var(--color-violet-50);
+        background-color: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
         color: #212121;
     }
 
@@ -113,11 +118,13 @@ body {
         .gs { font-weight: bold; color: #cd3131; }
     }
 
-    // Copy button: dark icon on the light panel. Give the container the panel's own
-    // violet-50 so it's opaque (it blends in until hovered) rather than transparent,
-    // which would let scrolled code and the scrollbar show through beneath it.
+    // Copy button: dark icon on the light panel. The container must be opaque so
+    // scrolled code and the scrollbar don't show through beneath it, but the panel
+    // fill is now half-transparent violet-50 over the white page — so mix the same
+    // step over white (not transparent) to get an opaque color that matches the
+    // panel and blends in until hovered.
     .copy-button-container {
-        background: var(--color-violet-50);
+        background: color-mix(in srgb, var(--color-violet-50) 50%, var(--color-white));
 
         &:hover {
             background: var(--color-violet-100);
@@ -134,7 +141,7 @@ body {
 
     // example-program footer (the code panel's bottom lip).
     .example-program .example-program-footer {
-        background: var(--color-violet-50);
+        background: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
 
         a {
             color: var(--color-gray-700);
@@ -150,7 +157,7 @@ body {
         .code-tabbed-tabs,
         .code-tabbed-content,
         .code-tabbed-status {
-            background: var(--color-violet-50);
+            background: color-mix(in srgb, var(--color-violet-50) 50%, transparent);
         }
 
         .code-tabbed-tab {
@@ -167,4 +174,13 @@ body {
             }
         }
     }
+}
+
+// Standalone code block → bordered card. A fenced block that isn't already inside
+// its own frame (a chooser card, an example-program panel, a code-chrome terminal,
+// or a code-tabbed demo) gets a 1px --chrome-border so it matches the chooser
+// chrome. The :not() list excludes the surfaces that supply their own frame;
+// pre.mermaid is excluded so diagram canvases stay unframed.
+.highlight:not(pulumi-chooser *, .example-program *, .code-chrome *, .code-tabbed *) pre:not(.mermaid) {
+    border: 1px solid var(--chrome-border);
 }


### PR DESCRIPTION
Ports the violet code-chrome treatment to the registry (light-only): a single `--chrome-*` token layer in `_theme.scss` drives the chooser toolbars, tab strips, card/strip borders, and hover underlines, while tab text stays semantic gray and the active underline stays brand primary. Code panels (`pre`, `.chroma`, example-program footer, code-tabbed) now fill with Violet 50 at 50% opacity so the page shows through, and standalone fenced blocks gain a `--chrome-border` card frame; the copy-button container mixes over white to stay opaque. Also includes a `go.mod` `require` for the local `./themes/default` module that `go mod tidy` wants alongside the existing `replace` directive.

---

Adding a community package? It is a one-line entry in
[`community-packages/package-list.json`](https://github.com/pulumi/registry/blob/master/community-packages/package-list.json).
See [Adding a Package](https://github.com/pulumi/registry#adding-a-package) for the steps.
Automated checks post a fact-sheet on your PR telling you what passed and what to fix, and a
Pulumi maintainer approves. Nothing merges automatically.