### PR TITLE
resourcedocsgen: normalize docs on every ingestion path

### DIFF
--- a/scripts/generate-versioned-docs.sh
+++ b/scripts/generate-versioned-docs.sh
@@ -271,6 +271,8 @@ process_package() {
             if ! curl -sfL "$INDEX_URL" -o "$DOCS_OUT_DIR/_index.md" 2>/dev/null; then
                 echo "[$PACKAGE] Could not fetch _index.md from $INDEX_URL"
                 rm -f "$DOCS_OUT_DIR/_index.md"
+            else
+                "$RESOURCEDOCSGEN" sanitize-docs --in-place "$DOCS_OUT_DIR/_index.md"
             fi
         fi
 

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -273,8 +273,7 @@ func packageMetadataFromGitHubCmd(metadataDir, packageDocsDir *string) *cobra.Co
 				continue
 			}
 
-			// Normalize end of line representation
-			content = bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+			content = normalizeDocs(content)
 
 			frontmatter := []byte(`---
 # WARNING: this file was fetched from ` + url + `
@@ -678,13 +677,7 @@ func readDocsFile(url string) ([]byte, error) {
 		return nil, err
 	}
 
-	// Normalize end of line representation
-	content = bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
-
-	// Defensively repair malformed Hugo shortcode delimiters (e.g. "{{ <" -> "{{<").
-	// Upstream-generated docs occasionally emit these, and a single malformed
-	// delimiter fails the entire Hugo site build. See sanitizeShortcodeDelimiters.
-	content = sanitizeShortcodeDelimiters(content)
+	content = normalizeDocs(content)
 
 	rest, ok := bytes.CutPrefix(bytes.TrimLeft(content, "\n\t\r "), []byte("---\n"))
 	if !ok {

--- a/tools/resourcedocsgen/cmd/root.go
+++ b/tools/resourcedocsgen/cmd/root.go
@@ -47,6 +47,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(docs.ResourceDocsCmd())
 	rootCmd.AddCommand(PackageMetadataCmd())
 	rootCmd.AddCommand(CheckVersion())
+	rootCmd.AddCommand(SanitizeDocsCmd())
 
 	return rootCmd
 }

--- a/tools/resourcedocsgen/cmd/sanitize_cmd.go
+++ b/tools/resourcedocsgen/cmd/sanitize_cmd.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// normalizeDocs applies the content repairs resourcedocsgen performs on every
+// docs file it writes: end-of-line normalization and malformed Hugo shortcode
+// delimiter repair. It is lenient and idempotent and never fails on content
+// shape, so callers on `set -e` paths can apply it unconditionally.
+func normalizeDocs(content []byte) []byte {
+	content = bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+	return sanitizeShortcodeDelimiters(content)
+}
+
+// SanitizeDocsCmd exposes normalizeDocs to callers that obtain docs by means
+// other than resourcedocsgen's own fetch. The versioned-docs build
+// (scripts/generate-versioned-docs.sh) downloads a package's _index.md with a
+// raw curl straight into the Hugo content tree, so it never passes through
+// readDocsFile's repair. Piping that file through this command applies the
+// identical repair, so a malformed delimiter from any docs source is fixed
+// once, in one place, rather than re-implemented per consumer.
+func SanitizeDocsCmd() *cobra.Command {
+	var inPlace bool
+	cmd := &cobra.Command{
+		Use:   "sanitize-docs [file]",
+		Short: "Repair malformed Hugo shortcode delimiters in a docs file",
+		Long: "Read a docs file (or stdin) and repair malformed Hugo shortcode opening " +
+			"delimiters (\"{{ <\" / \"{{ %\"), which otherwise abort the Hugo site build. " +
+			"Writes the result to stdout, or back to the file with --in-place.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if inPlace && len(args) != 1 {
+				return fmt.Errorf("--in-place requires a file argument")
+			}
+
+			var (
+				input []byte
+				err   error
+			)
+			if len(args) == 1 {
+				input, err = os.ReadFile(args[0])
+			} else {
+				input, err = io.ReadAll(cmd.InOrStdin())
+			}
+			if err != nil {
+				return err
+			}
+
+			output := normalizeDocs(input)
+
+			if inPlace {
+				return os.WriteFile(args[0], output, 0o600)
+			}
+			_, err = cmd.OutOrStdout().Write(output)
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&inPlace, "in-place", false, "Rewrite the file in place instead of writing to stdout")
+	return cmd
+}

--- a/tools/resourcedocsgen/cmd/sanitize_cmd_test.go
+++ b/tools/resourcedocsgen/cmd/sanitize_cmd_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const malformedDocs = "---\ntitle: Example\n---\n\n" +
+	"{{ < chooser language \"typescript\" >}}\n" +
+	"{{ % choosable language typescript %}}\n"
+
+func TestSanitizeDocsCmd_Stdin(t *testing.T) {
+	t.Parallel()
+
+	cmd := SanitizeDocsCmd()
+	var out bytes.Buffer
+	cmd.SetIn(bytes.NewBufferString(malformedDocs))
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	assert.NotContains(t, got, "{{ <")
+	assert.NotContains(t, got, "{{ %")
+	assert.Contains(t, got, `{{< chooser language "typescript" >}}`)
+	assert.Contains(t, got, "{{% choosable language typescript %}}")
+}
+
+func TestSanitizeDocsCmd_InPlace(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "_index.md")
+	require.NoError(t, os.WriteFile(path, []byte(malformedDocs), 0o600))
+
+	cmd := SanitizeDocsCmd()
+	cmd.SetArgs([]string{"--in-place", path})
+	require.NoError(t, cmd.Execute())
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), "{{ <")
+	assert.Contains(t, string(got), `{{< chooser language "typescript" >}}`)
+}
+
+func TestSanitizeDocsCmd_InPlaceRequiresFile(t *testing.T) {
+	t.Parallel()
+
+	cmd := SanitizeDocsCmd()
+	cmd.SetArgs([]string{"--in-place"})
+	cmd.SetIn(bytes.NewBufferString(malformedDocs))
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+
+	assert.Error(t, cmd.Execute())
+}


### PR DESCRIPTION
resourcedocsgen repairs docs on fetch (EOL normalization + malformed Hugo
shortcode delimiter repair, the latter added in #11410), but only on the
readDocsFile path. Two other paths write provider docs into the Hugo content
tree without those repairs, so a malformed delimiter or stray CRLF on either
still reaches the site build:

- `metadata from-github` fetches _index.md and installation-configuration.md
  via readRemoteFile directly (the nightly community-package publish).
- generate-versioned-docs.sh downloads _index.md with a raw curl.

Fold the two repairs into one lenient, idempotent normalizeDocs helper and run
every path through it:

- Add a `sanitize-docs` subcommand exposing normalizeDocs, so shell callers
  reuse the one implementation instead of a copy.
- Pipe the versioned-docs curl through `sanitize-docs --in-place`.
- Route readDocsFile and the from-github loop through normalizeDocs.

normalizeDocs never fails on content shape, so it is safe on the versioned-docs
`set -euo pipefail` path; readDocsFile keeps its own frontmatter validation and
edit_url/banner handling, which are specific to that path.

Coverage after this change (Unicode-whitespace delimiters land separately with
#11743, which every path inherits by calling the same function):

| Path | Writes | Normalized |
|---|---|---|
| `metadata` (--indexFileURL) -> readDocsFile | _index.md, installation-configuration.md | yes (#11410) |
| `metadata from-github` -> readRemoteFile | _index.md, installation-configuration.md | yes (this change) |
| generate-versioned-docs.sh curl | _index.md | yes (this change) |

Because mirrored docs are now repaired on the consumer side, a mirror-side
repair (pulumi/registry-mirror-tools#3) is not required.

## Test plan

- `go test ./cmd/`, `go vet ./cmd/`, `golangci-lint run ./cmd/`, gofmt, and
  shellcheck on generate-versioned-docs.sh all pass
- sanitize-docs: stdin, --in-place, and missing-file-arg cases
  (sanitize_cmd_test.go)
- End to end: `sanitize-docs --in-place` on a file with CRLF and `{{ <`
  produces LF and `{{<`
- readDocsFile and from-github are behavior-preserving refactors, covered by
  the existing metadata tests and TestReadDocsFileSanitizesShortcodeDelimiters
