### PR TITLE
Post the open P0 and P1 registry issues to Slack

### DIFF
--- a/.github/workflows/priority-digest.yml
+++ b/.github/workflows/priority-digest.yml
@@ -1,0 +1,62 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-registry
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
+name: "Scheduled jobs: Priority digest"
+on:
+  schedule:
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Print the digest in the job log instead of posting it to Slack
+        type: boolean
+        default: false
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  post:
+    name: Post open P0 and P1 issues to Slack
+    environment: production
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
+      - name: Check out branch
+        uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Post the digest
+        run: >-
+          uv run --with requests scripts/ci/priority_digest.py
+          ${{ inputs.dry-run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [post]
+    timeout-minutes: 5
+    permissions:
+      id-token: write
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
+      - name: Slack Notification
+        uses: docker://sholung/action-slack-notify:v2.3.0
+        env:
+          SLACK_CHANNEL: registry-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "priority digest failure in pulumi/registry repo :meow_sad:"
+          SLACK_USERNAME: registrybot
+          SLACK_WEBHOOK: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/test-ci-scripts.yml
+++ b/.github/workflows/test-ci-scripts.yml
@@ -50,7 +50,7 @@ jobs:
           GOBIN="$PWD/bin" go install "github.com/pulumi/registry-mirror-tools/cmd/registry-mirror-discover@$COMMIT"
           GOBIN="$PWD/bin" go install "github.com/pulumi/registry-mirror-tools/cmd/registry-mirror-publish@$COMMIT"
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install pyyaml requests
       - name: Run tests
         run: python -m unittest discover -s scripts/ci -p 'test_*.py' -v
       - name: Run scripts/ tests

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -534,6 +534,7 @@ All workflow files live in `.github/workflows/`.
 | `publish-provider-update.yml` | provider docs build | `repository_dispatch` |
 | `bucket-cleanup.yml` | Scheduled jobs: Bucket cleanup | Daily 3:00 PM UTC |
 | `update-tutorials.yml` | Scheduled jobs: Update How To Guides | Daily 3:00 PM UTC |
+| `priority-digest.yml` | Scheduled jobs: Priority digest | Daily 3:00 PM UTC |
 | `export-repo-secrets.yml` | Export secrets to ESC | `workflow_dispatch` |
 | `add-triage-label.yml` | Add triage label to new issues | Issue opened / reopened |
 | `add-to-project.yml` | Add issues to project | Issue opened / reopened |
@@ -774,6 +775,14 @@ Runs in the production environment (`388588623842:role/ContinuousDelivery`). Nod
 3. Opens or updates a PR on branch `tutorials/refresh` via `peter-evans/create-pull-request@v7`.
 
 Auto-merge is currently disabled (commented out in the workflow).
+
+#### `priority-digest.yml` — Post Open P0 and P1 Issues to Slack
+
+**Trigger**: Daily at 3:00 PM UTC; also `workflow_dispatch` with a `dry-run` input
+
+Runs `scripts/ci/priority_digest.py`, which searches GitHub for open issues labelled `p0` or `p1` across `pulumi/registry` and `pulumi/terraform-to-pulumi-registry-pipeline`, then posts them to #team-iac-cloud, oldest first, with each issue's age and assignee.
+
+Replaces a Metabase subscription that posted the same query as a screenshot. Uses `PULUMI_BOT_TOKEN` and `SLACK_WEBHOOK_URL` from ESC; no other configuration. `--dry-run` prints the message to the job log instead of posting.
 
 #### `export-repo-secrets.yml` — Sync GitHub Secrets → ESC
 
@@ -1084,7 +1093,7 @@ The `export-repo-secrets.yml` workflow provides a manual escape hatch to sync Gi
 | `DEPLOYMENT_ENVIRONMENT` | GitHub var | build, cleanup | e.g., `testing` or `production` |
 | `NODE_OPTIONS` | Hardcoded | build, browser tests | `--max_old_space_size=8192` |
 | `SLACK_ACCESS_TOKEN` | ESC | link check, cleanup | Slack Web API token for posting messages |
-| `SLACK_WEBHOOK_URL` | ESC | notify jobs | Slack incoming webhook for failure alerts |
+| `SLACK_WEBHOOK_URL` | ESC | notify jobs, priority digest | Slack incoming webhook for failure alerts and the daily digest |
 | `ASSET_BUNDLE_ID` | `build.sh` (computed) | Hugo templates | Unique suffix for CSS/JS cache-busting |
 | `CSS_BUNDLE` / `JS_BUNDLE` | `build.sh` (computed) | Hugo templates | Paths to versioned asset bundles |
 
@@ -1111,6 +1120,7 @@ Note: `mise.toml` specifies Node 20 for local development, while CI workflows us
 | Link check | 3:00 PM every Monday | `check-links.yml` | `make check_links` |
 | Browser tests (scheduled) | 2:00 PM daily | `run-browser-tests.yml` | `make run-browser-tests` |
 | Stale bucket cleanup | 3:00 PM daily | `bucket-cleanup.yml` | `make ci_bucket_cleanup` |
+| Open P0 and P1 issue digest | 3:00 PM daily | `priority-digest.yml` | `scripts/ci/priority_digest.py` |
 
 ---
 

--- a/scripts/ci/priority_digest.py
+++ b/scripts/ci/priority_digest.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+REPOSITORIES = ["pulumi/registry", "pulumi/terraform-to-pulumi-registry-pipeline"]
+PRIORITY_LABELS = ["p0", "p1"]
+LISTED_AT_MOST = 20
+
+QUERY = " ".join(
+    [f"repo:{repository}" for repository in REPOSITORIES]
+    + ["is:issue", "is:open", "label:" + ",".join(PRIORITY_LABELS), "sort:created-asc"]
+)
+
+
+def require_env(name):
+    value = os.getenv(name)
+    if not value:
+        sys.exit(f"{name} is not set")
+    return value
+
+
+def search_issues():
+    token = require_env("GITHUB_TOKEN")
+    issues = []
+    page = 1
+    while True:
+        response = requests.get(
+            "https://api.github.com/search/issues",
+            params={"q": QUERY, "per_page": 100, "page": page},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        body = response.json()
+        issues += body["items"]
+        if len(issues) >= body["total_count"] or not body["items"]:
+            return issues
+        page += 1
+
+
+def escape(text):
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def age_in_days(issue, now=None):
+    created = datetime.fromisoformat(issue["created_at"].replace("Z", "+00:00"))
+    return ((now or datetime.now(timezone.utc)) - created).days
+
+
+def repository_of(issue):
+    return "/".join(issue["repository_url"].split("/")[-2:])
+
+
+def describe(issue, now=None):
+    labels = [label["name"] for label in issue["labels"]]
+    priority = ", ".join(label for label in labels if label in PRIORITY_LABELS)
+    kind = ", ".join(label for label in labels if label.startswith("kind/"))
+    assignees = ", ".join(assignee["login"] for assignee in issue["assignees"]) or "unassigned"
+    return " · ".join(part for part in [priority, kind, assignees, f"{age_in_days(issue, now)}d old"] if part)
+
+
+def render(issues, now=None):
+    if not issues:
+        return ":white_check_mark: *Registry P0 and P1*: nothing open."
+
+    search_url = "https://github.com/search?type=issues&q=" + requests.utils.quote(QUERY)
+    lines = [f":bell: *Registry P0 and P1*: <{search_url}|{len(issues)} open>, oldest first."]
+
+    for repository in REPOSITORIES:
+        listed = [issue for issue in issues if repository_of(issue) == repository]
+        if not listed:
+            continue
+        lines.append("")
+        lines.append(f"*{repository}* ({len(listed)})")
+        for issue in listed[:LISTED_AT_MOST]:
+            lines.append(
+                f"• <{issue['html_url']}|#{issue['number']}> {escape(issue['title'])} — {describe(issue, now)}"
+            )
+        if len(listed) > LISTED_AT_MOST:
+            lines.append(f"• …and {len(listed) - LISTED_AT_MOST} more")
+
+    return "\n".join(lines)
+
+
+def log_counts(issues):
+    for repository in REPOSITORIES:
+        found = sum(1 for issue in issues if repository_of(issue) == repository)
+        print(f"{repository}: {found} open", file=sys.stderr)
+
+
+def post(channel, message):
+    response = requests.post(
+        require_env("SLACK_WEBHOOK_URL"),
+        json={
+            "channel": channel,
+            "text": message,
+            "username": "registrybot",
+            "icon_url": "https://www.pulumi.com/logos/brand/avatar-on-white.png",
+            "mrkdwn": True,
+            "unfurl_links": False,
+        },
+        timeout=30,
+    )
+    if response.status_code != 200 or response.text.strip() != "ok":
+        sys.exit(f"Slack rejected the message: {response.status_code} {response.text.strip()}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="priority-digest",
+        description="""Post the open P0 and P1 registry issues to Slack, oldest first
+
+        GITHUB_TOKEN must be set to read issues.
+        SLACK_WEBHOOK_URL must be set to post.
+        SLACK_CHANNEL may be set. Defaults to #team-iac-cloud.
+        """,
+        epilog="This is a Pulumi internal tool - it is not intended for external use")
+    parser.add_argument("--dry-run", action="store_true", help="Print the message instead of posting it")
+    parser.add_argument("--channel", default=os.getenv("SLACK_CHANNEL", "#team-iac-cloud"),
+                        help="Slack channel to post to, as #name.")
+
+    args = parser.parse_args()
+
+    issues = search_issues()
+    log_counts(issues)
+    message = render(issues)
+
+    if args.dry_run:
+        print(message)
+    else:
+        post(args.channel, message)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test_priority_digest.py
+++ b/scripts/ci/test_priority_digest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Unit tests for priority_digest.py"""
+
+import unittest
+from datetime import datetime, timezone
+
+from priority_digest import describe, escape, render, repository_of
+
+
+NOW = datetime(2026, 8, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def issue(number=1, title="Something broke", repository="registry", created="2026-08-04T12:00:00Z",
+          labels=("p1", "kind/bug"), assignees=()):
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/pulumi/{repository}/issues/{number}",
+        "repository_url": f"https://api.github.com/repos/pulumi/{repository}",
+        "created_at": created,
+        "labels": [{"name": name} for name in labels],
+        "assignees": [{"login": login} for login in assignees],
+    }
+
+
+class TestEscape(unittest.TestCase):
+    def test_escapes_slack_control_characters(self):
+        self.assertEqual(escape("<https://evil.example|Click>"), "&lt;https://evil.example|Click&gt;")
+
+    def test_escapes_ampersand_first(self):
+        self.assertEqual(escape("a & <b>"), "a &amp; &lt;b&gt;")
+
+    def test_leaves_ordinary_titles_alone(self):
+        self.assertEqual(escape("Pipeline failed: intersight did not update"),
+                         "Pipeline failed: intersight did not update")
+
+
+class TestRepositoryOf(unittest.TestCase):
+    def test_reads_owner_and_name(self):
+        self.assertEqual(repository_of(issue(repository="registry")), "pulumi/registry")
+
+
+class TestDescribe(unittest.TestCase):
+    def test_lists_priority_kind_assignee_and_age(self):
+        self.assertEqual(describe(issue(), NOW), "p1 · kind/bug · unassigned · 10d old")
+
+    def test_names_assignees(self):
+        self.assertEqual(describe(issue(assignees=("fnune",)), NOW), "p1 · kind/bug · fnune · 10d old")
+
+    def test_omits_labels_it_does_not_recognise(self):
+        self.assertEqual(describe(issue(labels=("needs-triage",)), NOW), "unassigned · 10d old")
+
+
+class TestRender(unittest.TestCase):
+    def test_reports_nothing_open(self):
+        self.assertEqual(render([]), ":white_check_mark: *Registry P0 and P1*: nothing open.")
+
+    def test_groups_by_repository(self):
+        message = render([
+            issue(number=1, repository="registry"),
+            issue(number=2, repository="terraform-to-pulumi-registry-pipeline"),
+        ], NOW)
+        self.assertIn("*pulumi/registry* (1)", message)
+        self.assertIn("*pulumi/terraform-to-pulumi-registry-pipeline* (1)", message)
+
+    def test_links_each_issue(self):
+        message = render([issue(number=12079)], NOW)
+        self.assertIn("• <https://github.com/pulumi/registry/issues/12079|#12079>", message)
+
+    def test_escapes_titles(self):
+        message = render([issue(title="<https://evil.example|Click here>")], NOW)
+        self.assertNotIn("<https://evil.example|Click here>", message)
+        self.assertIn("&lt;https://evil.example|Click here&gt;", message)
+
+    def test_truncates_long_lists(self):
+        message = render([issue(number=n) for n in range(25)], NOW)
+        self.assertIn("• …and 5 more", message)
+
+    def test_counts_every_issue_in_the_header(self):
+        message = render([issue(number=n) for n in range(25)], NOW)
+        self.assertIn("|25 open>", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The daily Metabot post is a Metabase screenshot: nothing is clickable, and the state is stale by the time it arrives.

This replaces it with a scheduled job that queries the same issues from GitHub and posts them as real links, with each issue's age and assignee. Same repositories and labels as the Metabase question it replaces.

Posts to #team-iac-cloud through the existing `SLACK_WEBHOOK_URL` from ESC, relying on the legacy incoming webhook's channel override, so there is no new secret and no new infrastructure. `workflow_dispatch` takes a `dry-run` input that prints the message to the job log instead.

Verified by posting to #team-iac-cloud:


```
:bell: *Registry P0 and P1*: <…|4 open>, oldest first.

*pulumi/registry* (3)
• <…|#12079> Workflow failure: [PR #12076] - Pull request — p1 · kind/engineering · unassigned · 1d old
• <…|#12101> Workflow failure: Check for Community Package Updates — p1 · kind/engineering · unassigned · 0d old
• <…|#12104> Workflow failure: provider docs build — p1 · kind/engineering · unassigned · 0d old

*pulumi/terraform-to-pulumi-registry-pipeline* (1)
• <…|#368> Pipeline failed: intersight did not update — p1 · kind/bug · unassigned · 9d old
```

`render()`, `describe()` and `escape()` are covered by `test_priority_digest.py`, which `test-ci-scripts.yml` picks up automatically.

Once this is posting, turn off the Metabase subscription for "Registry P0 and P1".

Closes part of pulumi/pulumi-service#47998.
