### PR TITLE
[registry] Publish independently of the build, and stop retrying permanent rejections

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -115,6 +115,47 @@ jobs:
         with:
           name: origin-bucket-metadata
           path: origin-bucket-metadata.json
+
+  # Publishing reads the package YAML and the committed _index.md from the
+  # checkout, and fetches schemas over HTTP. It needs no build output, so it
+  # does not depend on the build job: a flake in the site build must not stop
+  # a released package version from reaching the registry.
+  publish:
+    name: Publish to registry
+    env:
+      GOPATH: ${{ github.workspace }}/go
+      ESC_ACTION_OIDC_AUTH: true
+      ESC_ACTION_OIDC_ORGANIZATION: pulumi
+      ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@3af4859af8a73a362fb599b944124097d4bb80c5 # v3
+        with:
+          environment: github-secrets/pulumi-registry
+          export-environment-variables: false
+      - name: Check out branch
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          # Full history needed for registry-mirror-discover to find package versions
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.x
+      - name: Configure git for private Go modules
+        run: git config --global url."https://${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/registry-mirror-tools".insteadOf "https://github.com/pulumi/registry-mirror-tools"
+      - name: Get registry-mirror-discover version
+        id: mirror-version
+        run: echo "hash=$(grep 'REGISTRY_MIRROR_TOOLS_COMMIT=' scripts/generate-versioned-docs.sh | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+      - name: Cache registry-mirror-discover binary
+        uses: actions/cache@v6
+        with:
+          path: bin/registry-mirror-discover
+          key: registry-mirror-discover-${{ steps.mirror-version.outputs.hash }}
       - name: Install uv for publish
         uses: astral-sh/setup-uv@v7
       - name: Publish to registry (primary)
@@ -125,6 +166,8 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
           PULUMI_API_URL: https://api.pulumi.com
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PUBLISH_COMMIT_SHA: ${{ github.sha }}
 
       - name: Push to the Live Registry (legacy fallback)
         id: legacy-publish

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -651,10 +651,19 @@ Push to master
                 │       │           (reads origin-bucket-metadata.json, updates CloudFront)
                 │       └── scripts/ci/make-s3-redirects.sh
                 │               └── Apply 301 redirects from scripts/redirects/
-                ├── Archive origin-bucket-metadata.json as artifact
-                └── uv run push-registry.py
-                        └── Publish new provider versions to registry service
+                └── Archive origin-bucket-metadata.json as artifact
+
+publish (independent job, does not need build)
+    └── uv run publish_to_registry.py
+            └── Publish new provider versions to the registry service
+                └── on a permanent rejection, open an issue instead of retrying
 ```
+
+The `publish` job deliberately has no `needs:`. Publishing reads the package YAML and the
+committed `_index.md` from the checkout and fetches schemas over HTTP, so it needs no build
+output. Keeping it independent means a flake in the site build cannot stop a released package
+version from reaching the registry. See `docs/registry-publish-drift.md` for the failures that
+motivated this.
 
 **Runner**: `pulumi-service-ubuntu-24.04-16core`
 

--- a/scripts/ci/publish_to_registry.py
+++ b/scripts/ci/publish_to_registry.py
@@ -13,9 +13,13 @@ Usage:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -170,13 +174,83 @@ def ensure_tools_installed(repo_root: Path) -> tuple[Path, Path]:
     return discover_bin, publish_bin
 
 
+@dataclass
+class PackageFailure:
+    """A package registry-mirror-publish reported as failed."""
+
+    spec: str
+    reason: str
+    status_code: int | None
+
+    @property
+    def permanent(self) -> bool:
+        """A 4xx on a well-formed request fails identically however often we retry.
+
+        The canonical case is a schema whose version field disagrees with the
+        version being published. Retrying that is noise, not resilience.
+        """
+        return self.status_code is not None and 400 <= self.status_code < 500
+
+
+@dataclass
+class PublishOutcome:
+    succeeded: bool
+    failures: list[PackageFailure]
+    parsed: bool
+
+    @property
+    def permanent_failures(self) -> list[PackageFailure]:
+        return [f for f in self.failures if f.permanent]
+
+    @property
+    def worth_retrying(self) -> bool:
+        """Retry unless every failure is one we know will recur.
+
+        Unparsed output is retried, so a change to the tool's output format
+        degrades to the old behaviour rather than skipping the retries.
+        """
+        if not self.parsed or not self.failures:
+            return True
+        return any(not f.permanent for f in self.failures)
+
+
+def parse_publish_output(stdout: str) -> tuple[list[PackageFailure], bool]:
+    """Read the per-package JSON that registry-mirror-publish emits.
+
+    Returns the failures and whether any structured output was found at all.
+    """
+    failures = []
+    parsed_any = False
+    for line in stdout.splitlines():
+        marker = line.find("[output] ")
+        if marker < 0:
+            continue
+        try:
+            record = json.loads(line[marker + len("[output] "):])
+        except json.JSONDecodeError:
+            continue
+        parsed_any = True
+        if record.get("status") != "failed":
+            continue
+        reason = str(record.get("reason", "")).strip()
+        spec = (f"{record.get('source')}/{record.get('publisher')}/"
+                f"{record.get('package')}@{record.get('version')}")
+        failures.append(PackageFailure(spec, reason, http_status_in(reason)))
+    return failures, parsed_any
+
+
+def http_status_in(reason: str) -> int | None:
+    match = re.search(r"\b([45]\d{2})\b", reason)
+    return int(match.group(1)) if match else None
+
+
 def publish_specs(
     specs: list[str],
     repo_root: Path,
     discover_bin: Path,
     publish_bin: Path,
     dry_run: bool = False,
-) -> bool:
+) -> PublishOutcome:
     """Run discover and publish pipeline for the given specs."""
     specs_input = "\n".join(specs)
 
@@ -194,6 +268,7 @@ def publish_specs(
     publish = subprocess.Popen(
         publish_cmd,
         stdin=discover.stdout,
+        stdout=subprocess.PIPE,
         text=True,
     )
 
@@ -201,10 +276,90 @@ def publish_specs(
     discover.stdin.close()
     discover.stdout.close()
 
-    publish.wait()
+    stdout, _ = publish.communicate()
     discover.wait()
+    print(stdout, end="")
 
-    return discover.returncode == 0 and publish.returncode == 0
+    failures, parsed = parse_publish_output(stdout)
+    succeeded = discover.returncode == 0 and publish.returncode == 0
+    return PublishOutcome(succeeded, failures, parsed)
+
+
+ISSUE_TITLE = "Registry publish rejected: {package}"
+ISSUE_LABEL = "registry-publish-failure"
+
+
+def github_api(method: str, path: str, token: str, payload: dict | None = None) -> dict | list | None:
+    request = urllib.request.Request(
+        f"https://api.github.com{path}",
+        method=method,
+        data=json.dumps(payload).encode() if payload else None,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "pulumi-registry-publish",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read() or "null")
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as err:
+        print(f"GitHub API {method} {path} failed: {err}")
+        return None
+
+
+def issue_body(failure: PackageFailure, commit: str) -> str:
+    return "\n".join([
+        f"`{failure.spec}` was rejected by the registry service:",
+        "",
+        "```text",
+        failure.reason,
+        "```",
+        "",
+        f"Published from {commit}." if commit else "",
+        "",
+        "This is a permanent rejection, not a flake: the publish retries were skipped because the "
+        "same request will be rejected identically every time. The package will keep failing on "
+        "every release until its upstream repository is fixed.",
+        "",
+        "The usual cause is a schema whose `version` field disagrees with the version being "
+        "published. Providers should either omit the field, which is what bridged providers do so "
+        "the service takes the version from the publish request, or stamp the real version at "
+        "release time.",
+    ])
+
+
+def report_permanent_failures(failures: list[PackageFailure]) -> None:
+    """Open one issue per permanently failing package, reusing an open one if present."""
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        print("GITHUB_TOKEN or GITHUB_REPOSITORY unset, skipping issue reporting")
+        return
+
+    commit = os.environ.get("PUBLISH_COMMIT_SHA", "")
+    for failure in failures:
+        package = failure.spec.split("/")[-1].split("@")[0]
+        title = ISSUE_TITLE.format(package=package)
+        query = urllib.parse.quote(f'repo:{repo} is:issue is:open in:title "{title}"')
+        found = github_api("GET", f"/search/issues?q={query}", token)
+
+        existing = (found or {}).get("items") if isinstance(found, dict) else None
+        if existing:
+            number = existing[0]["number"]
+            print(f"Issue #{number} already open for {package}, adding a comment")
+            github_api("POST", f"/repos/{repo}/issues/{number}/comments", token,
+                       {"body": issue_body(failure, commit)})
+            continue
+
+        created = github_api("POST", f"/repos/{repo}/issues", token, {
+            "title": title,
+            "body": issue_body(failure, commit),
+            "labels": [ISSUE_LABEL],
+        })
+        if created:
+            print(f"Opened issue #{created.get('number')} for {package}")
 
 
 def publish_with_retry(specs: list[str], config: Config) -> bool:
@@ -220,17 +375,28 @@ def publish_with_retry(specs: list[str], config: Config) -> bool:
     print()
 
     backoff = config.initial_backoff
+    outcome = None
     for attempt in range(1, config.max_retries + 1):
         print(f"Attempt {attempt} of {config.max_retries}...")
 
-        if publish_specs(specs, config.repo_root, discover_bin, publish_bin, config.dry_run):
+        outcome = publish_specs(specs, config.repo_root, discover_bin, publish_bin, config.dry_run)
+        if outcome.succeeded:
             print("Successfully published packages")
             return True
+
+        if not outcome.worth_retrying:
+            print("Every failure is a permanent rejection, not retrying:")
+            for failure in outcome.permanent_failures:
+                print(f"  {failure.spec}: {failure.reason}")
+            break
 
         if attempt < config.max_retries:
             print(f"Publish failed, retrying in {backoff}s...")
             time.sleep(backoff)
             backoff = min(backoff * 2, config.max_backoff)
+
+    if outcome and outcome.permanent_failures and not config.dry_run:
+        report_permanent_failures(outcome.permanent_failures)
 
     print(f"Failed to publish after {config.max_retries} attempts")
     return False

--- a/scripts/ci/test_publish_to_registry.py
+++ b/scripts/ci/test_publish_to_registry.py
@@ -9,12 +9,16 @@ from unittest.mock import MagicMock, patch
 
 from publish_to_registry import (
     Config,
+    PackageFailure,
+    PublishOutcome,
     SpecResult,
     build_package_spec,
     build_specs,
     get_changed_packages,
     load_publishers,
+    parse_publish_output,
     publish_with_retry,
+    report_permanent_failures,
 )
 
 
@@ -268,12 +272,16 @@ class TestBuildSpecs(unittest.TestCase):
         self.assertEqual(errors, ["missing version"])
 
 
+def _outcome(succeeded, failures=None, parsed=False):
+    return PublishOutcome(succeeded, failures or [], parsed)
+
+
 class TestPublishWithRetry(unittest.TestCase):
     @patch("publish_to_registry.ensure_tools_installed")
     @patch("publish_to_registry.publish_specs")
     def test_succeeds_on_first_attempt(self, mock_publish, mock_tools):
         mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
-        mock_publish.return_value = True
+        mock_publish.return_value = _outcome(True)
         config = Config(repo_root=Path("/repo"))
 
         result = publish_with_retry(["pulumi/pulumi/aws@6.50.0"], config)
@@ -286,7 +294,7 @@ class TestPublishWithRetry(unittest.TestCase):
     @patch("publish_to_registry.time.sleep")
     def test_retries_on_failure(self, mock_sleep, mock_publish, mock_tools):
         mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
-        mock_publish.side_effect = [False, False, True]
+        mock_publish.side_effect = [_outcome(False), _outcome(False), _outcome(True)]
         config = Config(repo_root=Path("/repo"), max_retries=3, initial_backoff=1)
 
         result = publish_with_retry(["pulumi/pulumi/aws@6.50.0"], config)
@@ -300,7 +308,7 @@ class TestPublishWithRetry(unittest.TestCase):
     @patch("publish_to_registry.time.sleep")
     def test_fails_after_max_retries(self, mock_sleep, mock_publish, mock_tools):
         mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
-        mock_publish.return_value = False
+        mock_publish.return_value = _outcome(False)
         config = Config(repo_root=Path("/repo"), max_retries=3, initial_backoff=1)
 
         result = publish_with_retry(["pulumi/pulumi/aws@6.50.0"], config)
@@ -313,7 +321,7 @@ class TestPublishWithRetry(unittest.TestCase):
     @patch("publish_to_registry.time.sleep")
     def test_exponential_backoff(self, mock_sleep, mock_publish, mock_tools):
         mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
-        mock_publish.side_effect = [False, False, False]
+        mock_publish.side_effect = [_outcome(False), _outcome(False), _outcome(False)]
         config = Config(
             repo_root=Path("/repo"),
             max_retries=3,
@@ -331,7 +339,7 @@ class TestPublishWithRetry(unittest.TestCase):
     @patch("publish_to_registry.time.sleep")
     def test_backoff_capped_at_max(self, mock_sleep, mock_publish, mock_tools):
         mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
-        mock_publish.side_effect = [False, False, False, False]
+        mock_publish.side_effect = [_outcome(False)] * 4
         config = Config(
             repo_root=Path("/repo"),
             max_retries=4,
@@ -410,3 +418,133 @@ class TestEveryPackageResolves(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+REJECTION = (
+    'publish_failed: complete publish failed: 400: {"code":400,"message":'
+    '"Bad Request: Schema version (0.0.0-dev) must match query parameter version (1.3.0)"}'
+)
+
+
+def _output_line(status, reason=""):
+    return "2026-08-04T17:13:16Z [output] " + json.dumps({
+        "source": "pulumi", "publisher": "pulumi", "package": "terraform-provider",
+        "version": "1.3.0", "status": status, "reason": reason,
+    })
+
+
+class TestParsePublishOutput(unittest.TestCase):
+    def test_reads_failures_and_their_status_code(self):
+        failures, parsed = parse_publish_output(_output_line("failed", REJECTION))
+        self.assertTrue(parsed)
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].spec, "pulumi/pulumi/terraform-provider@1.3.0")
+        self.assertEqual(failures[0].status_code, 400)
+        self.assertTrue(failures[0].permanent)
+
+    def test_published_packages_are_not_failures(self):
+        failures, parsed = parse_publish_output(_output_line("published"))
+        self.assertTrue(parsed)
+        self.assertEqual(failures, [])
+
+    def test_output_without_json_is_not_parsed(self):
+        failures, parsed = parse_publish_output("Done. Published: 0, Skipped: 0, Failed: 1")
+        self.assertFalse(parsed)
+        self.assertEqual(failures, [])
+
+    def test_malformed_json_is_skipped(self):
+        failures, parsed = parse_publish_output("[output] {not json")
+        self.assertFalse(parsed)
+        self.assertEqual(failures, [])
+
+
+class TestFailureClassification(unittest.TestCase):
+    def test_server_errors_are_retried(self):
+        outcome = PublishOutcome(False, [PackageFailure("a@1", "503: upstream", 503)], parsed=True)
+        self.assertTrue(outcome.worth_retrying)
+        self.assertEqual(outcome.permanent_failures, [])
+
+    def test_client_errors_are_not_retried(self):
+        outcome = PublishOutcome(False, [PackageFailure("a@1", REJECTION, 400)], parsed=True)
+        self.assertFalse(outcome.worth_retrying)
+        self.assertEqual(len(outcome.permanent_failures), 1)
+
+    def test_a_single_transient_failure_still_retries(self):
+        outcome = PublishOutcome(False, [
+            PackageFailure("a@1", REJECTION, 400),
+            PackageFailure("b@2", "502: bad gateway", 502),
+        ], parsed=True)
+        self.assertTrue(outcome.worth_retrying)
+
+    def test_unparsed_output_falls_back_to_retrying(self):
+        outcome = PublishOutcome(False, [], parsed=False)
+        self.assertTrue(outcome.worth_retrying)
+
+    def test_failure_without_a_status_code_is_retried(self):
+        outcome = PublishOutcome(False, [PackageFailure("a@1", "connection reset", None)], parsed=True)
+        self.assertTrue(outcome.worth_retrying)
+
+
+class TestRetrySkipsPermanentFailures(unittest.TestCase):
+    @patch("publish_to_registry.report_permanent_failures")
+    @patch("publish_to_registry.ensure_tools_installed")
+    @patch("publish_to_registry.publish_specs")
+    @patch("publish_to_registry.time.sleep")
+    def test_permanent_rejection_stops_after_one_attempt(self, mock_sleep, mock_publish,
+                                                        mock_tools, mock_report):
+        mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
+        failure = PackageFailure("pulumi/pulumi/terraform-provider@1.3.0", REJECTION, 400)
+        mock_publish.return_value = PublishOutcome(False, [failure], parsed=True)
+
+        result = publish_with_retry(["pulumi/pulumi/terraform-provider@1.3.0"],
+                                    Config(repo_root=Path("/repo"), max_retries=3))
+
+        self.assertFalse(result)
+        self.assertEqual(mock_publish.call_count, 1)
+        self.assertEqual(mock_sleep.call_count, 0)
+        mock_report.assert_called_once_with([failure])
+
+    @patch("publish_to_registry.report_permanent_failures")
+    @patch("publish_to_registry.ensure_tools_installed")
+    @patch("publish_to_registry.publish_specs")
+    @patch("publish_to_registry.time.sleep")
+    def test_dry_run_does_not_file_issues(self, mock_sleep, mock_publish, mock_tools, mock_report):
+        mock_tools.return_value = (Path("/bin/discover"), Path("/bin/publish"))
+        mock_publish.return_value = PublishOutcome(
+            False, [PackageFailure("a@1", REJECTION, 400)], parsed=True)
+
+        publish_with_retry(["a@1"], Config(repo_root=Path("/repo"), dry_run=True))
+
+        mock_report.assert_not_called()
+
+
+class TestReportPermanentFailures(unittest.TestCase):
+    def setUp(self):
+        self.env = {"GITHUB_TOKEN": "t", "GITHUB_REPOSITORY": "pulumi/registry"}
+
+    @patch("publish_to_registry.github_api")
+    def test_opens_an_issue_when_none_is_open(self, mock_api):
+        mock_api.side_effect = [{"items": []}, {"number": 7}]
+        with patch.dict("os.environ", self.env, clear=True):
+            report_permanent_failures([PackageFailure(
+                "pulumi/pulumi/terraform-provider@1.3.0", REJECTION, 400)])
+
+        method, path = mock_api.call_args_list[1][0][0], mock_api.call_args_list[1][0][1]
+        self.assertEqual((method, path), ("POST", "/repos/pulumi/registry/issues"))
+        self.assertIn("terraform-provider", mock_api.call_args_list[1][0][3]["title"])
+
+    @patch("publish_to_registry.github_api")
+    def test_comments_instead_of_opening_a_duplicate(self, mock_api):
+        mock_api.side_effect = [{"items": [{"number": 42}]}, {}]
+        with patch.dict("os.environ", self.env, clear=True):
+            report_permanent_failures([PackageFailure(
+                "pulumi/pulumi/terraform-provider@1.3.0", REJECTION, 400)])
+
+        method, path = mock_api.call_args_list[1][0][0], mock_api.call_args_list[1][0][1]
+        self.assertEqual((method, path), ("POST", "/repos/pulumi/registry/issues/42/comments"))
+
+    @patch("publish_to_registry.github_api")
+    def test_without_a_token_nothing_is_filed(self, mock_api):
+        with patch.dict("os.environ", {}, clear=True):
+            report_permanent_failures([PackageFailure("a@1", REJECTION, 400)])
+        mock_api.assert_not_called()


### PR DESCRIPTION
Supersedes the reconciliation blocker on #11998.

## The problem

Publishing was the last step of the `build` job. When the build failed, the publish step was skipped, and because the primary path is scoped to `git diff HEAD~1`, nothing ever revisited that package. The version was simply never published.

Seven package versions were dropped this way between March and August:

| run | date | dropped | why the build failed |
|---|---|---|---|
| 23263250725 | 2026-03-18 | `equinix@0.29.1` | `Build and deploy` |
| 24817511189 | 2026-04-23 | `fastly@12.0.1` | `Build and deploy` |
| 24817652115 | 2026-04-23 | `mongodbatlas@4.8.0` | `Build and deploy` |
| 24824043787 | 2026-04-23 | `ctfd@2.4.3` | `Build and deploy` |
| 25906915426 | 2026-05-15 | `equinix@0.30.0` | build job never started |
| 29441117266 | 2026-07-15 | `rootly@3.7.0` | `Install s5cmd` download failed |
| 30673917138 | 2026-07-31 | `selectel@8.2.4` | 403 fetching `llm-docs.json` |

None is a publish bug. Four were later repaired by the legacy fallback's full sweep, but only by coincidence: `terraform-provider` happened to fail in the same run and drag the fallback in. `fastly@12.0.1`, `ctfd@2.4.3` and `selectel@8.2.4` are still 404 today.

Retrying does not address this — `publish_with_retry` already backs off three times, and it never ran. The failing layer is the build.

## Publish is now its own job

Publishing needs a checkout, not a build. It reads the package YAML and the committed `_index.md` from the repo and fetches schemas over HTTP; the only generated content is `api-docs/`, which it never touches. Confirmed against the tool's own output, where `docs_source` is either an upstream URL or `registry:<pkg>@<sha>`, resolved from the checkout at that commit.

So `publish` has no `needs:`. A site build flake can no longer stop a released version from reaching the registry, and all seven drops above would not have happened.

The legacy fallback moves across unchanged, so this does not conflict semantically with #11998 — that PR then just deletes the step from its new home.

## Permanent rejections stop retrying and file an issue

`registry-mirror-publish` emits per-package JSON:

```json
{"package":"terraform-provider","version":"1.3.0","status":"failed",
 "reason":"publish_failed: complete publish failed: 400: {\"code\":400,\"message\":\"Bad Request: Schema version (0.0.0-dev) must match query parameter version (1.3.0)\"}"}
```

The retry loop now captures and parses that. A `4xx` is a deterministic rejection — the same request will be rejected identically forever, which is what the 11 fallback runs demonstrate — so the remaining attempts are skipped and an issue is opened naming the package, the version and the service's message. `5xx`, connection errors and anything without a recognisable status retry as before.

Two deliberate choices:

- **Fail open.** Output the parser does not recognise is treated as retryable, so a change to the tool's format degrades to today's behaviour rather than silently skipping retries. The format is a contract owned by `registry-mirror-tools` at pinned commit `dda1dfd8`, so this matters.
- **Dedupe.** The reporter searches for an open issue with the same title first and comments on it instead of opening a second. Without that, every nightly would file a fresh `terraform-provider` issue.

Issues are filed with `PULUMI_BOT_TOKEN`, not the default `GITHUB_TOKEN`, and never in `--dry-run`.

## Tests

32 pass. New coverage for output parsing, the 4xx/5xx/unparsed classification, that a permanent rejection stops after one attempt, that `--dry-run` files nothing, and that the reporter comments rather than duplicating.

## Notes

The publish step keeps `continue-on-error: true`, so a failed publish still leaves the job green and relies on the Slack alert plus the new issue for visibility. Worth revisiting, but changing it here would have mixed a behavioural change into a structural one.

One consequence worth a look: the registry can now update while the site build is failing. I think that is correct — the registry is what `pulumi package add` resolves and it should not be held hostage to a docs build — but the two can now be briefly out of step, which today they cannot.

Background: `docs/registry-publish-drift.md` in #11998.
