### PR TITLE
Fix missing GitHub icon on how-to-guide "View Code" buttons

### DIFF
--- a/themes/default/theme/src/scss/_phosphor.scss
+++ b/themes/default/theme/src/scss/_phosphor.scss
@@ -20,6 +20,11 @@
 // every generated file from a styling refactor, so render those <i> tags as
 // the GitHub SVG via mask-image. Add more entries if other fa-* names appear
 // in content.
+//
+// The mask is an inline data URI rather than a hosted path (e.g. /icons/github.svg):
+// the registry's static assets under that path are not served on the merged
+// production site, so a hosted reference 404s and the <i> paints as a solid
+// currentColor box. Inlining keeps the icon self-contained and deploy-agnostic.
 i.fab.fa-github,
 i.fa-github {
     display: inline-block;
@@ -27,6 +32,7 @@ i.fa-github {
     height: 1em;
     vertical-align: -0.125em;
     background-color: currentColor;
-    -webkit-mask: url("/icons/github.svg") no-repeat center / contain;
-    mask: url("/icons/github.svg") no-repeat center / contain;
+    // GitHub mark (simple-icons), URL-encoded for use as a CSS mask.
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E") no-repeat center / contain;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E") no-repeat center / contain;
 }


### PR DESCRIPTION
## Problem

On how-to-guide pages (e.g. [aws-ts-nextjs](https://www.pulumi.com/registry/packages/aws/how-to-guides/aws-ts-nextjs/)), the GitHub icon in the **"View Code"** button is missing / appears as a white box on production, while it renders fine locally.

## Root cause

FontAwesome was removed from the theme; a shim in `_phosphor.scss` renders the legacy `<i class="fab fa-github">` markup (emitted by `mktutorial` into every how-to-guide page) as a masked GitHub SVG:

```scss
i.fab.fa-github { background-color: currentColor; -webkit-mask: url("/icons/github.svg") ...; }
```

`/icons/github.svg` **404s on the merged production site** (this repo's static assets under that path aren't served there), so the mask image fails to load. With no mask, the `<i>` paints as a solid `currentColor` box — white on the violet button, i.e. the icon looks missing / wrong color.

It renders fine **locally** only because `hugo serve` serves `/icons/github.svg` from the theme's static dir (200). The local↔prod difference is that single 404.

*(The "Deploy with Pulumi" `button.svg` was a red herring — it loads fine on prod; the earlier blank render was a transient CDN blip.)*

## Fix

Inline the GitHub mark as a **data-URI mask** so the icon is self-contained and no longer depends on a hosted asset path. Verified on the live prod page by swapping in the data-URI mask — the octocat renders correctly.

Fixes **all existing** how-to-guide pages on the next deploy, with **no content regeneration** needed (they all share this one shim).

Changed files: `themes/default/theme/src/scss/_phosphor.scss` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)