### PR TITLE
[ci] Retry yarn install on a registry HTTP error

### DIFF
--- a/.github/actions/build-and-deploy-preview/action.yml
+++ b/.github/actions/build-and-deploy-preview/action.yml
@@ -73,8 +73,7 @@ runs:
         pattern: "community-packages/package-list.json"
 
     - name: Yarn Install
-      shell: bash
-      run: yarn install
+      uses: ./.github/actions/yarn-install
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -1,0 +1,22 @@
+name: Yarn install
+description: >-
+  Install node dependencies, retrying when the npm registry answers with an HTTP status.
+  Yarn retries dropped connections and timeouts itself, but treats a 502 as final.
+
+runs:
+  using: composite
+  steps:
+    - name: Install node dependencies
+      shell: bash
+      run: |
+        max_attempts=3
+        for attempt in $(seq "$max_attempts"); do
+          if yarn install --network-timeout 300000; then
+            exit 0
+          fi
+          if [ "$attempt" -lt "$max_attempts" ]; then
+            sleep $((attempt * 10))
+          fi
+        done
+        echo "yarn install failed after $max_attempts attempts."
+        exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,10 +65,11 @@ jobs:
           node-version: "24.x"
           cache: 'yarn'
 
+      - name: Yarn Install
+        uses: ./.github/actions/yarn-install
+
       - name: Lint Markdown
-        run: |
-          yarn install
-          make lint-markdown
+        run: make lint-markdown
 
   lint-scripts:
     name: Lint Scripts
@@ -84,7 +85,7 @@ jobs:
           cache: 'yarn'
 
       - name: Yarn Install
-        run: yarn install
+        uses: ./.github/actions/yarn-install
       - name: Run Linter
         run: yarn run lint
 

--- a/scripts/ensure.sh
+++ b/scripts/ensure.sh
@@ -33,9 +33,25 @@ if [[ -z "$(which yarn)" ]]; then
     exit 1
 fi
 
+# Yarn retries dropped connections and timeouts on its own, but treats an HTTP status from
+# the registry as final, so a 502 on any one tarball ends the whole install.
+retry_yarn() {
+    local max_attempts=3 attempt
+    for attempt in $(seq "$max_attempts"); do
+        if yarn "$@" --network-timeout 300000; then
+            return 0
+        fi
+        if [[ "$attempt" -lt "$max_attempts" ]]; then
+            sleep $((attempt * 10))
+        fi
+    done
+    echo "yarn $* failed after $max_attempts attempts."
+    return 1
+}
+
 echo "Installing Node.js modules..."
-yarn install
-yarn --cwd infrastructure install
-yarn --cwd ./themes/default/theme install
-yarn --cwd ./themes/default/theme/stencil install
+retry_yarn install
+retry_yarn --cwd infrastructure install
+retry_yarn --cwd ./themes/default/theme install
+retry_yarn --cwd ./themes/default/theme/stencil install
 


### PR DESCRIPTION

Yarn already retries dropped connections and timeouts. `isPossibleOfflineError` in yarn 1.22 returns true only for `ENOTFOUND`, `ECONNRESET`, `ESOCKETTIMEDOUT` and `ETIMEDOUT`, and retries those five times. An HTTP status takes a different path and is treated as final, so this ends an install outright:

```text
error Error: https://registry.npmjs.org/verror/-/verror-1.10.0.tgz: Request failed "502 Bad Gateway"
```

That is what failed `Lint Markdown` on #12049, with nothing wrong in the PR. The socket connected and the server answered, just badly, so yarn's own retry never engaged. `maxRetryAttempts` is hardcoded to 5 with no config or CLI option, unlike `network-timeout`, so this cannot be tuned from the outside.

Every `yarn install` in CI now retries three times with a growing backoff:

- The two lint jobs and the preview build go through one composite action.
- `scripts/ensure.sh` gets a `retry_yarn` helper for its four installs. `make ensure` runs in the `test-provider-api-docs` job, and installing from four lockfiles gives it more exposure to a bad response than either lint job. It also helps anyone running `make ensure` on a poor connection.

`--network-timeout 300000` is passed throughout so a slow tarball does not trip the timeout that yarn would otherwise retry.

Same failure class as #12046, which retries the version check in the nightly community package workflow.

## Test plan

1. Automated tests
    - `shellcheck -S warning` clean on `scripts/ensure.sh` and on the action's script
    - The action and both touched workflow files parse with `yaml.safe_load`
    - No unretried `yarn install` remains under `scripts/` or `.github/`
2. Manual checks
    - Simulated both loops under `bash -e` and under `errexit`/`pipefail` as `ensure.sh` runs: succeeds on the first attempt, recovers on the second, exits 1 after three failures
    - Read yarn 1.22.22's retry predicate and the `requestFailed` path to confirm a 502 is never retried
3. CI
    - Rebased onto current master; all 14 checks green. The earlier `mktutorial / Lint` red was `golangci-lint` timing out fetching its JSON schema, not this change.
