### PR TITLE
Remove dead PULUMI_AI_WS_URL stack reference

### DIFF
--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -396,19 +396,18 @@ This is the master build script for CI runs. It accepts one argument: `preview` 
 **Steps executed by `build.sh`**:
 
 1. Calls `make build-assets` (theme CSS/JS compilation).
-2. Fetches the Pulumi AI WebSocket URL from `pulumi/pulumigpt-api/corp` stack output (`PULUMI_AI_WS_URL`).
-3. Computes a `build_identifier` (for preview: `pr-<number>-<sha8>`; for push: `push-<sha8>`).
-4. Sets asset bundle paths:
+2. Computes a `build_identifier` (for preview: `pr-<number>-<sha8>`; for push: `push-<sha8>`).
+3. Sets asset bundle paths:
    - `CSS_BUNDLE=static/css/styles.<id>.css`
    - `JS_BUNDLE=static/js/bundle.min.<id>.js`
-5. **Restores cached API docs** from `.cache/api-docs/` into the Hugo content/static trees (see section 4.7 for details).
-6. Runs `make api-docs`, which compiles `resourcedocsgen` and generates all provider API docs. The tool skips unchanged packages using sentinel files.
-7. **Saves API docs** output (including sentinel files) back to `.cache/api-docs/` for the next run. Versioned packages (`@`-suffixed) are excluded — they have their own cache. LLM docs from `llm-docs-out/` are also cached to `.cache/api-docs/llm-docs/` and restored on the next run.
-8. Runs `node ./scripts/apply-fixes.js`.
-9. Runs Hugo with `--minify --buildFuture --templateMetrics`:
+4. **Restores cached API docs** from `.cache/api-docs/` into the Hugo content/static trees (see section 4.7 for details).
+5. Runs `make api-docs`, which compiles `resourcedocsgen` and generates all provider API docs. The tool skips unchanged packages using sentinel files.
+6. **Saves API docs** output (including sentinel files) back to `.cache/api-docs/` for the next run. Versioned packages (`@`-suffixed) are excluded — they have their own cache. LLM docs from `llm-docs-out/` are also cached to `.cache/api-docs/llm-docs/` and restored on the next run.
+7. Runs `node ./scripts/apply-fixes.js`.
+8. Runs Hugo with `--minify --buildFuture --templateMetrics`:
     - `preview` mode: sets `HUGO_BASEURL` to the S3 website URL and uses `-e preview`
     - `update` mode: uses `-e production`
-10. Runs `yarn run minify-css` to purge and minify CSS.
+9. Runs `yarn run minify-css` to purge and minify CSS.
 
 ### 4.6 Versioned documentation
 
@@ -1056,7 +1055,6 @@ The `export-repo-secrets.yml` workflow provides a manual escape hatch to sync Gi
 | `NODE_OPTIONS` | Hardcoded | build, browser tests | `--max_old_space_size=8192` |
 | `SLACK_ACCESS_TOKEN` | ESC | link check, cleanup | Slack Web API token for posting messages |
 | `SLACK_WEBHOOK_URL` | ESC | notify jobs | Slack incoming webhook for failure alerts |
-| `PULUMI_AI_WS_URL` | Pulumi stack output | `build.sh` | URL for Pulumi AI WebSocket |
 | `ASSET_BUNDLE_ID` | `build.sh` (computed) | Hugo templates | Unique suffix for CSS/JS cache-busting |
 | `CSS_BUNDLE` / `JS_BUNDLE` | `build.sh` (computed) | Hugo templates | Paths to versioned asset bundles |
 
@@ -1209,5 +1207,5 @@ Pulumi Cloud plays **four distinct roles** in this system:
 | **Registry API** | `api.pulumi.com/api/registry` | Stores published package versions; queried by the Pulumi CLI for package and plugin resolution |
 | **Secrets / ESC** | `github-secrets/pulumi-registry` environment | Provides CI secrets (tokens, keys) via OIDC; eliminates long-lived secrets in GitHub |
 | **IaC State Backend** | `pulumi/registry/testing` and `pulumi/registry/production` stacks | Stores Terraform-like state for the AWS infrastructure (CloudFront, S3, policies) managed by `infrastructure/index.ts` |
-| **Stack References** | `pulumi/pulumigpt-api`, `pulumi/dwh-workflows-*` stacks | Exposes runtime service URLs and IAM role ARNs as stack outputs, consumed by the build and deploy pipeline |
+| **Stack References** | `pulumi/dwh-workflows-*` stacks | Exposes runtime service URLs and IAM role ARNs as stack outputs, consumed by the build and deploy pipeline |
 

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -24,7 +24,6 @@ security:
       - ASSET_BUNDLE_ID
       - REPO_THEME_PATH
       - GITHUB_TOKEN
-      - PULUMI_AI_WS_URL
       - ALGOLIA_APP_ID
       - ALGOLIA_APP_SEARCH_KEY
 

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -7,8 +7,6 @@ source ./scripts/ci/common.sh
 echo "Building CSS and JS assets....."
 make build-assets
 
-export PULUMI_AI_WS_URL=${PULUMI_AI_WS_URL:-$(pulumi stack output --stack pulumi/pulumigpt-api/corp websocketUri)}
-
 printf "Compiling theme JavaScript and CSS...\n\n"
 export ASSET_BUNDLE_ID="$(build_identifier)"
 


### PR DESCRIPTION
## What

Removes the `PULUMI_AI_WS_URL` environment variable and its stack reference to `pulumi/pulumigpt-api/corp`.

- `scripts/ci/build.sh` — drop the `pulumi stack output` call
- `config/_default/config.yml` — drop the entry from Hugo's `security.funcs.getenv` allowlist
- `BUILD-AND-DEPLOY.md` — drop the three references (build step, env var table, stack reference table)

## Why

`build.sh` fetched `websocketUri` from the `pulumi/pulumigpt-api/corp` stack on **every CI build**, but nothing has read the resulting variable since the Pulumi AI frontend was removed in pulumi/docs#3394 (Sept 2023). It was exported, allowlisted, and documented — but never consumed. `grep` finds no reader in `layouts/`, `themes/`, `assets/`, or `static/`.

## The stack behind it is orphaned

While confirming this was safe to remove:

| | |
|---|---|
| Stack | `pulumi/pulumigpt-api/corp` — 38 resources, still live |
| Last update | **2023-09-14** |
| Source | was `pulumi/pulumi.ai` at `projects/pulumigpt-chat-website/` (project name `pulumigpt-api`) |
| Source deleted | **2023-10-09**, 25 days later |

So the infrastructure has outlived its source by nearly three years, and is a teardown candidate — tracked in pulumi/pulumi.ai#2202.

**This PR should land before that stack is destroyed.** Today, `pulumi stack output ... websocketUri` would fail once the output goes away, breaking the registry build. Removing the reference first decouples the two.

Mirrors the same removal in pulumi/docs#20250.

## Risk

Low. No consumer, and the build does strictly less work. Worth a green CI run to confirm the Hugo build is unaffected by the `getenv` allowlist change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)