### PR TITLE
Fix package metadata generation for multi-package repos (defang)

### DIFF
--- a/.github/workflows/generate-package-metadata.yml
+++ b/.github/workflows/generate-package-metadata.yml
@@ -98,19 +98,41 @@ jobs:
       - name: Build resourcedocsgen
         if: env.PROVIDER_VERSION
         run: go build -C tools/resourcedocsgen
+      - name: Read package name at the release version
+        # The skip-dedup read above resolves the name at HEAD, because the
+        # release version isn't known yet at that point. Re-read it here pinned
+        # to the exact ref the metadata command downloads — the release tag — so
+        # a provider that renamed its schema between its latest release and HEAD
+        # can't trigger a spurious providerName/schema-name mismatch. Falls back
+        # to the HEAD-derived name.
+        if: env.PROVIDER_VERSION
+        id: package_at_version
+        run: |
+          package_name=""
+          if [[ "$SCHEMA_FILE" == *.json ]]; then
+            package_name=$(curl -fsSL "https://raw.githubusercontent.com/${REPO_SLUG}/${PROVIDER_VERSION}/${SCHEMA_FILE}" \
+              | jq -r '.name // empty' 2>/dev/null || true)
+          fi
+          echo "name=${package_name:-$FALLBACK_NAME}" >> $GITHUB_OUTPUT
+        env:
+          REPO_SLUG: ${{ matrix.repoSlug }}
+          SCHEMA_FILE: ${{ matrix.schemaFile }}
+          PROVIDER_VERSION: ${{ env.PROVIDER_VERSION }}
+          FALLBACK_NAME: ${{ steps.package.outputs.name }}
       - name: Generate Package Metadata
         if: env.PROVIDER_VERSION
         run: >-
           ./tools/resourcedocsgen/resourcedocsgen metadata from-github
-          --repoSlug   "${{ matrix.repoSlug      }}"
-          --schemaFile "${{ matrix.schemaFile    }}"
-          --version    "${{ env.PROVIDER_VERSION }}"
+          --repoSlug     "${{ matrix.repoSlug                 }}"
+          --schemaFile   "${{ matrix.schemaFile               }}"
+          --providerName "${{ steps.package_at_version.outputs.name }}"
+          --version      "${{ env.PROVIDER_VERSION            }}"
       - name: Create registry PR
         if: env.PROVIDER_VERSION
         uses: ./.github/actions/new-provider-version-pr
         with:
           github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          provider_short_name: ${{ steps.package.outputs.name }}
+          provider_short_name: ${{ steps.package_at_version.outputs.name }}
           provider_version: ${{ env.PROVIDER_VERSION }}
 
   notify:


### PR DESCRIPTION
## What went wrong

The nightly [**Check for Community Package Updates**](https://github.com/pulumi/registry/actions/runs/29806607510) run failed for all three `DefangLabs/pulumi-defang` schemas (`defang-aws`, `defang-azure`, `defang-gcp`):

```
Error: generating package metadata: --providerName doesn't match the schema name: "defang" != "defang-aws"
```

(The `git ... exit code 128` lines in that run are unrelated post-job cleanup warnings — `No url found for submodule path 'examples'` — not the cause.)

`DefangLabs/pulumi-defang` publishes three separate schemas from one repo (the split in #11614). The **Generate Package Metadata** step invoked `resourcedocsgen metadata from-github` without `--providerName`, so it inferred the name from the repo slug (`pulumi-defang` → `defang`) and rejected it against each schema's real `name` (`defang-aws`, etc.) at `tools/resourcedocsgen/cmd/metadata.go:320`.

The workflow already derives the correct per-schema name (`steps.package.outputs.name`, added in #11244) for PR naming — it just wasn't being passed to the metadata command.

## Fix

1. **Pass `--providerName`** (the schema-derived name) to `metadata from-github`, so each package in a multi-package repo validates against its own schema name. This also makes the general multi-package-per-repo case work going forward.
2. **Ref-alignment (robustness):** the existing name read resolves at `HEAD`, but the metadata command downloads the schema at the **release tag**. A new `Read package name at the release version` step re-reads the name pinned to the same release tag, so a provider that renames its schema between its latest release and `HEAD` can't cause a spurious `providerName`/schema-name mismatch. Both `--providerName` and the PR's `provider_short_name` now use this release-pinned name. The `HEAD` read is kept solely as the early skip-dedup key (the release version isn't known at that point).

## Verification

- YAML parses cleanly.
- No change to single-package repos: the release-pinned read returns the same schema name that `resourcedocsgen` reads, so the validation passes as before. `.yaml`-schema packages fall back to the existing repo-derived name.
- The three failed defang jobs will publish on the next scheduled run (or a manual `workflow_dispatch`) once this merges, since the matrix is read from `community-packages/package-list.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)