### PR TITLE
Pin the PR preview comment and link the changed pages

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -87,6 +87,8 @@ jobs:
         run: yarn install
       - name: Run Linter
         run: yarn run lint
+      - name: Test preview comment
+        run: make test-preview-comment
 
   lint-dark-logos:
     name: Lint Dark Logo Variants

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -894,10 +894,12 @@ marker means a contributor can't redirect the pinned comment by quoting the mark
 comment list is paginated deliberately — GitHub returns 30 comments per page by default, and an
 unpaginated search would miss the marker on a long PR and post a duplicate on every build.
 
-**How changed pages are resolved**: the changed-file list comes from the GitHub API
-(`/pulls/<n>/files`), not a local `git diff`, so it works identically for the `pull_request`
-build and the maintainer-triggered `/preview` command. Each path is mapped to a URL by
-`changed_paths_to_urls` (`scripts/ci/common.sh`) under two rules:
+**How changed pages are resolved**: `changed_pages_section` (`scripts/ci/common.sh`) reads the
+changed-file list from the GitHub API (`/pulls/<n>/files`), not a local `git diff`, so it works
+identically for the `pull_request` build and the maintainer-triggered `/preview` command. It
+collects every API page before mapping — `changed_paths_to_urls` de-duplicates only within a
+single invocation, so mapping page by page would double-list a package whose YAML and landing
+page straddle the 100-file page boundary. Each path is mapped under two rules:
 
 | Changed path | URL |
 |---|---|

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -24,7 +24,8 @@ This document describes the build, test, and deployment system for the `pulumi/r
    - [6.1 Pulumi IaC](#61-pulumi-iac)
    - [6.2 AWS Resources](#62-aws-resources)
    - [6.3 S3 Preview Bucket Lifecycle](#63-s3-preview-bucket-lifecycle)
-   - [6.4 Custom Redirects](#64-custom-redirects)
+   - [6.4 The Pinned Preview Comment](#64-the-pinned-preview-comment)
+   - [6.5 Custom Redirects](#65-custom-redirects)
 7. [Registry Publication (push-registry.py)](#registry-publication-push-registrypy)
 8. [Testing Strategy](#testing-strategy)
    - [8.1 Go Unit Tests](#81-go-unit-tests)
@@ -588,7 +589,7 @@ PR opened / committed
         │                       ├── s5cmd sync llm-docs-out/ → bucket (Content-Encoding: gzip)
         │                       ├── Run browser tests (Cypress smoke test)
         │                       ├── Write origin-bucket-metadata.json
-        │                       └── Post PR comment with preview URL
+        │                       └── Update the pinned PR comment (preview URL + changed pages)
         │
         └── sentinel (depends on all jobs above)
                 └── Writes "Sentinel" GitHub status check = success
@@ -858,7 +859,7 @@ scripts/ci/sync.sh preview
   4. Run Cypress smoke tests
   5. Write origin-bucket-metadata.json
   6. aws ssm put-parameter /registry/commits/<sha>/bucket = <bucket-name>
-  7. Post PR comment: "Your preview is ready at http://..."
+  7. Create or update the pinned PR comment with the preview URL and changed pages
 
 PR merged or closed
        │
@@ -876,7 +877,47 @@ Daily bucket-cleanup.yml (3:00 PM UTC)
   - Deletes bucket after 48+ hours in cleanup state
 ```
 
-### 6.4 Custom Redirects
+### 6.4 The Pinned Preview Comment
+
+Each preview build maintains a **single** comment on the PR rather than adding one per commit.
+The comment is written by `post_preview_comment` in `scripts/ci/sync.sh`, and carries:
+
+1. The preview URL for the current commit (`<bucket-website>/registry/`).
+2. A **Changed pages** list — direct links to the pages the PR changed, so a reviewer lands on
+   them instead of navigating the preview by hand.
+
+**How it stays pinned**: the body opens with the HTML marker `<!-- registry-preview-link -->`.
+`upsert_github_pr_comment` (`scripts/ci/common.sh`) pages through the PR's comments looking for
+that marker on a comment authored by `github-actions[bot]` or `pulumi-bot`, then `PATCH`es that
+comment; it only `POST`s a new one when no match exists. Matching on the author as well as the
+marker means a contributor can't redirect the pinned comment by quoting the marker. The
+comment list is paginated deliberately — GitHub returns 30 comments per page by default, and an
+unpaginated search would miss the marker on a long PR and post a duplicate on every build.
+
+**How changed pages are resolved**: the changed-file list comes from the GitHub API
+(`/pulls/<n>/files`), not a local `git diff`, so it works identically for the `pull_request`
+build and the maintainer-triggered `/preview` command. Each path is mapped to a URL by
+`changed_paths_to_urls` (`scripts/ci/common.sh`) under two rules:
+
+| Changed path | URL |
+|---|---|
+| `themes/default/content/**/*.md` | Hugo's own rules (`content_path_to_url`) |
+| `themes/default/data/registry/packages/<pkg>.yaml` | `/registry/packages/<pkg>/` |
+
+The YAML rule is the one that matters most here: the generated `api-docs/` content is
+gitignored and never appears in a PR diff, so without it the list would be empty on most
+registry PRs. Results are de-duplicated, then filtered to URLs that actually rendered
+(`public/<url>index.html` exists), which drops removed files and `url:`/alias overrides rather
+than linking them as dead URLs. The list is capped at 50 entries with an "…and N more" line.
+
+The whole block is reporting, not deployment: it is invoked as `post_preview_comment || log …`
+so a GitHub API hiccup can never fail an otherwise-good build. Conversely, because `sync.sh`
+runs under `set -o errexit` after the Cypress smoke test, a **failed** build posts nothing.
+
+`make test-preview-comment` (`scripts/ci/test-preview-comment.sh`) covers the mapping, the
+de-duplication, and the existence gate offline; it runs in the `Lint Scripts` PR job.
+
+### 6.5 Custom Redirects
 
 **Source files**: `scripts/redirects/` — pipe-delimited text files with `key | location` entries.
 

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,18 @@ lint-mktutorial:
 	cd tools/mktutorial/ && golangci-lint run --config ../../.golangci.yml
 
 .PHONY: test
-test: test-infra
+test: test-infra test-preview-comment
 	cd ./tools/resourcedocsgen && go test ./...
 
 .PHONY: test-infra
 test-infra:
 	cd infrastructure && node --test redirects.test.js
+
+# Covers the URL mapping behind the pinned preview comment in scripts/ci/sync.sh. Offline
+# and dependency-free, so it runs alongside the script linter in PR CI.
+.PHONY: test-preview-comment
+test-preview-comment:
+	./scripts/ci/test-preview-comment.sh
 
 .PHONY: build
 build: build-assets

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -74,17 +74,22 @@ upsert_github_pr_comment() {
     local existing_comment_id=""
     local page comments_json page_count
     for page in $(seq 1 "$max_comment_pages"); do
-        comments_json=$(curl -s \
+        comments_json=$(curl -s --max-time 30 \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             "${pr_comment_api_url}?per_page=100&page=${page}")
 
+        # The `if type == "array"` guard is load-bearing, not decoration: jq's `.[]` iterates an
+        # object's values as readily as an array's elements, so on an error payload
+        # ({"message": "Bad credentials", ...}) it would yield strings and `.body` would then
+        # be a hard jq error rather than an empty result.
         local found
         found=$(echo "$comments_json" | jq -r \
             --arg marker "$marker" \
             --argjson logins "$(pr_comment_author_logins)" \
-            '[.[] | select((.body // "") | contains($marker))
-                  | select(.user.login as $l | $logins | index($l))] | last | .id // empty' \
-            2>/dev/null)
+            'if type == "array" then
+                 [.[] | select((.body // "") | contains($marker))
+                      | select(.user.login as $l | $logins | index($l))] | last | .id // empty
+             else empty end')
         if [[ -n "$found" ]]; then
             existing_comment_id="$found"
         fi
@@ -97,20 +102,28 @@ upsert_github_pr_comment() {
         fi
     done
 
+    # curl exits 0 on a 4xx/5xx, so check the status explicitly. The comment is best-effort and
+    # deliberately doesn't fail the build, but a silently dropped one is very hard to diagnose
+    # from a green job -- so at minimum say so in the log.
+    local method url status
     if [[ -n "$existing_comment_id" ]]; then
-        curl -s \
-            -X PATCH \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "${repo_api_url}/issues/comments/${existing_comment_id}" > /dev/null
+        method="PATCH"
+        url="${repo_api_url}/issues/comments/${existing_comment_id}"
     else
-        curl -s \
-            -X POST \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "$pr_comment_api_url" > /dev/null
+        method="POST"
+        url="$pr_comment_api_url"
+    fi
+
+    status=$(curl -s --max-time 30 -o /dev/null -w '%{http_code}' \
+        -X "$method" \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "$url")
+
+    if [[ ! "$status" =~ ^2[0-9][0-9]$ ]]; then
+        log "GitHub returned HTTP ${status:-000} for ${method} ${url}; the comment was not saved."
+        return 1
     fi
 }
 
@@ -184,6 +197,73 @@ changed_paths_to_urls() {
         seen[$url]=1
         echo "$url"
     done
+}
+
+# Builds the "Changed pages" section of the preview comment: direct links to the pages this PR
+# changed, so a reviewer lands on them instead of hunting through the site. Emits nothing when
+# no changed file resolves to a rendered page.
+#
+# The base branch isn't reliably available locally (the /preview command path checks out
+# differently from the pull_request path), so we ask the GitHub API which files changed rather
+# than diffing. Each changed path is mapped to the URL it renders, then kept only if it
+# actually rendered to a page in this build -- that drops removed files, non-page sources, and
+# url:/alias overrides rather than linking them as dead URLs.
+#
+# Usage: changed_pages_section <repo-api-url> <pr-number> <build-dir> <site-base-url>
+changed_pages_section() {
+    local repo_api_url=$1
+    local pr_number=$2
+    local build_dir=$3
+    local base_url=$4
+
+    local max_listed_urls=50    # Cap the rendered list so huge PRs stay readable.
+    local max_files_pages=10    # Cap API pagination (10 * 100 = up to 1000 files).
+    local changed_files=()
+    local changed_pages=()
+    local page files_json page_count path url
+
+    # Collect the changed filenames across every page first, and map them in a single pass
+    # afterwards. changed_paths_to_urls only de-duplicates within one invocation, so mapping
+    # page by page would emit /registry/packages/aws/ twice on a PR big enough to split
+    # aws.yaml and aws/_index.md across two pages.
+    for page in $(seq 1 "$max_files_pages"); do
+        files_json=$(curl -s --max-time 30 \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            "${repo_api_url}/pulls/${pr_number}/files?per_page=100&page=${page}")
+
+        while IFS= read -r path; do
+            if [[ -n "$path" ]]; then
+                changed_files+=("$path")
+            fi
+        done < <(echo "$files_json" \
+            | jq -r 'if type == "array" then .[] | select(.status != "removed") | .filename else empty end')
+
+        # Stop on the last (short) page, or if the response wasn't an array (e.g. a transient
+        # API error), which yields 0 and breaks cleanly.
+        page_count="$(echo "$files_json" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)"
+        if [[ "${page_count:-0}" -lt 100 ]]; then
+            break
+        fi
+    done
+
+    if [[ "${#changed_files[@]}" -gt 0 ]]; then
+        while IFS= read -r url; do
+            if [[ -n "$url" && -f "${build_dir}${url}index.html" ]]; then
+                changed_pages+=("- [${url}](${base_url}${url})")
+            fi
+        done < <(printf '%s\n' "${changed_files[@]}" | changed_paths_to_urls)
+    fi
+
+    if [[ "${#changed_pages[@]}" -eq 0 ]]; then
+        return 0
+    fi
+
+    local listed
+    listed=$(printf '%s\n' "${changed_pages[@]:0:$max_listed_urls}")
+    printf '\n\n**Changed pages:**\n%s' "$listed"
+    if [[ "${#changed_pages[@]}" -gt "$max_listed_urls" ]]; then
+        printf '\n- …and %s more' "$(( ${#changed_pages[@]} - max_listed_urls ))"
+    fi
 }
 
 # Returns the Git SHA of the HEAD commit. For pull requests, we take this from GitHub event metadata, since in that case, the HEAD commit will contain the SHA of the merge commit with the base branch.

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -39,6 +39,153 @@ post_github_pr_comment() {
          $pr_comment_api_url > /dev/null
 }
 
+# The logins the preview comment can legitimately be authored by. The pull_request build and
+# the /preview command both run with secrets.GITHUB_TOKEN, so in practice it's always
+# github-actions[bot]; pulumi-bot is here so a run authenticated with the bot PAT adopts the
+# same comment instead of starting a second one. Matching on the author as well as the marker
+# also keeps a contributor from redirecting the pinned comment by pasting the marker into a
+# comment of their own.
+pr_comment_author_logins() {
+    echo '["github-actions[bot]", "pulumi-bot"]'
+}
+
+# Creates a PR comment, or updates the existing one carrying the same marker. This is what
+# makes the preview comment "pinned": one comment per PR, rewritten on every build, rather
+# than a fresh comment per commit.
+# Usage: upsert_github_pr_comment <marker> <body> <comments-api-url> <repo-api-url>
+#   <comments-api-url> is .pull_request._links.comments.href from the event payload.
+#   <repo-api-url>     is .pull_request.base.repo.url from the event payload.
+upsert_github_pr_comment() {
+    local marker=$1
+    local body=$2
+    local pr_comment_api_url=$3
+    local repo_api_url=$4
+
+    local payload
+    payload=$(jq -n --arg body "$body" '{"body": $body}')
+
+    # Find the comment to update. The list has to be paginated: GitHub returns issue comments
+    # oldest-first, 30 per page by default, so an unpaginated search only ever sees the 30
+    # oldest. The pinned comment is usually among them -- but not on a PR that collected 30+
+    # comments before its first successful preview build (fact sheets, /check runs, review
+    # chatter, or earlier builds that failed before they got this far). Once it falls off page
+    # one it is never found again, and every later build appends another duplicate.
+    local max_comment_pages=10
+    local existing_comment_id=""
+    local page comments_json page_count
+    for page in $(seq 1 "$max_comment_pages"); do
+        comments_json=$(curl -s \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            "${pr_comment_api_url}?per_page=100&page=${page}")
+
+        local found
+        found=$(echo "$comments_json" | jq -r \
+            --arg marker "$marker" \
+            --argjson logins "$(pr_comment_author_logins)" \
+            '[.[] | select((.body // "") | contains($marker))
+                  | select(.user.login as $l | $logins | index($l))] | last | .id // empty' \
+            2>/dev/null)
+        if [[ -n "$found" ]]; then
+            existing_comment_id="$found"
+        fi
+
+        # Stop on the last (short) page, or if the response wasn't an array — a transient API
+        # error yields 0 here and breaks cleanly rather than looping ten times.
+        page_count="$(echo "$comments_json" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)"
+        if [[ "${page_count:-0}" -lt 100 ]]; then
+            break
+        fi
+    done
+
+    if [[ -n "$existing_comment_id" ]]; then
+        curl -s \
+            -X PATCH \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "${repo_api_url}/issues/comments/${existing_comment_id}" > /dev/null
+    else
+        curl -s \
+            -X POST \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$pr_comment_api_url" > /dev/null
+    fi
+}
+
+# The Hugo content root. Hugo mounts themes/default/content as the site's content directory
+# (see the module import in config/_default/config.yml), so an on-disk path under here maps
+# directly onto a site path -- including the leading /registry/ segment.
+content_root() {
+    echo "themes/default/content/"
+}
+
+# Converts a Hugo content file path to its published, root-relative URL, following the same
+# rules the site uses: strip the content root, strip the ".md" extension, collapse section
+# landing pages ("/_index") and leaf-bundle pages ("/index") to their directory, and guarantee
+# a leading and trailing slash.
+# Usage:
+#   content_path_to_url themes/default/content/registry/packages/aws/_index.md
+#     # => /registry/packages/aws/
+#   content_path_to_url themes/default/content/registry/packages/aws/installation-configuration.md
+#     # => /registry/packages/aws/installation-configuration/
+content_path_to_url() {
+    local path=$1
+    local root
+    root="$(content_root)"
+
+    path="${path#"$root"}"           # Strip the leading content root.
+    path="${path%.md}"               # Strip the trailing .md extension.
+
+    if [[ "$path" == "_index" || "$path" == "index" ]]; then
+        path=""                      # Site root.
+    else
+        path="${path%/_index}"       # Collapse section landing pages (_index.md).
+        path="${path%/index}"        # Collapse leaf-bundle pages (index.md).
+    fi
+
+    echo "/${path}/" | sed 's#//*#/#g'
+}
+
+# Maps changed repository paths (read from stdin, one per line) to the site URLs they render,
+# de-duplicated and in first-seen order. Anything that isn't a page source is dropped.
+#
+# Two rules, because the registry has two kinds of page source:
+#   - Content markdown under themes/default/content/.
+#   - Package metadata under themes/default/data/registry/packages/<pkg>.yaml, which is what
+#     actually renders /registry/packages/<pkg>/. This rule is the important one here: the
+#     generated api-docs/ content is gitignored and never appears in a PR diff, so without it
+#     the changed-page list would be empty on most registry PRs.
+#
+# The <pkg> slug is the YAML's basename. That matches the file's `name:` field for every
+# package in the registry today, and callers existence-check the result anyway, so a
+# hypothetical divergence drops the link rather than emitting a dead one.
+changed_paths_to_urls() {
+    local path url root
+    local -A seen=()
+    root="$(content_root)"
+
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+
+        url=""
+        case "$path" in
+            "$root"*.md)
+                url="$(content_path_to_url "$path")"
+                ;;
+            themes/default/data/registry/packages/*.yaml)
+                url="/registry/packages/$(basename "$path" .yaml)/"
+                ;;
+        esac
+
+        [[ -z "$url" ]] && continue
+        [[ -n "${seen[$url]:-}" ]] && continue
+        seen[$url]=1
+        echo "$url"
+    done
+}
+
 # Returns the Git SHA of the HEAD commit. For pull requests, we take this from GitHub event metadata, since in that case, the HEAD commit will contain the SHA of the merge commit with the base branch.
 git_sha() {
     if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; then

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -155,12 +155,102 @@ aws s3 cp "$metadata_file" "${destination_bucket_uri}/registry/metadata.json" --
 # Persist an association between the current commit and the bucket we just deployed to.
 set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 
-# Finally, post a comment to the PR that directs the user to the resulting bucket URL.
+# The marker that makes the preview comment pinned: every build finds the comment carrying it
+# and rewrites that one, instead of leaving a fresh comment per commit.
+PREVIEW_COMMENT_MARKER="<!-- registry-preview-link -->"
+
+# Builds the "Changed pages" section: direct links to the pages this PR changed, so a reviewer
+# lands on them instead of hunting through the site.
+#
+# The base branch isn't reliably available locally (the /preview command path checks out
+# differently from the pull_request path), so we ask the GitHub API which files changed rather
+# than diffing. Each changed path is mapped to the URL it renders, then kept only if it
+# actually rendered to a page in this build -- that drops removed files, non-page sources, and
+# url:/alias overrides rather than linking them as dead URLs.
+changed_pages_section() {
+    local repo_api_url=$1
+    local pr_number=$2
+
+    local max_listed_pages=50   # Cap the rendered list so huge PRs stay readable.
+    local max_files_pages=10    # Cap API pagination (10 * 100 = up to 1000 files).
+    local changed_pages=()
+    local page files_json page_count url
+
+    for page in $(seq 1 "$max_files_pages"); do
+        files_json=$(curl -s \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            "${repo_api_url}/pulls/${pr_number}/files?per_page=100&page=${page}")
+
+        while IFS= read -r url; do
+            [[ -z "$url" ]] && continue
+            if [[ -f "${build_dir}${url}index.html" ]]; then
+                changed_pages+=("- [${url}](${s3_website_url}${url})")
+            fi
+        done < <(echo "$files_json" \
+            | jq -r '.[] | select(.status != "removed") | .filename' 2>/dev/null \
+            | changed_paths_to_urls)
+
+        # Stop on the last (short) page, or if the response wasn't an array (e.g. a transient
+        # API error), which yields 0 and breaks cleanly.
+        page_count="$(echo "$files_json" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)"
+        if [[ "${page_count:-0}" -lt 100 ]]; then
+            break
+        fi
+    done
+
+    if [[ "${#changed_pages[@]}" -eq 0 ]]; then
+        return 0
+    fi
+
+    local listed
+    listed=$(printf '%s\n' "${changed_pages[@]:0:$max_listed_pages}")
+    printf '\n\n**Changed pages:**\n%s' "$listed"
+    if [[ "${#changed_pages[@]}" -gt "$max_listed_pages" ]]; then
+        printf '\n- …and %s more' "$(( ${#changed_pages[@]} - max_listed_pages ))"
+    fi
+}
+
+# Posts (or updates) the pinned preview comment on the PR.
+post_preview_comment() {
+    if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" || -z "${GITHUB_TOKEN:-}" ]]; then
+        log "No GitHub event or token available; skipping the preview comment."
+        return 0
+    fi
+
+    local event pr_comment_api_url repo_api_url pr_number
+    event="$(cat "$GITHUB_EVENT_PATH")"
+    pr_comment_api_url="$(echo "$event" | jq -r '.pull_request._links.comments.href // empty')"
+    repo_api_url="$(echo "$event" | jq -r '.pull_request.base.repo.url // empty')"
+    pr_number="$(echo "$event" | jq -r '.number // empty')"
+
+    if [[ -z "$pr_comment_api_url" || -z "$repo_api_url" || -z "$pr_number" ]]; then
+        log "Event payload is missing pull request details; skipping the preview comment."
+        return 0
+    fi
+
+    local body
+    body="${PREVIEW_COMMENT_MARKER}
+Your site preview for commit $(git_sha_short) is ready! :tada:
+
+${preview_url}$(changed_pages_section "$repo_api_url" "$pr_number")"
+
+    upsert_github_pr_comment \
+        "$PREVIEW_COMMENT_MARKER" \
+        "$body" \
+        "$pr_comment_api_url" \
+        "$repo_api_url"
+}
+
+# Finally, for previews, point the PR at the resulting bucket URL. Everything below is
+# reporting, not deployment, so it must never fail the build -- hence the `|| log`.
 if [[ "$1" == "preview" ]]; then
-    pr_comment_api_url="$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request._links.comments.href")"
-    post_github_pr_comment \
-        "Your site preview for commit $(git_sha_short) is ready! :tada:\n\n${s3_website_url}/registry." \
-        $pr_comment_api_url
+    preview_url="${s3_website_url}/registry/"
+
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        echo "Site preview for commit $(git_sha_short): ${preview_url}" >> "$GITHUB_STEP_SUMMARY" || true
+    fi
+
+    post_preview_comment || log "Failed to post the preview comment; continuing."
 fi
 
 log "Done! The bucket website is now built and available at ${s3_website_url}."

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -159,57 +159,6 @@ set_bucket_for_commit "$(git_sha)" "$destination_bucket" "$(aws_region)"
 # and rewrites that one, instead of leaving a fresh comment per commit.
 PREVIEW_COMMENT_MARKER="<!-- registry-preview-link -->"
 
-# Builds the "Changed pages" section: direct links to the pages this PR changed, so a reviewer
-# lands on them instead of hunting through the site.
-#
-# The base branch isn't reliably available locally (the /preview command path checks out
-# differently from the pull_request path), so we ask the GitHub API which files changed rather
-# than diffing. Each changed path is mapped to the URL it renders, then kept only if it
-# actually rendered to a page in this build -- that drops removed files, non-page sources, and
-# url:/alias overrides rather than linking them as dead URLs.
-changed_pages_section() {
-    local repo_api_url=$1
-    local pr_number=$2
-
-    local max_listed_pages=50   # Cap the rendered list so huge PRs stay readable.
-    local max_files_pages=10    # Cap API pagination (10 * 100 = up to 1000 files).
-    local changed_pages=()
-    local page files_json page_count url
-
-    for page in $(seq 1 "$max_files_pages"); do
-        files_json=$(curl -s \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            "${repo_api_url}/pulls/${pr_number}/files?per_page=100&page=${page}")
-
-        while IFS= read -r url; do
-            [[ -z "$url" ]] && continue
-            if [[ -f "${build_dir}${url}index.html" ]]; then
-                changed_pages+=("- [${url}](${s3_website_url}${url})")
-            fi
-        done < <(echo "$files_json" \
-            | jq -r '.[] | select(.status != "removed") | .filename' 2>/dev/null \
-            | changed_paths_to_urls)
-
-        # Stop on the last (short) page, or if the response wasn't an array (e.g. a transient
-        # API error), which yields 0 and breaks cleanly.
-        page_count="$(echo "$files_json" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)"
-        if [[ "${page_count:-0}" -lt 100 ]]; then
-            break
-        fi
-    done
-
-    if [[ "${#changed_pages[@]}" -eq 0 ]]; then
-        return 0
-    fi
-
-    local listed
-    listed=$(printf '%s\n' "${changed_pages[@]:0:$max_listed_pages}")
-    printf '\n\n**Changed pages:**\n%s' "$listed"
-    if [[ "${#changed_pages[@]}" -gt "$max_listed_pages" ]]; then
-        printf '\n- …and %s more' "$(( ${#changed_pages[@]} - max_listed_pages ))"
-    fi
-}
-
 # Posts (or updates) the pinned preview comment on the PR.
 post_preview_comment() {
     if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" || -z "${GITHUB_TOKEN:-}" ]]; then
@@ -232,7 +181,7 @@ post_preview_comment() {
     body="${PREVIEW_COMMENT_MARKER}
 Your site preview for commit $(git_sha_short) is ready! :tada:
 
-${preview_url}$(changed_pages_section "$repo_api_url" "$pr_number")"
+${preview_url}$(changed_pages_section "$repo_api_url" "$pr_number" "$build_dir" "$s3_website_url")"
 
     upsert_github_pr_comment \
         "$PREVIEW_COMMENT_MARKER" \

--- a/scripts/ci/test-preview-comment.sh
+++ b/scripts/ci/test-preview-comment.sh
@@ -117,6 +117,126 @@ expect "only rendered pages survive" \
     "$(printf '%s\n' "${rendered[@]}")"
 
 echo
+echo "== changed_pages_section =="
+
+# The files API is paged at 100. changed_paths_to_urls only de-duplicates within a single
+# invocation, so the section has to collect every page before mapping -- otherwise a package's
+# YAML on page one and its landing page on page two each produce a link to the same URL.
+# Stub two full pages that straddle exactly that split.
+page_one='[{"status": "modified", "filename": "themes/default/data/registry/packages/aws.yaml"}'
+for i in $(seq 1 99); do
+    page_one+=",{\"status\": \"modified\", \"filename\": \"docs/filler-${i}.md\"}"
+done
+page_one+=']'
+page_two='[{"status": "modified", "filename": "themes/default/content/registry/packages/aws/_index.md"}]'
+
+curl() {
+    local url=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -H|--max-time) shift 2;;
+            -s) shift;;
+            *) url="$1"; shift;;
+        esac
+    done
+    if [[ "$url" == *"page=1"* ]]; then echo "$page_one"; else echo "$page_two"; fi
+}
+
+expect "a page-straddling package lists once, not twice" \
+    "$(printf '\n\n**Changed pages:**\n- [/registry/packages/aws/](http://preview.example/registry/packages/aws/)')" \
+    "$(changed_pages_section "https://api.github.com/repos/pulumi/registry" 42 "$build_dir" "http://preview.example")"
+
+curl() { echo '{"message": "Bad credentials", "status": "401"}'; }
+
+expect "an API error payload yields no section rather than a broken one" \
+    "" \
+    "$(changed_pages_section "https://api.github.com/repos/pulumi/registry" 42 "$build_dir" "http://preview.example")"
+
+unset -f curl
+
+echo
+echo "== upsert_github_pr_comment =="
+
+# upsert_github_pr_comment talks to nothing but curl, so shadowing curl drives the whole
+# find-or-create decision offline. $stub_comments is the canned comments-list response;
+# $stub_calls records what the function asked for.
+comments_url="https://api.github.com/repos/pulumi/registry/issues/42/comments"
+repo_url="https://api.github.com/repos/pulumi/registry"
+marker="<!-- registry-preview-link -->"
+export GITHUB_TOKEN=stub-token
+
+curl() {
+    local url="" method="GET" write_out=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -X) method="$2"; shift 2;;
+            -w) write_out="$2"; shift 2;;
+            -d|-H|-o|--max-time) shift 2;;
+            -s) shift;;
+            *) url="$1"; shift;;
+        esac
+    done
+
+    if [[ "$method" != "GET" ]]; then
+        echo "${method} ${url}" >> "$stub_calls"
+        # Mimic -w '%{http_code}' so the status check in upsert_github_pr_comment sees a 2xx.
+        [[ -n "$write_out" ]] && echo "201"
+        return 0
+    fi
+
+    # Only page one carries anything; later pages come back empty so the loop terminates.
+    if [[ "$url" == *"page=1"* ]]; then
+        echo "$stub_comments"
+    else
+        echo '[]'
+    fi
+}
+
+# Usage: run_upsert <comments-list-json>
+run_upsert() {
+    stub_comments=$1
+    stub_calls=$(mktemp)
+    upsert_github_pr_comment "$marker" "a body" "$comments_url" "$repo_url" || true
+    cat "$stub_calls"
+    rm -f "$stub_calls"
+}
+
+expect "no existing comment creates one" \
+    "POST ${comments_url}" \
+    "$(run_upsert '[]')"
+
+expect "an existing pinned comment is updated in place" \
+    "PATCH ${repo_url}/issues/comments/222" \
+    "$(run_upsert '[
+        {"id": 111, "user": {"login": "github-actions[bot]"}, "body": "unrelated"},
+        {"id": 222, "user": {"login": "github-actions[bot]"}, "body": "<!-- registry-preview-link -->\nold"}
+     ]')"
+
+# The marker alone must not be enough to redirect the pinned comment, or any contributor could
+# take it over by quoting it.
+expect "a marker from another author is ignored" \
+    "POST ${comments_url}" \
+    "$(run_upsert '[
+        {"id": 333, "user": {"login": "some-contributor"}, "body": "<!-- registry-preview-link --> hijack"}
+     ]')"
+
+expect "the bot comment wins even when a decoy sorts after it" \
+    "PATCH ${repo_url}/issues/comments/444" \
+    "$(run_upsert '[
+        {"id": 444, "user": {"login": "pulumi-bot"}, "body": "<!-- registry-preview-link -->\nold"},
+        {"id": 555, "user": {"login": "some-contributor"}, "body": "<!-- registry-preview-link --> hijack"}
+     ]')"
+
+# jq's .[] iterates an object's values as readily as an array's elements, so an error payload
+# would blow up the marker filter unless the type is checked first. Falling back to a fresh
+# comment is the right failure mode; erroring out and posting nothing is not.
+expect "an API error payload falls back to creating a comment" \
+    "POST ${comments_url}" \
+    "$(run_upsert '{"message": "Bad credentials", "status": "401"}')"
+
+unset -f curl
+
+echo
 if [[ "$failures" -gt 0 ]]; then
     echo "${failures} test(s) failed."
     exit 1

--- a/scripts/ci/test-preview-comment.sh
+++ b/scripts/ci/test-preview-comment.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Unit tests for the URL mapping behind the pinned preview comment posted by
+# scripts/ci/sync.sh. These cover the parts that decide *which* links land in the comment --
+# path-to-URL translation, de-duplication, and the existence gate -- without touching the
+# network, S3, or a Hugo build.
+#
+# Run directly (./scripts/ci/test-preview-comment.sh) or via `make test-preview-comment`.
+
+set -o errexit -o pipefail
+
+cd "$(dirname "$0")/../.."
+
+source ./scripts/ci/common.sh
+
+failures=0
+
+# Usage: expect <description> <expected> <actual>
+expect() {
+    local description=$1
+    local expected=$2
+    local actual=$3
+
+    if [[ "$expected" == "$actual" ]]; then
+        echo "ok   - ${description}"
+    else
+        echo "FAIL - ${description}"
+        echo "         expected: ${expected}"
+        echo "         actual:   ${actual}"
+        failures=$(( failures + 1 ))
+    fi
+}
+
+echo "== content_path_to_url =="
+
+expect "package landing page" \
+    "/registry/packages/aws/" \
+    "$(content_path_to_url themes/default/content/registry/packages/aws/_index.md)"
+
+expect "installation and configuration page" \
+    "/registry/packages/aws/installation-configuration/" \
+    "$(content_path_to_url themes/default/content/registry/packages/aws/installation-configuration.md)"
+
+expect "how-to guide" \
+    "/registry/packages/aws/how-to-guides/7-0-migration/" \
+    "$(content_path_to_url themes/default/content/registry/packages/aws/how-to-guides/7-0-migration.md)"
+
+expect "registry section landing page" \
+    "/registry/" \
+    "$(content_path_to_url themes/default/content/registry/_index.md)"
+
+expect "site root" \
+    "/" \
+    "$(content_path_to_url themes/default/content/_index.md)"
+
+expect "leaf bundle collapses to its directory" \
+    "/registry/packages/aws/how-to-guides/some-guide/" \
+    "$(content_path_to_url themes/default/content/registry/packages/aws/how-to-guides/some-guide/index.md)"
+
+echo
+echo "== changed_paths_to_urls =="
+
+expect "package YAML maps to the package page" \
+    "/registry/packages/aws/" \
+    "$(echo themes/default/data/registry/packages/aws.yaml | changed_paths_to_urls)"
+
+expect "a package YAML and its landing page de-duplicate" \
+    "/registry/packages/aws/" \
+    "$(printf '%s\n' \
+        themes/default/data/registry/packages/aws.yaml \
+        themes/default/content/registry/packages/aws/_index.md \
+        | changed_paths_to_urls)"
+
+expect "non-page sources are dropped" \
+    "" \
+    "$(printf '%s\n' \
+        themes/default/layouts/partials/registry/package/icon.html \
+        community-packages/package-list.json \
+        scripts/ci/sync.sh \
+        themes/default/data/registry/external_logo_treatment.yaml \
+        | changed_paths_to_urls)"
+
+expect "first-seen order is preserved across both rules" \
+    "$(printf '%s\n' /registry/packages/gcp/ /registry/packages/aws/ /registry/packages/aws/installation-configuration/)" \
+    "$(printf '%s\n' \
+        themes/default/data/registry/packages/gcp.yaml \
+        themes/default/content/registry/packages/aws/_index.md \
+        themes/default/data/registry/packages/aws.yaml \
+        themes/default/content/registry/packages/aws/installation-configuration.md \
+        | changed_paths_to_urls)"
+
+expect "blank lines are ignored" \
+    "/registry/packages/aws/" \
+    "$(printf '%s\n' "" themes/default/data/registry/packages/aws.yaml "" | changed_paths_to_urls)"
+
+echo
+echo "== existence gate =="
+
+# sync.sh only links a URL when the build actually rendered it, so that url:/alias overrides
+# and files that don't produce a page are dropped rather than linked as dead URLs. Stand up a
+# fake build tree and assert that filter directly.
+build_dir=$(mktemp -d)
+trap 'rm -rf "$build_dir"' EXIT
+mkdir -p "${build_dir}/registry/packages/aws"
+touch "${build_dir}/registry/packages/aws/index.html"
+
+rendered=()
+while IFS= read -r url; do
+    [[ -f "${build_dir}${url}index.html" ]] && rendered+=("$url")
+done < <(printf '%s\n' \
+    themes/default/data/registry/packages/aws.yaml \
+    themes/default/data/registry/packages/never-rendered.yaml \
+    | changed_paths_to_urls)
+
+expect "only rendered pages survive" \
+    "/registry/packages/aws/" \
+    "$(printf '%s\n' "${rendered[@]}")"
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+    echo "${failures} test(s) failed."
+    exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
Ports the pinned preview comment from `pulumi/docs` to this repo.

Today `scripts/ci/sync.sh` posts a **brand-new comment on every commit**, so a long-running PR accumulates a wall of near-identical "Your site preview for commit … is ready!" comments — and none of them tell a reviewer which pages to actually look at. This replaces that with **one comment per PR, rewritten on every build**, carrying:

1. The preview URL for the current commit (`<bucket-website>/registry/`).
2. A **Changed pages** list — direct links to the pages this PR changed.

Rendered body:

```
<!-- registry-preview-link -->
Your site preview for commit abcd1234 is ready! :tada:

http://registry--origin-pr-42-abcd1234.s3-website.us-west-2.amazonaws.com/registry/

**Changed pages:**
- [/registry/packages/aws/](http://…/registry/packages/aws/)
- [/registry/packages/gcp/](http://…/registry/packages/gcp/)
```

### How it stays pinned

The body opens with the marker `<!-- registry-preview-link -->`. `upsert_github_pr_comment` (`scripts/ci/common.sh`) finds the comment carrying it and `PATCH`es that one, only `POST`ing when there's no match.

Two deliberate departures from the `pulumi/docs` original:

- **The comment list is paginated.** The docs version issues an unpaginated `GET` on `…/issues/<n>/comments`, and GitHub returns issue comments oldest-first, 30 per page — so it only ever searches the 30 oldest. The pinned comment is normally created by the first build and sits safely inside that window, but on a PR that collects 30+ comments *before* its first successful preview build (fact sheets, `/check` runs, review chatter, builds that fail before commenting), it lands at position 31+ and becomes permanently invisible to the lookup. Every later build then appends another duplicate. This version walks up to 10 pages of 100, so ordering doesn't matter.
- **The lookup matches the comment author** (`github-actions[bot]` / `pulumi-bot`) as well as the marker, so a contributor can't redirect the pinned comment by quoting the marker in a comment of their own.

The stray `.` glued to the end of the old URL (`…/registry.`) is gone too.

### How changed pages are resolved

The changed-file list comes from the GitHub files API rather than a local `git diff`, so it behaves identically for the `pull_request` build and the maintainer-triggered `/preview` command (which runs the same composite action against a synthetic event file). `changed_paths_to_urls` maps each path under two rules:

| Changed path | URL |
|---|---|
| `themes/default/content/**/*.md` | Hugo's own rules (`content_path_to_url`) |
| `themes/default/data/registry/packages/<pkg>.yaml` | `/registry/packages/<pkg>/` |

The YAML rule is the one that carries this repo — the generated `api-docs/` content is gitignored and never appears in a PR diff, so a straight port of the docs' content-markdown-only rule would leave the section empty on most registry PRs. (The `<pkg>` slug is the YAML basename; verified it equals the file's `name:` field for all 308 packages, and results are existence-checked anyway.)

Results are de-duplicated (a PR touching both `aws.yaml` and `aws/_index.md` lists the page once) and filtered to URLs that actually rendered in this build, so `url:`/alias overrides and removed files drop out instead of becoming dead links. Capped at 50 with an "…and N more" line.

### Safety

The whole block is reporting, not deployment, so it's invoked as `post_preview_comment || log …` and can never fail an otherwise-good build. It no-ops cleanly when the event payload or token is missing (local runs). The preview URL also goes to `$GITHUB_STEP_SUMMARY`, so the link is on the job page even if the comment can't be posted.

Behavior that did **not** change: the comment is still posted only after a fully successful build, since `sync.sh` runs under `set -o errexit` after the Cypress smoke test.

### Testing

`scripts/ci/test-preview-comment.sh` (new) covers the path→URL mapping, de-duplication, ordering, and the existence gate — offline, no network or Hugo build. Wired up as `make test-preview-comment` and run in the existing `Lint Scripts` job, which is already in `sentinel.needs`.

Verified locally:

- `make test-preview-comment` — 12/12 pass.
- A stubbed-`curl` harness driving the real functions end-to-end: no existing comment → `POST`; existing pinned comment → `PATCH` of that comment (and *not* of a decoy comment from another author carrying the same marker); files API returning an error object → comment still posts, `Changed pages` section omitted; missing token → clean skip, exit 0.
- `bash -n` on both modified scripts. Note `make lint` doesn't cover bash — `yarn run lint` is eslint + prettier over `.js`, and shellcheck isn't in the toolchain.

Still to verify on this PR itself: that the real `preview` job produces exactly one comment, that a second push edits it rather than adding another, and that the changed-page links resolve.

### Known limitation (not addressed here)

`.github/workflows/pull-request.yml` has no `concurrency:` block, so two rapid pushes can produce overlapping preview runs that both read-then-write the pinned comment and create a duplicate. Adding `concurrency` with `cancel-in-progress` would fix it but would also start cancelling in-flight preview builds — a behavior change worth its own PR.