### PR TITLE
resourcedocsgen: repair Unicode-whitespace shortcode delimiters, not just space/tab

### DIFF
--- a/tools/resourcedocsgen/cmd/sanitize.go
+++ b/tools/resourcedocsgen/cmd/sanitize.go
@@ -34,7 +34,13 @@ import "regexp"
 // between "{{" and a following "<" or "%". A space after "{{" followed by anything
 // else (e.g. a Go template expression "{{ .Value }}") is left untouched, and the
 // closing side (e.g. the legitimate space in `... yaml" >}}`) is never modified.
-var malformedShortcodeOpen = regexp.MustCompile(`\{\{[ \t]+([<%])`)
+//
+// The whitespace class is [\t\p{Zs}] rather than [ \t]: \p{Zs} matches every
+// Unicode space separator, so a non-breaking space (U+00A0) or other exotic
+// space that Hugo still rejects — and that renders indistinguishably from a
+// plain space — is repaired too. \p{Zs} excludes newlines, so a match never
+// spans lines.
+var malformedShortcodeOpen = regexp.MustCompile(`\{\{[\t\p{Zs}]+([<%])`)
 
 // sanitizeShortcodeDelimiters repairs malformed Hugo shortcode opening delimiters
 // of the form "{{ <" / "{{ %" back to the well-formed "{{<" / "{{%". It is a

--- a/tools/resourcedocsgen/cmd/sanitize_test.go
+++ b/tools/resourcedocsgen/cmd/sanitize_test.go
@@ -92,6 +92,19 @@ func TestSanitizeShortcodeDelimiters(t *testing.T) {
 			expected: `{{% choosable language go %}}`,
 		},
 		{
+			// A non-breaking space (U+00A0) renders identically to a plain space
+			// but is not matched by [ \t]; Hugo still rejects it. This nbsp gap
+			// motivated widening the whitespace class to \p{Zs}.
+			name:     "non-breaking space (U+00A0) between braces and marker",
+			input:    "{{\u00a0< chooser language \"go\" >}}",
+			expected: `{{< chooser language "go" >}}`,
+		},
+		{
+			name:     "unicode en-quad (U+2000) between braces and marker",
+			input:    "{{\u2000% choosable language go %}}",
+			expected: `{{% choosable language go %}}`,
+		},
+		{
 			name:     "already well-formed is unchanged (idempotent)",
 			input:    `{{< chooser language "typescript" >}}`,
 			expected: `{{< chooser language "typescript" >}}`,


### PR DESCRIPTION
## Problem

`sanitizeShortcodeDelimiters` (added in #11410) repairs malformed Hugo shortcode delimiters `{{ <` / `{{ %` on fetch, but its matcher is `\{\{[ \t]+([<%])` — **ASCII space or tab only**.

A malformed delimiter written with a **non-breaking space (U+00A0)** or another Unicode space separator slips through unrepaired, yet:
- Hugo still rejects it and fails the entire `pulumi/registry` site build, and
- the shortcode linter (`scripts/lint/check-shortcode-delimiters.js`, which uses `\s`) still flags it on the PR.

Because a non-breaking space **renders identically to a plain space**, this is the corruption class that "looks fixed" in any text view but isn't — and it's a plausible contributor to publish PRs that fail *Lint Markdown* even though the on-fetch sanitizer "ran".

I reproduced it directly: feeding `{{<U+00A0>< chooser … >}}` through `resourcedocsgen metadata from-urls` emitted the delimiter **still malformed** (bytes `7b7b c2a0 3c`).

## Fix

Widen the whitespace class from `[ \t]` to `[\t\p{Zs}]`. `\p{Zs}` matches every Unicode space separator (U+00A0, U+2000–U+200A, U+202F, U+205F, U+3000, …) plus the ASCII space it already covered; `\t` keeps tabs. `\p{Zs}` excludes newlines, so a match still never spans lines, and Go templates (`{{ .Value }}`) and legitimate closing-side spaces (`… yaml" >}}`) remain untouched.

**Verified end to end:** with the fix, the same `from-urls` run emits `{{< chooser … >}}` (bytes `7b7b 3c`). New unit cases cover U+00A0 and U+2000.

This aligns resourcedocsgen with the same repair now applied at the mirror source in [pulumi/registry-mirror-tools#3](https://github.com/pulumi/registry-mirror-tools/pull/3) — defense in depth: the mirror stops emitting malformed delimiters, and resourcedocsgen repairs anything that still slips through.

## Tests

`go test ./...`, `go vet ./cmd/`, and `gofmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)