### PR TITLE
[ci] Retry the community package version check

### DIFF
--- a/.github/workflows/generate-package-metadata.yml
+++ b/.github/workflows/generate-package-metadata.yml
@@ -86,12 +86,26 @@ jobs:
       - name: Check for a new version
         if: steps.skip-run.outputs.skip != 1
         id: version
+        env:
+          REPO_SLUG: ${{ matrix.repoSlug }}
         run: |
-          echo 'PROVIDER_VERSION<<EOF' >> $GITHUB_ENV
-          go build -C tools/resourcedocsgen
-          ./tools/resourcedocsgen/resourcedocsgen pkgversion --repoSlug ${{ matrix.repoSlug }} \
-          >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          max_attempts=3
+          for attempt in $(seq "$max_attempts"); do
+            if go build -C tools/resourcedocsgen &&
+              provider_version=$(./tools/resourcedocsgen/resourcedocsgen pkgversion --repoSlug "$REPO_SLUG"); then
+              {
+                echo 'PROVIDER_VERSION<<EOF'
+                echo "$provider_version"
+                echo 'EOF'
+              } >> "$GITHUB_ENV"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          echo "Could not check $REPO_SLUG for a new version after $max_attempts attempts."
+          exit 1
       - name: Display new version
         if: env.PROVIDER_VERSION
         run: echo ${{ env.PROVIDER_VERSION}}


### PR DESCRIPTION
The "Check for a new version" step in the community package update workflow makes two unretried network calls: `go build` can download the Go toolchain, and `resourcedocsgen pkgversion` fetches release metadata from api.github.com and raw.githubusercontent.com. The workflow fans out to ~102 matrix jobs, so a single `connection reset by peer` fails the whole run and files a p1 issue. Four of the last twelve runs failed this way (Aug 6, 8, 9 and 11).

This PR retries the build and the version check together, three attempts with a five second linear backoff.

It also fixes the heredoc delimiter ordering. The opening `PROVIDER_VERSION<<EOF` line was written to `$GITHUB_ENV` before the command ran, so a failure under `bash -e` skipped the closing `EOF` and every one of these failures also reported `Unable to process file command 'env' successfully` and `Invalid value. Matching delimiter not found 'EOF'`, which buried the real error. The block is now written only after the command succeeds.

Downstream behavior is unchanged: an empty version still means "no new release" and still skips the steps that gate on `if: env.PROVIDER_VERSION`.

Fixes #12045

Related: #12019 is the other failure triaged in the same pass. That one is not transient (a missing `stripe` publisher entry) and is being fixed separately.

## Test plan

1. Automated checks
   - The workflow YAML parses with `yaml.safe_load`
   - `shellcheck` reports no findings for the extracted step script
2. Manual checks
   - Ran the retry loop under `bash -e` with stubbed `go build` and `pkgversion` commands covering: a new version, an empty version, a failure on the first two attempts, a permanent `pkgversion` failure, and a permanent build failure. `$GITHUB_ENV` always ends up with a complete `PROVIDER_VERSION<<EOF ... EOF` block or no block at all
