### PR TITLE
Fix community-package onboarding previews and add /preview feedback

### DIFF
--- a/.github/actions/build-and-deploy-preview/action.yml
+++ b/.github/actions/build-and-deploy-preview/action.yml
@@ -55,13 +55,16 @@ runs:
         PR: ${{ inputs.pr }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         REPO: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
       run: |
-        # Bring the PR's package-list entry and generated metadata into the tree, and shim the
-        # event so `make ci-pull-request` keys the bucket, URL and PR comment to this PR.
-        gh api "repos/$REPO/pulls/$PR" > /tmp/pr.json
-        jq -n --slurpfile pr /tmp/pr.json '{number: $pr[0].number, pull_request: $pr[0]}' > /tmp/pr-event.json
-        echo "GITHUB_EVENT_NAME=pull_request" >> "$GITHUB_ENV"
-        echo "GITHUB_EVENT_PATH=/tmp/pr-event.json" >> "$GITHUB_ENV"
+        # A native pull_request run already keys `make ci-pull-request` to this PR; only the
+        # comment-triggered path (issue_comment / workflow_dispatch) needs the event shimmed.
+        if [ "$EVENT_NAME" != "pull_request" ]; then
+          gh api "repos/$REPO/pulls/$PR" > /tmp/pr.json
+          jq -n --slurpfile pr /tmp/pr.json '{number: $pr[0].number, pull_request: $pr[0]}' > /tmp/pr-event.json
+          echo "GITHUB_EVENT_NAME=pull_request" >> "$GITHUB_ENV"
+          echo "GITHUB_EVENT_PATH=/tmp/pr-event.json" >> "$GITHUB_ENV"
+        fi
         python3 scripts/ci/community-package/cli.py preview --pr "$PR"
 
     - name: Validate JSON file syntax

--- a/.github/workflows/community-package-preview-command.yml
+++ b/.github/workflows/community-package-preview-command.yml
@@ -49,7 +49,7 @@ jobs:
         run: python3 scripts/ci/community-package/cli.py preview-command
 
       - uses: ./.github/actions/build-and-deploy-preview
-        if: steps.ack.outputs.should_build != 'false'
+        if: ${{ !cancelled() && steps.ack.outputs.should_build != 'false' }}
         with:
           pr: ${{ github.event.issue.number || inputs.pr }}
           github_token: ${{ github.token }}

--- a/.github/workflows/community-package-preview-command.yml
+++ b/.github/workflows/community-package-preview-command.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Acknowledge the comment and decide whether a preview is needed
         id: ack
         if: github.event_name == 'issue_comment'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -56,3 +57,15 @@ jobs:
           pulumi_stack_name: ${{ vars.PULUMI_STACK_NAME }}
           algolia_app_id: ${{ vars.ALGOLIA_APP_ID }}
           algolia_app_search_key: ${{ vars.ALGOLIA_APP_SEARCH_KEY }}
+
+      - name: Report a build failure on the PR
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number || inputs.pr }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: python3 scripts/ci/community-package/cli.py preview-failed

--- a/.github/workflows/community-package-preview-command.yml
+++ b/.github/workflows/community-package-preview-command.yml
@@ -38,7 +38,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Acknowledge the comment and decide whether a preview is needed
+        id: ack
+        if: github.event_name == 'issue_comment'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: python3 scripts/ci/community-package/cli.py preview-command
+
       - uses: ./.github/actions/build-and-deploy-preview
+        if: steps.ack.outputs.should_build != 'false'
         with:
           pr: ${{ github.event.issue.number || inputs.pr }}
           github_token: ${{ github.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -176,6 +176,7 @@ jobs:
 
       - uses: ./.github/actions/build-and-deploy-preview
         with:
+          pr: ${{ github.event.pull_request.number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pulumi_stack_name: ${{ vars.PULUMI_STACK_NAME }}
           algolia_app_id: ${{ vars.ALGOLIA_APP_ID }}

--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -92,10 +92,12 @@ def run_check(args: argparse.Namespace) -> int:
 
 
 def run_preview(args: argparse.Namespace) -> int:
-    _, head_sha = github_api.pull_request_head(args.pr)
-    base = package_list.current()
-    head = github_api.file_content_at(github_api.repo(), str(package_list.PATH), head_sha)
-    package_list.PATH.write_text(head)  # bring the fork's entry into the tree so the site build sees it
+    # Diff against the PR base by SHA, not the on-disk file: a native pull_request run is checked
+    # out at the head, where the on-disk list already contains the new entry.
+    pull = github_api.pull_request(args.pr)
+    base = github_api.file_content_at(github_api.repo(), str(package_list.PATH), pull["base"]["sha"])
+    head = github_api.file_content_at(github_api.repo(), str(package_list.PATH), pull["head"]["sha"])
+    package_list.PATH.write_text(head)  # bring the entry into the tree so the site build sees it
     entries = package_list.added_entries(base, head)
     if not entries:
         print("no added entries to preview")

--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -5,6 +5,7 @@
     preview         materialize a fork PR's entry so its site preview can be built
     report          post the fact-sheet as a sticky PR comment
     check-command   handle a /check comment
+    preview-command handle a /preview comment
 
 The logic lives in the sibling modules (verify_entry, resourcedocsgen, fact_sheet, comment_commands, ...); stdlib
 only, no third-party dependencies.
@@ -124,6 +125,7 @@ def main(argv: list[str]) -> int:
 
     sub.add_parser("report").set_defaults(run=lambda _: comment_commands.report())
     sub.add_parser("check-command").set_defaults(run=lambda _: comment_commands.check_command())
+    sub.add_parser("preview-command").set_defaults(run=lambda _: comment_commands.preview_command())
 
     args = parser.parse_args(argv)
     return int(args.run(args))

--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -6,6 +6,7 @@
     report          post the fact-sheet as a sticky PR comment
     check-command   handle a /check comment
     preview-command handle a /preview comment
+    preview-failed  post a build-failure comment for a /preview run
 
 The logic lives in the sibling modules (verify_entry, resourcedocsgen, fact_sheet, comment_commands, ...); stdlib
 only, no third-party dependencies.
@@ -128,6 +129,7 @@ def main(argv: list[str]) -> int:
     sub.add_parser("report").set_defaults(run=lambda _: comment_commands.report())
     sub.add_parser("check-command").set_defaults(run=lambda _: comment_commands.check_command())
     sub.add_parser("preview-command").set_defaults(run=lambda _: comment_commands.preview_command())
+    sub.add_parser("preview-failed").set_defaults(run=lambda _: comment_commands.preview_failed())
 
     args = parser.parse_args(argv)
     return int(args.run(args))

--- a/scripts/ci/community-package/comment_commands.py
+++ b/scripts/ci/community-package/comment_commands.py
@@ -78,6 +78,21 @@ def preview_command() -> int:
     return 0
 
 
+def _run_url() -> str:
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    repo = os.environ.get("GITHUB_REPOSITORY") or os.environ.get("REPO", "")
+    return f"{server}/{repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID', '')}"
+
+
+def preview_failed() -> int:
+    pr = int(os.environ["PR"])
+    github_api.post_comment(pr, f"❌ The preview build failed. See the [run log]({_run_url()}) for details.")
+    comment_id = os.environ.get("COMMENT_ID")
+    if comment_id:
+        github_api.add_reaction(comment_id, "-1")
+    return 0
+
+
 def _target_pr() -> int | None:
     recorded = Path("pr-number.txt")
     if recorded.exists() and recorded.read_text().strip():

--- a/scripts/ci/community-package/comment_commands.py
+++ b/scripts/ci/community-package/comment_commands.py
@@ -51,6 +51,33 @@ def check_command() -> int:
     return 0
 
 
+def _set_output(name: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a") as fh:
+            fh.write(f"{name}={value}\n")
+
+
+def _preview_reply(first_party: bool) -> tuple[str, str, str]:
+    if first_party:
+        return ("confused",
+                "ℹ️ This PR already builds a preview automatically, because its branch lives in this "
+                "repo. So `/preview` is not needed here; watch for the URL from the `Build and deploy "
+                "preview` check. The command is for fork PRs, whose automatic preview is skipped for "
+                "lack of secrets.",
+                "false")
+    return ("+1", "🔨 Building a preview. The URL will post here when it is ready.", "true")
+
+
+def preview_command() -> int:
+    pr, comment_id = int(os.environ["PR"]), os.environ["COMMENT_ID"]
+    reaction, comment, should_build = _preview_reply(github_api.pull_request_is_first_party(pr))
+    github_api.add_reaction(comment_id, reaction)
+    github_api.post_comment(pr, comment)
+    _set_output("should_build", should_build)
+    return 0
+
+
 def _target_pr() -> int | None:
     recorded = Path("pr-number.txt")
     if recorded.exists() and recorded.read_text().strip():

--- a/scripts/ci/community-package/github_api.py
+++ b/scripts/ci/community-package/github_api.py
@@ -65,6 +65,12 @@ def pull_request_head(pr: int) -> tuple[str, str]:
     return str(pull["user"]["login"]), str(pull["head"]["sha"])
 
 
+def pull_request_is_first_party(pr: int) -> bool:
+    pull = request(f"/repos/{repo()}/pulls/{pr}")
+    head_repo = (pull["head"].get("repo") or {}).get("full_name")
+    return bool(head_repo) and head_repo == pull["base"]["repo"]["full_name"]
+
+
 def open_pull_requests() -> list[dict[str, Any]]:
     return list(request(f"/repos/{repo()}/pulls?state=open&per_page=100"))
 

--- a/scripts/ci/community-package/github_api.py
+++ b/scripts/ci/community-package/github_api.py
@@ -60,13 +60,17 @@ def file_content_at(slug: str, path: str, ref: str) -> str:
     return base64.b64decode(encoded).decode()
 
 
+def pull_request(pr: int) -> dict[str, Any]:
+    return dict(request(f"/repos/{repo()}/pulls/{pr}"))
+
+
 def pull_request_head(pr: int) -> tuple[str, str]:
-    pull = request(f"/repos/{repo()}/pulls/{pr}")
+    pull = pull_request(pr)
     return str(pull["user"]["login"]), str(pull["head"]["sha"])
 
 
 def pull_request_is_first_party(pr: int) -> bool:
-    pull = request(f"/repos/{repo()}/pulls/{pr}")
+    pull = pull_request(pr)
     head_repo = (pull["head"].get("repo") or {}).get("full_name")
     return bool(head_repo) and head_repo == pull["base"]["repo"]["full_name"]
 

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -116,6 +116,16 @@ class CliNoticeTests(unittest.TestCase):
     def test_nothing_to_check_sheet(self) -> None:
         self.assertIn("Nothing to check", cli._nothing_to_check_sheet())
 
+    def test_preview_reply_first_party_skips_build(self) -> None:
+        _, comment, should_build = comment_commands._preview_reply(first_party=True)
+        self.assertEqual(should_build, "false")
+        self.assertIn("automatically", comment)
+
+    def test_preview_reply_fork_builds(self) -> None:
+        reaction, _, should_build = comment_commands._preview_reply(first_party=False)
+        self.assertEqual(should_build, "true")
+        self.assertEqual(reaction, "+1")
+
     def test_package_list_and_publisher_allowlist_are_permitted(self) -> None:
         changed = ["community-packages/package-list.json",
                    "tools/resourcedocsgen/pkg/publishers/publisher-names.json"]

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -126,6 +126,25 @@ class CliNoticeTests(unittest.TestCase):
         self.assertEqual(should_build, "true")
         self.assertEqual(reaction, "+1")
 
+    def test_preview_failure_comment_links_the_run(self) -> None:
+        posted: list[tuple[int, str]] = []
+        real = github_api.post_comment
+
+        def fake(pr: int, body: str) -> None:
+            posted.append((pr, body))
+
+        github_api.post_comment = fake
+        os.environ.update(PR="11661", GITHUB_SERVER_URL="https://github.com",
+                          GITHUB_REPOSITORY="pulumi/registry", GITHUB_RUN_ID="999")
+        os.environ.pop("COMMENT_ID", None)
+        try:
+            comment_commands.preview_failed()
+        finally:
+            github_api.post_comment = real
+        self.assertEqual(posted[0][0], 11661)
+        self.assertIn("actions/runs/999", posted[0][1])
+        self.assertIn("failed", posted[0][1])
+
     def test_package_list_and_publisher_allowlist_are_permitted(self) -> None:
         changed = ["community-packages/package-list.json",
                    "tools/resourcedocsgen/pkg/publishers/publisher-names.json"]


### PR DESCRIPTION
## What

Makes the site-preview experience correct for community-package onboarding PRs under the data-only flow, and gives `/preview` the same interactivity as `/check`.

Under the data-only onboarding flow an onboarding PR carries only the `community-packages/package-list.json` entry; the `<package>.yaml` and docs are generated, not committed. The automatic first-party `pull_request` preview built the raw tree, so the new package 404'd (e.g. `/registry/packages/thoth/`). The metadata-materializing step ran only for the `/preview` command.

## Changes

- **Automatic preview materializes onboarding entries.** `pull-request.yml` now passes `pr` to `build-and-deploy-preview`, so the first-party preview generates the new package's metadata (`resourcedocsgen metadata from-github`) and renders it instead of 404ing.
- **`run_preview` diffs the PR base by SHA**, not the on-disk file: a `pull_request` run is checked out at the head, where the on-disk list already contains the new entry, so the old on-disk diff found nothing.
- **Event-shim gated to the comment path.** The materialize step only shims `GITHUB_EVENT_*` when there is no native `pull_request` event (`issue_comment` / `workflow_dispatch`), so it does not tamper with the real event on the automatic build.
- **`/preview` acknowledges the comment**, mirroring `/check`: a reaction plus a status comment. On a first-party PR (already covered by the automatic preview) it explains that `/preview` is not needed and skips the redundant build; on a fork PR it posts a building note and proceeds.
- **`/preview` build guarded with `!cancelled()`** instead of the implicit `success()`: if the best-effort acknowledgment step errors, fall back to building (the safe direction) rather than silently skipping, while still respecting concurrency cancellation.
- **`/preview` reports build failures.** A `failure()` step comments a run-log link on the PR (previously the failure was only a red check). The acknowledgment step is `continue-on-error` so a transient ack error falls through to the build instead of surfacing as a spurious failure comment.

## Test plan

- `python3 -m unittest discover -p 'test_*.py'` in `scripts/ci/community-package` (27 tests); `mypy --strict *.py` clean; plane-separation guard passes.
- All three touched YAML files validate.
- End-to-end (after merge): re-run PR #11661's automatic preview and confirm `/registry/packages/thoth/` renders.

## Note

Touches the shared `build-and-deploy-preview` action and `pull-request.yml`, so it affects every preview build. For non-onboarding PRs the added materialize call is a cheap no-op (no added entries, early return).
