### PR TITLE
Remove the HCL preview badge from the language chooser

### DIFF
--- a/themes/default/theme/stencil/src/components/chooser/chooser.tsx
+++ b/themes/default/theme/stencil/src/components/chooser/chooser.tsx
@@ -581,7 +581,7 @@ export class Chooser {
             name: "HCL",
             extension: "hcl",
             logo: "/images/docs/icons/languages/hcl-color-32-32.svg",
-            preview: true,
+            preview: false,
         },
         {
             key: "opa",


### PR DESCRIPTION
Pulumi's HCL support is no longer in preview, so the language chooser on code samples should no longer show a "Preview" badge next to HCL. This flips the `preview` flag on the HCL entry in the chooser component.