### PR TITLE
[registry] Run the community package checks on every publish path

### DIFF
--- a/.github/workflows/community-package-check.yml
+++ b/.github/workflows/community-package-check.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: pip install pyyaml
+
       - name: Install the Pulumi CLI (for the plugin install probe)
         run: |
           curl -fsSL https://get.pulumi.com | sh

--- a/.github/workflows/community-package-policy.yml
+++ b/.github/workflows/community-package-policy.yml
@@ -21,5 +21,7 @@ jobs:
         run: python3 -m unittest discover -p 'test_*.py'
         working-directory: scripts/ci/community-package
       - name: Type-check
-        run: pipx run mypy --strict *.py
+        run: |
+          pip install mypy types-PyYAML
+          mypy --strict *.py
         working-directory: scripts/ci/community-package

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,7 @@ jobs:
     - test-provider-api-docs
     - preview
     - test-live-publish
+    - check-publish
     runs-on: ubuntu-latest
     steps:
     - uses: guibranco/github-status-action-v2@77639353504055053524efa7a3719aaf0b731ce9 # v1.2.4
@@ -41,6 +42,44 @@ jobs:
         # Write to the PR commit SHA if it's available as we don't want the merge commit sha,
         # otherwise use the current SHA for any other type of build.
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
+
+  check-publish:
+    name: Check published packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Check the packages this PR publishes
+        id: check
+        run: >-
+          python3 scripts/ci/community-package/cli.py check-publish
+          --diff "origin/${{ github.base_ref }}"
+          --out "${{ runner.temp }}/factsheets"
+
+      - name: Post the fact-sheet
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          shopt -s nullglob
+          sheets=("${RUNNER_TEMP}"/factsheets/*.factsheet.md)
+          [ ${#sheets[@]} -eq 0 ] && exit 0
+          cat "${sheets[@]}" > "${RUNNER_TEMP}/comment.md"
+          gh pr comment "$PR" --edit-last --create-if-none --body-file "${RUNNER_TEMP}/comment.md"
 
   resourcedocsgen:
     uses: ./.github/workflows/check-go.yml

--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -2,14 +2,15 @@
 """Command-line entry point for the community package tooling. Each subcommand is one CI step:
 
     check           verify the added entry and write a fact-sheet (runs on the PR)
+    check-publish   verify the packages a publish PR writes (runs on every publish path)
     preview         materialize a fork PR's entry so its site preview can be built
     report          post the fact-sheet as a sticky PR comment
     check-command   handle a /check comment
     preview-command handle a /preview comment
     preview-failed  post a build-failure comment for a /preview run
 
-The logic lives in the sibling modules (verify_entry, resourcedocsgen, fact_sheet, comment_commands, ...); stdlib
-only, no third-party dependencies.
+The logic lives in the sibling modules (verify_entry, resourcedocsgen, fact_sheet, comment_commands, ...).
+PyYAML is the only third-party dependency.
 """
 from __future__ import annotations
 
@@ -113,6 +114,41 @@ def run_preview(args: argparse.Namespace) -> int:
     return 0
 
 
+PACKAGE_YAML_DIR = Path("themes/default/data/registry/packages")
+
+
+def _changed_package_yamls(base_ref: str) -> list[Path]:
+    changed = subprocess.run(["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+                             capture_output=True, text=True).stdout
+    return [Path(f) for f in changed.splitlines()
+            if f.endswith(".yaml") and Path(f).parent == PACKAGE_YAML_DIR]
+
+
+def run_check_publish(args: argparse.Namespace) -> int:
+    """Check the packages a publish PR writes, whatever opened it.
+
+    Every publish path ends in a PR that writes a package YAML, so checking the PR covers
+    the dispatches and the nightly bump alike without touching either workflow.
+    """
+    out = Path(args.out)
+    changed = _changed_package_yamls(args.diff)
+    if not changed:
+        print("no package YAML changed in this PR")
+        return 0
+
+    repo_root = Path.cwd()
+    failed = False
+    for index, yaml_path in enumerate(sorted(changed)):
+        manifest = verify_entry.verify_package_yaml(yaml_path, repo_root)
+        if manifest.delisted:
+            print(f"{manifest.providerName} is delisted; nothing to check")
+            continue
+        _write_sheet(out, f"{index:03d}.factsheet.md", fact_sheet.render(manifest))
+        if not manifest.green:
+            failed = True
+    return 1 if failed else 0
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="community-package")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -121,6 +157,11 @@ def main(argv: list[str]) -> int:
     check.add_argument("--diff", metavar="BASEREF", required=True)
     check.add_argument("--out", default=".")
     check.set_defaults(run=run_check)
+
+    check_publish = sub.add_parser("check-publish")
+    check_publish.add_argument("--diff", metavar="BASEREF", required=True)
+    check_publish.add_argument("--out", default=".")
+    check_publish.set_defaults(run=run_check_publish)
 
     preview = sub.add_parser("preview")
     preview.add_argument("--pr", type=int, required=True)

--- a/scripts/ci/community-package/fact_sheet.py
+++ b/scripts/ci/community-package/fact_sheet.py
@@ -52,39 +52,55 @@ def render(manifest: Manifest) -> str:
         return "\n".join([
             f"## ❌ `{manifest.providerName}` · community package check",
             "",
-            f"`{manifest.repoSlug}`",
+            f"`{manifest.repoSlug or manifest.schemaFile}`",
             "",
             f"**Not ready.** {manifest.error}",
         ] + _stamp_lines())
 
     icon, verdict = _verdict(manifest)
-    commit_url = f"https://github.com/{manifest.repoSlug}/commit/{manifest.version.commitSha}"
+
+    if manifest.version.commitSha:
+        commit_url = f"https://github.com/{manifest.repoSlug}/commit/{manifest.version.commitSha}"
+        subtitle = (f"`{manifest.repoSlug}` · `{manifest.version.tag}` · commit "
+                    f"[`{manifest.version.commitSha[:12]}`]({commit_url})")
+    else:
+        subtitle = f"`{manifest.repoSlug or manifest.schemaFile}` · `{manifest.version.tag}`"
 
     lines = [
         f"## {icon} `{manifest.providerName}` · community package check",
         "",
-        f"`{manifest.repoSlug}` · `{manifest.version.tag}` · commit [`{manifest.version.commitSha[:12]}`]({commit_url})",
+        subtitle,
         "",
         verdict,
         "",
         "| check | | command |",
         "|---|:-:|---|",
-        f"| docs generate | {'✅' if manifest.generation else '❌'} | `resourcedocsgen metadata from-github` |",
+        f"| docs generate | {'✅' if manifest.generation else '❌'} | `resourcedocsgen metadata "
+        f"{'from-github' if manifest.version.commitSha else 'from-urls'}` |",
     ]
     for result in manifest.installMatrix:
-        label = "plugin install" if result.language == "plugin" else f"{result.language} SDK"
+        if result.language == "plugin":
+            label = "plugin install"
+        elif result.language == "package add":
+            label = "package add"
+        else:
+            label = f"{result.language} SDK"
         command = f"`{result.command}`" if result.command else "_not advertised_"
         lines.append(f"| {label} | {_RESULT_ICON.get(result.result, result.result)} | {command} |")
     if manifest.publisher:
-        lines.append(f"| publisher listed | {'✅' if manifest.publisherKnown else '⚠️'} "
-                     f"| `{manifest.publisher}` in publisher-names.json |")
+        if manifest.publisherKnown:
+            listed = "✅"
+        else:
+            listed = "⚠️" if manifest.green else "❌"
+        lines.append(f"| publisher listed | {listed} | `{manifest.publisher}` in publisher-names.json |")
     lines += ["", f"Owner `{manifest.owner}`"]
 
     if manifest.publisher and not manifest.publisherKnown:
-        lines += ["", f"**Publisher** ⚠️ `{manifest.publisher}` is not in `publisher-names.json`. Add "
+        lines += ["", f"**Publisher** ❌ `{manifest.publisher}` is not in `publisher-names.json`. Add "
                       f"`\"{manifest.publisher}\": \"<slug>\"` to "
                       "`tools/resourcedocsgen/pkg/publishers/publisher-names.json` in this PR; without it the "
-                      "registry-backend schema fetch fails and falls back to VCS."]
+                      "registry-backend schema fetch fails and falls back to VCS. If this publisher already "
+                      "ships under a different slug, use that slug as the value so the two do not split."]
 
     findings = manifest.docLint
     lines.append("")
@@ -95,9 +111,11 @@ def render(manifest: Manifest) -> str:
         lines.append("**Doc-lint** ✅ clean. No relative images or raw HTML.")
 
     if manifest.docs:
-        lines += ["", "**Provider docs** (source at the reviewed commit):"]
+        source = "source at the reviewed commit" if manifest.version.commitSha else "source as published"
+        lines += ["", f"**Provider docs** ({source}):"]
         for doc in manifest.docs:
-            url = f"https://github.com/{manifest.repoSlug}/blob/{manifest.version.commitSha}/{doc.path}"
+            url = (f"https://github.com/{manifest.repoSlug}/blob/{manifest.version.commitSha}/{doc.path}"
+                   if manifest.version.commitSha else manifest.docSourceURL or manifest.schemaFile)
             body, note = doc.content, ""
             if doc.lines > 400:
                 body = "\n".join(doc.content.splitlines()[:400])

--- a/scripts/ci/community-package/models.py
+++ b/scripts/ci/community-package/models.py
@@ -65,3 +65,5 @@ class Manifest:
     error: str = ""
     publisher: str = ""
     publisherKnown: bool = True
+    docSourceURL: str = ""
+    delisted: bool = False

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -7,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 import cli  # noqa: E402
@@ -316,6 +318,96 @@ class SecretCodeSeparationTests(unittest.TestCase):
             self.assertNotIn("pull_request_target", text, name)
             if holds_secret:
                 self.assertNotRegex(text, r"ref:.*\.head\.", f"{name}: secret job checks out the PR head")
+
+
+class VerifyPackageYamlTests(unittest.TestCase):
+    def _tree(self, root: Path, name: str, data: dict[str, Any], index: str | None = "# Stripe\n") -> Path:
+        yaml_dir = root / "themes/default/data/registry/packages"
+        yaml_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = yaml_dir / f"{name}.yaml"
+        yaml_path.write_text(json.dumps(data))
+        if index is not None:
+            index_dir = root / "themes/default/content/registry/packages" / name
+            index_dir.mkdir(parents=True, exist_ok=True)
+            (index_dir / "_index.md").write_text(index)
+        return yaml_path
+
+    def _verify(self, data: dict[str, Any], index: str | None = "# Stripe\n",
+                publishers: dict[str, str] | None = None) -> Manifest:
+        names = {"stripe": "stripe"} if publishers is None else publishers
+        with tempfile.TemporaryDirectory() as scratch:
+            root = Path(scratch)
+            yaml_path = self._tree(root, "stripe", data, index)
+            with patch.object(verify_entry, "_load_publisher_names", return_value=names):
+                return verify_entry.verify_package_yaml(yaml_path, root)
+
+    def test_registered_publisher_is_green(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"})
+        self.assertTrue(manifest.green)
+        self.assertEqual(manifest.version.tag, "0.4.0")
+
+    def test_a_prerelease_version_is_accepted(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.3.0-beta.4"})
+        self.assertTrue(manifest.green)
+
+    def test_unregistered_publisher_blocks(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"}, publishers={})
+        self.assertFalse(manifest.green)
+        self.assertFalse(manifest.publisherKnown)
+
+    def test_missing_version_is_unverifiable(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe"})
+        self.assertFalse(manifest.green)
+        self.assertIn("no `version`", manifest.error)
+
+    def test_missing_index_blocks_and_says_why(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"}, index=None)
+        self.assertFalse(manifest.green)
+        self.assertIn("landing page", manifest.error)
+
+    def test_doc_lint_findings_are_advisory(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"},
+                                index="# Stripe\n\n![diagram](./img/arch.png)\n")
+        self.assertTrue(manifest.green)
+        self.assertTrue(manifest.warnings)
+        self.assertTrue(manifest.docLint)
+
+    def test_delisted_package_is_skipped(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "DEPRECATED", "version": "0.4.0"},
+                                index=None, publishers={})
+        self.assertTrue(manifest.delisted)
+        self.assertTrue(manifest.green)
+
+    def test_no_network_calls(self) -> None:
+        import urllib.request
+        with patch.object(urllib.request, "urlopen", side_effect=AssertionError("network call")):
+            manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"})
+        self.assertTrue(manifest.green)
+
+    def test_sheet_renders_without_a_commit(self) -> None:
+        manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"}, publishers={})
+        sheet = fact_sheet.render(manifest)
+        self.assertIn("not in `publisher-names.json`", sheet)
+        self.assertNotIn("/commit/", sheet)
+
+
+class ChangedPackageYamlTests(unittest.TestCase):
+    def _changed(self, paths: list[str]) -> list[Path]:
+        completed = type("R", (), {"stdout": "\n".join(paths)})()
+        with patch("cli.subprocess.run", return_value=completed):
+            return cli._changed_package_yamls("origin/master")
+
+    def test_selects_only_package_yamls(self) -> None:
+        changed = self._changed([
+            "themes/default/data/registry/packages/stripe.yaml",
+            "themes/default/content/registry/packages/stripe/_index.md",
+            "themes/default/data/registry/package_versions/stripe.yaml",
+            "community-packages/package-list.json",
+        ])
+        self.assertEqual(changed, [Path("themes/default/data/registry/packages/stripe.yaml")])
+
+    def test_no_package_change_is_empty(self) -> None:
+        self.assertEqual(self._changed(["README.md"]), [])
 
 
 if __name__ == "__main__":

--- a/scripts/ci/community-package/verify_entry.py
+++ b/scripts/ci/community-package/verify_entry.py
@@ -4,6 +4,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import yaml
+
 import doc_lint
 import github_api
 import sdk_install_probe
@@ -11,6 +13,8 @@ import resourcedocsgen
 from models import DocFile, Entry, Manifest, Version, provider_name
 
 PUBLISHER_NAMES_PATH = Path("tools/resourcedocsgen/pkg/publishers/publisher-names.json")
+
+DELISTED_PUBLISHER = "DEPRECATED"
 
 
 def _load_publisher_names() -> dict[str, str]:
@@ -94,4 +98,97 @@ def verify(entry: Entry) -> Manifest:
         docs=docs,
         publisher=publisher,
         publisherKnown=publisher_known,
+    )
+
+
+def _unverifiable_package(name: str, yaml_path: str, reason: str) -> Manifest:
+    return Manifest(
+        repoSlug="",
+        schemaFile=yaml_path,
+        providerName=name,
+        version=Version("(none)", ""),
+        owner="",
+        installMatrix=[],
+        docLint=[],
+        green=False,
+        generation=False,
+        docs=[],
+        error=reason,
+    )
+
+
+def _delisted(name: str, yaml_path: str, version: str) -> Manifest:
+    return Manifest(
+        repoSlug="",
+        schemaFile=yaml_path,
+        providerName=name,
+        version=Version(version, ""),
+        owner="",
+        installMatrix=[],
+        docLint=[],
+        green=True,
+        generation=True,
+        docs=[],
+        publisher=DELISTED_PUBLISHER,
+        delisted=True,
+    )
+
+
+def verify_package_yaml(yaml_path: Path, repo_root: Path) -> Manifest:
+    """Verify a package from the registry PR that publishes it.
+
+    Every publish path ends in a PR that writes the package YAML and its `_index.md`,
+    so both files are in the tree and this runs without a single network call.
+
+    The install probes are deliberately absent. `pulumi package add terraform-provider`
+    runs the upstream provider binary to read its schema, and this job runs in a
+    workflow that holds PULUMI_BOT_TOKEN, so probing here would put third-party code
+    next to a write token.
+    """
+    name = yaml_path.stem
+    try:
+        data = yaml.safe_load(yaml_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return _unverifiable_package(name, str(yaml_path), f"`{yaml_path}` could not be read: {exc}.")
+
+    name = str(data.get("name") or name).strip()
+    version = str(data.get("version", "")).strip()
+    if not version:
+        return _unverifiable_package(name, str(yaml_path), f"`{yaml_path}` declares no `version`.")
+
+    publisher = str(data.get("publisher", "")).strip()
+    if publisher == DELISTED_PUBLISHER:
+        return _delisted(name, str(yaml_path), version)
+
+    publisher_known = _publisher_known(publisher, _load_publisher_names())
+
+    index_path = repo_root / "themes/default/content/registry/packages" / name / "_index.md"
+    try:
+        text = index_path.read_text()
+    except OSError:
+        return _unverifiable_package(name, str(yaml_path),
+                                     f"No landing page at `{index_path.relative_to(repo_root)}`. It is the "
+                                     "package's front page in the registry, so it is required.")
+    index = DocFile("_index.md", text.count("\n") + 1, text)
+
+    findings = doc_lint.find_issues(index.content)
+
+    green = bool(publisher_known)
+    warnings = green and bool(findings)
+
+    return Manifest(
+        repoSlug="",
+        schemaFile=str(data.get("schema_file_url") or yaml_path),
+        providerName=name,
+        version=Version(version, ""),
+        owner=publisher,
+        installMatrix=[],
+        docLint=findings,
+        green=green,
+        warnings=warnings,
+        generation=True,
+        docs=[index],
+        publisher=publisher,
+        publisherKnown=publisher_known,
+        docSourceURL="",
     )


### PR DESCRIPTION
`/check` only runs on PRs that edit `community-packages/package-list.json`. Everything else we publish is unchecked: no publisher check, no doc-lint, no check that the landing page exists. That is how [`stripe`](https://github.com/pulumi/registry/pull/12018) shipped with an unregistered publisher.

Every publish path ends in a PR writing a package YAML and its `_index.md`, so the check runs there: one job in `pull-request.yml`, in `Sentinel`'s `needs:`, covering both dispatches and the nightly bump. It reads both files off disk, so there are no network calls and no SDK install probes. The fact-sheet posts as a comment and a red check holds the auto-merge. No publish workflow changes.

Fixes #12019.

## Fallout

None. Ran against all 308 packages: 30 are delisted and skipped, and all 278 live packages pass. One has a doc-lint finding, which warns rather than blocks.

## Test plan

43 unit tests (10 new), `mypy --strict` clean, plus the scan above. The job itself runs green on this PR ([run](https://github.com/pulumi/registry/actions/runs/31682562754/job/94391125520)): no package YAML changed here, so it exits 0 and posts nothing.
