### PR TITLE
[registry] Add the stripe publisher to publisher-names.json

### DIFF
--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -147,6 +147,7 @@
     "splightplatform": "splightplatform",
     "stackitcloud": "stackitcloud",
     "Statsig": "statsig",
+    "stripe": "stripe",
     "sumologic": "sumologic",
     "supabase": "supabase",
     "sysdiglabs": "sysdiglabs",


### PR DESCRIPTION

`stripe.yaml` arrived with `publisher: stripe` when the package was onboarded in #12018, but `publisher-names.json` has no matching entry. `push-registry.py` raises on any publisher it cannot resolve, so `Test Live Registry Publish` has failed on every run of that PR since 2026-08-07.

The slug follows the OpenTofu namespace, as it does for the other 102 bridged packages: `registry.opentofu.org/stripe/stripe` resolves to `opentofu/stripe/stripe@0.3.0-beta.4`.

Fixes https://github.com/pulumi/registry/issues/12019

## Test plan

1. Automated tests
    - `go test ./...` in `tools/resourcedocsgen`: the file is `go:embed`ed and `publishers` panics on malformed JSON, so a green run proves it parses
2. Manual checks
    - Replayed `push-registry.py`'s publisher resolution against the `stripe.yaml` from #12018: it raised `Missing publisher entry for "stripe"` before, and yields `opentofu/stripe/stripe@0.3.0-beta.4` after
    - Audited all 307 package YAMLs: 30 DEPRECATED, 277 resolve, none unresolved