### PR TITLE
Allow publisher-names.json in community package /check

### DIFF
--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -32,16 +32,28 @@ def _write_step_summary(text: str) -> None:
             fh.write(text + "\n")
 
 
+# The publisher allowlist is hand-maintained Go source embedded into resourcedocsgen, not
+# generated after merge, so a new publisher's entry has to ride along with the onboarding PR.
+PUBLISHER_NAMES_PATH = Path("tools/resourcedocsgen/pkg/publishers/publisher-names.json")
+ALLOWED_PATHS = {str(package_list.PATH), str(PUBLISHER_NAMES_PATH)}
+
+
+def _files_outside_allowlist(changed: list[str]) -> list[str]:
+    return [f for f in changed if f and f not in ALLOWED_PATHS]
+
+
 def _offending_files(base_ref: str) -> list[str]:
     changed = subprocess.run(["git", "diff", "--name-only", f"{base_ref}...HEAD"],
                              capture_output=True, text=True).stdout
-    return [f for f in changed.splitlines() if f and f != str(package_list.PATH)]
+    return _files_outside_allowlist(changed.splitlines())
 
 
 def _rejection_sheet(offending: list[str]) -> str:
-    lines = [f"## ❌ This PR must change only `{package_list.PATH}`", "",
-             "**Not ready.** The following files do not belong in a community package PR. They are",
-             "generated and committed automatically after merge, so remove them and push again:", ""]
+    lines = ["## ❌ This PR changes files outside the community package allowlist", "",
+             "**Not ready.** A community package PR may only touch the package list "
+             f"(`{package_list.PATH}`) and, when a new publisher needs onboarding, the publisher "
+             f"allowlist (`{PUBLISHER_NAMES_PATH}`). The following files are generated and committed "
+             "automatically after merge, so remove them and push again:", ""]
     lines += [f"- `{f}`" for f in offending]
     return "\n".join(lines)
 

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -116,6 +116,19 @@ class CliNoticeTests(unittest.TestCase):
     def test_nothing_to_check_sheet(self) -> None:
         self.assertIn("Nothing to check", cli._nothing_to_check_sheet())
 
+    def test_package_list_and_publisher_allowlist_are_permitted(self) -> None:
+        changed = ["community-packages/package-list.json",
+                   "tools/resourcedocsgen/pkg/publishers/publisher-names.json"]
+        self.assertEqual(cli._files_outside_allowlist(changed), [])
+
+    def test_generated_files_are_offending(self) -> None:
+        changed = ["community-packages/package-list.json",
+                   "themes/default/content/registry/packages/thoth/_index.md",
+                   "themes/default/data/registry/packages/thoth.yaml"]
+        self.assertEqual(cli._files_outside_allowlist(changed),
+                         ["themes/default/content/registry/packages/thoth/_index.md",
+                          "themes/default/data/registry/packages/thoth.yaml"])
+
 
 class DocLintTests(unittest.TestCase):
     def test_flags_broken_refs_and_ignores_absolute(self) -> None:


### PR DESCRIPTION
The community package check rejected any PR touching a file other than
community-packages/package-list.json, on the premise that everything else
is generated and committed after merge. That holds for the docs and the
metadata YAML, but not for tools/resourcedocsgen/pkg/publishers/publisher-names.json:
it is hand-maintained Go source embedded into resourcedocsgen, so a new
publisher's display-name-to-slug entry cannot be added any other way and
must ride along with the onboarding PR.

Add publisher-names.json to the check allowlist and reword the rejection
sheet to name both permitted files. Extract the allowlist filter into a
pure helper so it is unit tested directly.

## Test plan

- `python3 -m unittest discover -p 'test_*.py'` in scripts/ci/community-package (25 tests)
  - new: package-list.json and publisher-names.json pass the allowlist
  - new: generated docs/YAML files are still reported as offending
- `mypy --strict *.py` clean
