### PR TITLE
[registry] Block community package checks on a mismatched schema version

### DIFF
--- a/scripts/ci/community-package/fact_sheet.py
+++ b/scripts/ci/community-package/fact_sheet.py
@@ -93,6 +93,9 @@ def render(manifest: Manifest) -> str:
         else:
             listed = "⚠️" if manifest.green else "❌"
         lines.append(f"| publisher listed | {listed} | `{manifest.publisher}` is a key in publisher-names.json |")
+    if manifest.schemaVersion:
+        lines.append(f"| schema version | {'✅' if manifest.schemaVersionMatches else '❌'} "
+                     f"| `{manifest.schemaVersion}` in `{manifest.schemaFile}` |")
     lines += ["", f"Owner `{manifest.owner}`"]
 
     if manifest.publisher and not manifest.publisherKnown:
@@ -104,6 +107,14 @@ def render(manifest: Manifest) -> str:
                       "value are usually the same. If this publisher already ships under a slug, use that one "
                       "so the two do not split. Without the entry the schema fetch from the registry backend "
                       "fails and falls back to VCS."]
+
+    if not manifest.schemaVersionMatches:
+        lines += ["", f"**Schema version** ❌ `{manifest.schemaFile}` declares version "
+                      f"`{manifest.schemaVersion}`, but the release is `{manifest.version.tag}`. The registry "
+                      "publishes the schema straight from the release tag and rejects a version that does not "
+                      "match. Either omit the `version` key entirely, which is what bridged providers do so the "
+                      "registry takes the version from the publish request, or stamp the real version at "
+                      "release time."]
 
     findings = manifest.docLint
     lines.append("")

--- a/scripts/ci/community-package/models.py
+++ b/scripts/ci/community-package/models.py
@@ -69,3 +69,5 @@ class Manifest:
     publisherKnown: bool = True
     docSourceURL: str = ""
     delisted: bool = False
+    schemaVersion: str = ""
+    schemaVersionMatches: bool = True

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -206,6 +206,17 @@ class VerifyTests(unittest.TestCase):
     def test_absent_publisher_is_not_flagged(self) -> None:
         self.assertTrue(verify_entry._publisher_known("", {}))
 
+    def test_schema_version_matches_tag_without_prefix(self) -> None:
+        self.assertTrue(verify_entry._schema_version_matches("0.4.5", "v0.4.5"))
+        self.assertTrue(verify_entry._schema_version_matches("0.4.5", "0.4.5"))
+
+    def test_placeholder_schema_version_does_not_match(self) -> None:
+        self.assertFalse(verify_entry._schema_version_matches("0.0.0", "v0.4.5"))
+        self.assertFalse(verify_entry._schema_version_matches("0.0.0-dev", "v1.3.0"))
+
+    def test_absent_schema_version_is_not_flagged(self) -> None:
+        self.assertTrue(verify_entry._schema_version_matches("", "v1.3.0"))
+
 
 class ReportTargetTests(unittest.TestCase):
     def test_prefers_recorded_pr_number(self) -> None:
@@ -239,11 +250,13 @@ class ReportTargetTests(unittest.TestCase):
 def _manifest(green: bool = True, warnings: bool = False, findings: list[DocFinding] | None = None,
               installs: list[InstallResult] | None = None, docs: list[DocFile] | None = None,
               publisher: str = "", publisherKnown: bool = True, generation: bool = True,
-              generationError: str = "", indexPresent: bool = True) -> Manifest:
+              generationError: str = "", indexPresent: bool = True,
+              schemaVersion: str = "", schemaVersionMatches: bool = True) -> Manifest:
     return Manifest("x/pulumi-demo", "s.json", "demo", Version("v1.0.0", "0" * 40), "x",
                     installs or [], findings or [], green=green, warnings=warnings,
                     generation=generation, docs=docs or [], generationError=generationError,
-                    indexPresent=indexPresent, publisher=publisher, publisherKnown=publisherKnown)
+                    indexPresent=indexPresent, publisher=publisher, publisherKnown=publisherKnown,
+                    schemaVersion=schemaVersion, schemaVersionMatches=schemaVersionMatches)
 
 
 class FactSheetTests(unittest.TestCase):
@@ -267,6 +280,17 @@ class FactSheetTests(unittest.TestCase):
         out = fact_sheet.render(_manifest(publisher="Aten Security", publisherKnown=True))
         self.assertIn("publisher listed", out)
         self.assertNotIn("no entry for", out)
+
+    def test_mismatched_schema_version_is_flagged_in_the_sheet(self) -> None:
+        out = fact_sheet.render(_manifest(green=False, schemaVersion="0.0.0", schemaVersionMatches=False))
+        self.assertIn("❌", out.splitlines()[0])
+        self.assertIn("schema version", out)
+        self.assertIn("declares version `0.0.0`", out)
+
+    def test_matching_schema_version_shows_row_without_note(self) -> None:
+        out = fact_sheet.render(_manifest(schemaVersion="1.0.0"))
+        self.assertIn("schema version", out)
+        self.assertNotIn("declares version", out)
 
     def test_red_render_with_install_failure(self) -> None:
         out = fact_sheet.render(_manifest(

--- a/scripts/ci/community-package/verify_entry.py
+++ b/scripts/ci/community-package/verify_entry.py
@@ -28,6 +28,10 @@ def _publisher_known(publisher: str, names: dict[str, str]) -> bool:
     return not publisher or publisher in names
 
 
+def _schema_version_matches(schema_version: str, tag: str) -> bool:
+    return not schema_version or schema_version == tag.lstrip("v")
+
+
 def _doc_file(slug: str, sha: str, path: str) -> DocFile | None:
     data = github_api.raw_file(slug, sha, path)
     if data is None:
@@ -68,6 +72,8 @@ def verify(entry: Entry) -> Manifest:
     name = provider_name(entry.repoSlug, schema)
     publisher = str(schema.get("publisher", "")).strip()
     publisher_known = _publisher_known(publisher, _load_publisher_names())
+    schema_version = str(schema.get("version", "")).strip()
+    schema_version_matches = _schema_version_matches(schema_version, tag)
 
     index = _doc_file(entry.repoSlug, sha, "docs/_index.md")
     install_doc = _doc_file(entry.repoSlug, sha, "docs/installation-configuration.md")
@@ -81,7 +87,7 @@ def verify(entry: Entry) -> Manifest:
     findings = doc_lint.find_issues(index.content if index else "")
 
     has_blocking_failure = any(r.blocking and r.result != "pass" for r in installs)
-    green = bool(generated and not has_blocking_failure and index is not None)
+    green = bool(generated and not has_blocking_failure and index is not None and schema_version_matches)
     advisory_failure = any(not r.blocking and r.result not in ("pass", "absent") for r in installs)
     warnings = green and (advisory_failure or bool(findings) or (bool(publisher) and not publisher_known))
 
@@ -101,6 +107,8 @@ def verify(entry: Entry) -> Manifest:
         indexPresent=index is not None,
         publisher=publisher,
         publisherKnown=publisher_known,
+        schemaVersion=schema_version,
+        schemaVersionMatches=schema_version_matches,
     )
 
 


### PR DESCRIPTION
## Why

The registry publishes a community package's schema straight from its release tag. The service rejects a schema whose own `version` field disagrees with the version being published:

```text
400 Bad Request: Schema version (0.0.0) must match query parameter version (0.4.5)
```

Two packages are in this state today and have been since they onboarded — `powerplatform` (`0.0.0`, rpothin/pulumi-powerplatform#82) and `terraform-provider` (`0.0.0-dev`, pulumi/pulumi-terraform-provider#113). Every release of both has failed the primary publish path and only landed because `push.yml` falls back to `push-registry.py`, which silently rewrites the version. Neither would have onboarded cleanly if `/check` had looked.

## What

`/check` now compares the schema's `version` against the release tag and blocks on a mismatch. An absent `version` stays valid — that's the bridged-provider convention (`pulumi-random`, `pulumi-cloudflare`, `pulumi-docker`, `pulumi-kubernetes`, `pulumi-command` all omit the field), and the service then takes the version from the publish request.

The fact sheet gains a `schema version` row and, on mismatch, a note naming both values and the two ways out.

## Notes

Blocking rather than advisory: it is a guaranteed publish failure once the legacy fallback is gone.

This is retroactive — an existing package that re-runs `/check` goes red until its upstream is fixed. That is `powerplatform` today, and `terraform-provider` until #113 ships in a release.

It only guards community submissions. First-party providers go through `publish-provider-update.yml`, which has no equivalent gate; that's a follow-up.
