### PR TITLE
Flag unknown publishers in the community package check

### DIFF
--- a/scripts/ci/community-package/fact_sheet.py
+++ b/scripts/ci/community-package/fact_sheet.py
@@ -75,7 +75,16 @@ def render(manifest: Manifest) -> str:
         label = "plugin install" if result.language == "plugin" else f"{result.language} SDK"
         command = f"`{result.command}`" if result.command else "_not advertised_"
         lines.append(f"| {label} | {_RESULT_ICON.get(result.result, result.result)} | {command} |")
+    if manifest.publisher:
+        lines.append(f"| publisher listed | {'✅' if manifest.publisherKnown else '⚠️'} "
+                     f"| `{manifest.publisher}` in publisher-names.json |")
     lines += ["", f"Owner `{manifest.owner}`"]
+
+    if manifest.publisher and not manifest.publisherKnown:
+        lines += ["", f"**Publisher** ⚠️ `{manifest.publisher}` is not in `publisher-names.json`. Add "
+                      f"`\"{manifest.publisher}\": \"<slug>\"` to "
+                      "`tools/resourcedocsgen/pkg/publishers/publisher-names.json` in this PR; without it the "
+                      "registry-backend schema fetch fails and falls back to VCS."]
 
     findings = manifest.docLint
     lines.append("")

--- a/scripts/ci/community-package/models.py
+++ b/scripts/ci/community-package/models.py
@@ -63,3 +63,5 @@ class Manifest:
     generation: bool = True
     docs: list[DocFile] = field(default_factory=list)
     error: str = ""
+    publisher: str = ""
+    publisherKnown: bool = True

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -167,6 +167,14 @@ class VerifyTests(unittest.TestCase):
         self.assertEqual(manifest.error, "no release")
         self.assertEqual(manifest.providerName, "demo")
 
+    def test_publisher_known_only_when_listed(self) -> None:
+        names = {"Aten Security": "atensecurity", "aptible": "aptible"}
+        self.assertTrue(verify_entry._publisher_known("Aten Security", names))
+        self.assertFalse(verify_entry._publisher_known("Aten Security", {"aptible": "aptible"}))
+
+    def test_absent_publisher_is_not_flagged(self) -> None:
+        self.assertTrue(verify_entry._publisher_known("", {}))
+
 
 class ReportTargetTests(unittest.TestCase):
     def test_prefers_recorded_pr_number(self) -> None:
@@ -198,9 +206,11 @@ class ReportTargetTests(unittest.TestCase):
 
 
 def _manifest(green: bool = True, warnings: bool = False, findings: list[DocFinding] | None = None,
-              installs: list[InstallResult] | None = None, docs: list[DocFile] | None = None) -> Manifest:
+              installs: list[InstallResult] | None = None, docs: list[DocFile] | None = None,
+              publisher: str = "", publisherKnown: bool = True) -> Manifest:
     return Manifest("x/pulumi-demo", "s.json", "demo", Version("v1.0.0", "0" * 40), "x",
-                    installs or [], findings or [], green=green, warnings=warnings, docs=docs or [])
+                    installs or [], findings or [], green=green, warnings=warnings, docs=docs or [],
+                    publisher=publisher, publisherKnown=publisherKnown)
 
 
 class FactSheetTests(unittest.TestCase):
@@ -213,6 +223,17 @@ class FactSheetTests(unittest.TestCase):
         self.assertIn("docs/_index.md:12", out)
         self.assertIn("/blob/" + "0" * 40 + "/docs/_index.md", out)
         self.assertIn("# Title", out)
+
+    def test_unknown_publisher_is_flagged_in_the_sheet(self) -> None:
+        out = fact_sheet.render(_manifest(warnings=True, publisher="Aten Security", publisherKnown=False))
+        self.assertIn("publisher listed", out)
+        self.assertIn("⚠️", out)
+        self.assertIn("not in `publisher-names.json`", out)
+
+    def test_known_publisher_shows_row_without_warning_note(self) -> None:
+        out = fact_sheet.render(_manifest(publisher="Aten Security", publisherKnown=True))
+        self.assertIn("publisher listed", out)
+        self.assertNotIn("not in `publisher-names.json`", out)
 
     def test_red_render_with_install_failure(self) -> None:
         out = fact_sheet.render(_manifest(

--- a/scripts/ci/community-package/verify_entry.py
+++ b/scripts/ci/community-package/verify_entry.py
@@ -10,6 +10,19 @@ import sdk_install_probe
 import resourcedocsgen
 from models import DocFile, Entry, Manifest, Version, provider_name
 
+PUBLISHER_NAMES_PATH = Path("tools/resourcedocsgen/pkg/publishers/publisher-names.json")
+
+
+def _load_publisher_names() -> dict[str, str]:
+    try:
+        return dict(json.loads(PUBLISHER_NAMES_PATH.read_text()))
+    except OSError:
+        return {}
+
+
+def _publisher_known(publisher: str, names: dict[str, str]) -> bool:
+    return not publisher or publisher in names
+
 
 def _doc_file(slug: str, sha: str, path: str) -> DocFile | None:
     data = github_api.raw_file(slug, sha, path)
@@ -49,6 +62,8 @@ def verify(entry: Entry) -> Manifest:
                                     f"at release `{tag}`. Check the `schemaFile` path in the package list.")
     schema = json.loads(schema_bytes)
     name = provider_name(entry.repoSlug, schema)
+    publisher = str(schema.get("publisher", "")).strip()
+    publisher_known = _publisher_known(publisher, _load_publisher_names())
 
     index = _doc_file(entry.repoSlug, sha, "docs/_index.md")
     install_doc = _doc_file(entry.repoSlug, sha, "docs/installation-configuration.md")
@@ -63,7 +78,7 @@ def verify(entry: Entry) -> Manifest:
     has_blocking_failure = any(r.blocking and r.result != "pass" for r in installs)
     green = bool(generated and not has_blocking_failure and index is not None)
     advisory_failure = any(not r.blocking and r.result not in ("pass", "absent") for r in installs)
-    warnings = green and (advisory_failure or bool(findings))
+    warnings = green and (advisory_failure or bool(findings) or (bool(publisher) and not publisher_known))
 
     return Manifest(
         repoSlug=entry.repoSlug,
@@ -77,4 +92,6 @@ def verify(entry: Entry) -> Manifest:
         warnings=warnings,
         generation=generated,
         docs=docs,
+        publisher=publisher,
+        publisherKnown=publisher_known,
     )


### PR DESCRIPTION
The registry-backend schema fetch maps a package's publisher display name to
its slug through publisher-names.json (embedded in resourcedocsgen). A
publisher missing from that allowlist yields a malformed URL and a 400,
falling back to a VCS schema fetch. Nothing surfaced the gap on the PR, so an
onboarding author had no signal to add the entry.

Read the publisher from the schema during the check and, when it is not in
publisher-names.json, add an advisory row and a note to the fact-sheet telling
the author to add it (allowed in the onboarding PR since #11835). Advisory,
not blocking: the VCS fallback still renders the package.

## Test plan

- python3 -m unittest discover -p 'test_*.py' in scripts/ci/community-package (29 tests)
  - new: _publisher_known listed/unlisted/absent; fact-sheet flags an unknown publisher
- mypy --strict *.py clean
