### PR TITLE
[ci] Key the Go module cache on the module each job builds

### DIFF
--- a/.github/actions/build-and-deploy-preview/action.yml
+++ b/.github/actions/build-and-deploy-preview/action.yml
@@ -40,7 +40,8 @@ runs:
     - name: Install Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.x
+        go-version-file: tools/resourcedocsgen/go.mod
+        cache-dependency-path: tools/resourcedocsgen/go.sum
 
     - name: Install Hugo
       uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/bucket-cleanup.yml
+++ b/.github/workflows/bucket-cleanup.yml
@@ -32,9 +32,11 @@ jobs:
         with:
           node-version: '24.x'
 
-      - uses: actions/setup-go@v6
+      - name: Set up Go, opting out of the repo-root module cache key
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26.x
+          cache: false
 
       - name: Configure Git
         run: |

--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: '${{ inputs.path }}/go.mod'
+        cache-dependency-path: '${{ inputs.path }}/go.sum'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
@@ -49,6 +50,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: '${{ inputs.path }}/go.mod'
+        cache-dependency-path: '${{ inputs.path }}/go.sum'
     - name: Run Tests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/community-package-check.yml
+++ b/.github/workflows/community-package-check.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/generate-package-metadata.yml
+++ b/.github/workflows/generate-package-metadata.yml
@@ -82,6 +82,12 @@ jobs:
       - name: Check out registry repo
         if: steps.skip-run.outputs.skip != 1
         uses: actions/checkout@v7
+      - name: Set up Go
+        if: steps.skip-run.outputs.skip != 1
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
       - name: Sleep to prevent hitting secondary rate limits
         if: steps.skip-run.outputs.skip != 1
         run: sleep 1

--- a/.github/workflows/publish-provider-update.yml
+++ b/.github/workflows/publish-provider-update.yml
@@ -70,6 +70,11 @@ jobs:
       - run: echo "Building ${{ env.PROVIDER_SHORT_NAME }} docs @ ${{ env.PROVIDER_VERSION }}"
       - name: checkout registry repo
         uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
       - name: Build resourcedocsgen
         run: go build -C tools/resourcedocsgen
       - name: Generate Package Metadata
@@ -114,6 +119,11 @@ jobs:
       - run: echo "Building ${{ env.PROVIDER_SHORT_NAME }} docs @ ${{ env.PROVIDER_VERSION }}"
       - name: checkout registry repo
         uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
       - name: Check the publisher is registered
         env:
           PUBLISHER_NAMES: tools/resourcedocsgen/pkg/publishers/publisher-names.json

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -199,7 +199,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.x
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.x
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/test-ci-scripts.yml
+++ b/.github/workflows/test-ci-scripts.yml
@@ -37,19 +37,37 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - name: Set up Go
+      - name: Set up Go, opting out of the repo-root module cache key
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache: false
+      - name: Get registry-mirror-tools version
+        id: mirror-version
+        run: |
+          hash="$(grep 'REGISTRY_MIRROR_TOOLS_COMMIT=' scripts/generate-versioned-docs.sh | cut -d'"' -f2)"
+          if [ -z "$hash" ]; then
+            echo "Could not read REGISTRY_MIRROR_TOOLS_COMMIT from scripts/generate-versioned-docs.sh" >&2
+            exit 1
+          fi
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+      - name: Cache the registry-mirror-tools binaries
+        uses: actions/cache@v6
+        with:
+          path: |
+            bin/registry-mirror-discover
+            bin/registry-mirror-publish
+          key: registry-mirror-tools-bins-${{ runner.os }}-${{ steps.mirror-version.outputs.hash }}
       - name: Configure git for private Go modules
         run: git config --global url."https://${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}:x-oauth-basic@github.com/pulumi/registry-mirror-tools".insteadOf "https://github.com/pulumi/registry-mirror-tools"
       - name: Install registry-mirror-tools
         env:
           GOPRIVATE: github.com/pulumi/registry-mirror-tools
         run: |
-          COMMIT="dda1dfd85d540fab45a0d19060e963564d0b36aa"
-          GOBIN="$PWD/bin" go install "github.com/pulumi/registry-mirror-tools/cmd/registry-mirror-discover@$COMMIT"
-          GOBIN="$PWD/bin" go install "github.com/pulumi/registry-mirror-tools/cmd/registry-mirror-publish@$COMMIT"
+          COMMIT="${{ steps.mirror-version.outputs.hash }}"
+          for cmd in registry-mirror-discover registry-mirror-publish; do
+            [ -x "bin/$cmd" ] || GOBIN="$PWD/bin" go install "github.com/pulumi/registry-mirror-tools/cmd/$cmd@$COMMIT"
+          done
       - name: Install dependencies
         run: pip install pyyaml requests
       - name: Run tests

--- a/.github/workflows/testing-deploy.yml
+++ b/.github/workflows/testing-deploy.yml
@@ -40,7 +40,8 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.x
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
 
       - uses: peaceiris/actions-hugo@v3
         with:

--- a/.github/workflows/update-tutorials.yml
+++ b/.github/workflows/update-tutorials.yml
@@ -19,15 +19,16 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@3af4859af8a73a362fb599b944124097d4bb80c5 # v3
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.26.x
-
       - name: Check out the repo
         uses: actions/checkout@v7
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.x
+          cache-dependency-path: tools/mktutorial/go.sum
 
       - name: Checkout examples repo
         id: checkout-examples

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -466,11 +466,15 @@ CI builds use multiple cache layers to avoid redundant work. All caches are stor
 | Cache | Key | Paths | What it stores |
 |---|---|---|---|
 | Node/Yarn | `node-cache-Linux-x64-yarn-<yarn.lock hash>` | `~/.cache/yarn/v6` | Yarn package cache |
-| Go | `setup-go-...-<go.sum hash>` | `GOMODCACHE`, `GOCACHE` | Go module and build cache |
+| Go (resourcedocsgen) | `setup-go-...-<tools/resourcedocsgen/go.sum hash>` | `GOMODCACHE`, `GOCACHE` | Go module and build cache |
+| Go (mktutorial) | `setup-go-...-<tools/mktutorial/go.sum hash>` | `GOMODCACHE`, `GOCACHE` | Go module and build cache |
+| registry-mirror-tools binaries | `registry-mirror-tools-bins-<os>-<commit hash>` | `bin/registry-mirror-discover`, `bin/registry-mirror-publish` | Pre-built binaries for `test-ci-scripts.yml` |
 | Docs + schemas | `docs-cache-<run_id>` (restore key: `docs-cache-`) | `.cache/schemas`, `.cache/versioned-docs`, `.cache/api-docs` | API docs output, versioned docs, provider schemas, LLM docs JSON |
 | registry-mirror-discover | `registry-mirror-discover-<commit hash>` | `bin/registry-mirror-discover` | Pre-built binary for versioned docs discovery |
 
 The docs cache uses `restore-keys: docs-cache-` so it falls back to the most recent previous run's cache when an exact match isn't found (the key includes `run_id`, so it's always unique).
+
+Each Go job keys on the `go.sum` of the module it compiles, via `cache-dependency-path`. Keep it that way: one key per module, never one key listing both. `setup-go` restores on an exact primary-key match and exposes no `restore-keys`, so a single shared key means the first job to finish decides what every later job restores — and if that is a `mktutorial` check, the jobs building `resourcedocsgen` stay cold. Jobs that compile neither module set `cache: false` rather than falling back to the repo-root `go.mod`, which describes the Hugo theme module and never changes.
 
 #### Incremental API docs generation
 
@@ -1145,7 +1149,7 @@ The `export-repo-secrets.yml` workflow provides a manual escape hatch to sync Gi
 | Tool | `mise.toml` | `pull-request.yml` (preview) | `push.yml` (production) | `testing-deploy.yml` |
 |---|---|---|---|---|
 | Node.js | 20 | 22.x | 22.x | 22.x |
-| Go | 1.26 | 1.26.x | 1.26.x | 1.21.x |
+| Go | 1.26 | `tools/resourcedocsgen/go.mod` | `tools/resourcedocsgen/go.mod` | `tools/resourcedocsgen/go.mod` |
 | Hugo | 0.157 | 0.157.0 | 0.157.0 | 0.157.0 |
 | golangci-lint | 2.1.6 | v2.1.6 (check-go.yml) | — | — |
 | s5cmd | — | v2.3.0 | v2.3.0 | v2.3.0 |


### PR DESCRIPTION
A survey of 1604 workflow runs between 2026-01-28 and 2026-08-14 found 334 failed jobs. The largest bucket is `Check for a new version` in `generate-package-metadata.yml`, 134 failures across 84 repos. Half of the sampled failures were the unretried TCP reset in `pkgversion.go` that #12046 fixed. The other half are Go module downloads dying mid-transfer against `proxy.golang.org`:

```
go: downloading github.com/pkg/errors v0.9.1
/home/runner/go/pkg/mod/github.com/go-git/go-git/v5@v5.19.1/utils/diff/diff.go:13:2: github.com/sergi/go-diff@v1.4.0: read "https://proxy.golang.org/github.com/..."
```

Go has no retry flag for module downloads and `GOPROXY`'s `,direct` fallback only triggers on 404 and 410, not on a read error, so the fix is to not download the modules in the first place.

## Why the cache was never warm

`actions/setup-go` caches modules by default, but no job told it which module it builds. Its default is to hash the `go.mod` it finds at the repo root — here a ten-line stub declaring the Hugo theme module, untouched by anything under `tools/`. Its cache key is `setup-go-<os>-<arch>-<image>-go-<installed version>-<hash>`, restored on an exact match with no `restore-keys`, so:

- every job that set Go up competed for the same key, whatever module it actually compiled;
- the first job to finish claimed it, and every later job restored someone else's modules, downloaded its own, and could not save them because the key was taken;
- a dependency change in `tools/resourcedocsgen` never invalidated anything.

Two workflows had no `setup-go` step at all and so had no cache under any key.

## Survey

| Workflow / job | Go before | Cache before | After |
|---|---|---|---|
| `generate-package-metadata.yml` — `check-for-package-update` | preinstalled, no `setup-go` | none | `setup-go`, keyed on `tools/resourcedocsgen/go.sum` |
| `publish-provider-update.yml` — `build-resource-provider-docs`, `build-provider-docs` | preinstalled, no `setup-go` | none | `setup-go`, keyed on `tools/resourcedocsgen/go.sum` |
| `check-go.yml` — `lint`, `test` | `go-version-file` | root `go.mod` | keyed on `${{ inputs.path }}/go.sum` |
| `community-package-check.yml` | `go-version-file` | root `go.mod` | keyed on `tools/resourcedocsgen/go.sum` |
| `pull-request.yml` — `test-provider-api-docs` | `go-version: 1.26.x` | root `go.mod` | `go-version-file` + `tools/resourcedocsgen/go.sum` |
| `push.yml` — `build` | `go-version: 1.26.x` | root `go.mod` | `go-version-file` + `tools/resourcedocsgen/go.sum` |
| `testing-deploy.yml` — `buildSite` | `go-version: 1.26.x` | root `go.mod` | `go-version-file` + `tools/resourcedocsgen/go.sum` |
| `actions/build-and-deploy-preview` (PR preview, `/preview`) | `go-version: 1.26.x` | root `go.mod` | `go-version-file` + `tools/resourcedocsgen/go.sum` |
| `update-tutorials.yml` — `merge` | `go-version: 1.26.x`, before the checkout | root `go.mod` | moved after the checkout, keyed on `tools/mktutorial/go.sum` |
| `test-ci-scripts.yml` — `test` | `go-version: '1.26'` | root `go.mod` | `cache: false`, plus an `actions/cache` keyed on the pinned commit |
| `bucket-cleanup.yml` — `all` | `go-version: 1.26.x` | root `go.mod` | `cache: false` |

## Notes on the shape of the fix

**One key per module, not one key for both.** Listing both `go.sum` files everywhere would put every workflow back on a single key, and the job that claims it decides what the cache holds — if that is the `mktutorial` check, the nightly metadata run stays as cold as it is today. Each job keys on the `go.sum` it compiles, so `resourcedocsgen` jobs share one key across seven workflows and `mktutorial` jobs have their own.

**`go-version-file` where it unifies the key.** The key carries the *installed* Go version, so `1.26.x` and a `go.mod` saying `go 1.26` collide only if they resolve to the same patch. The workflows that build `resourcedocsgen` read the version from its `go.mod`, so they share a cache with `check-go.yml` and the version stops being repeated in five places. `update-tutorials.yml` keeps `1.26.x`: `mktutorial`'s `go.mod` declares 1.23, and since `setup-go` exports `GOTOOLCHAIN=local`, pinning the nightly to 1.23 would turn a dependency that wants a newer toolchain into a failure rather than a download.

**Two jobs opt out.** `bucket-cleanup.yml` compiles no module in this repo, and `test-ci-scripts.yml` only runs `go install <module>@<commit>`, which no `go.sum` here describes — the only configuration that can key it is the pinned commit, so that one gets a hand-rolled `actions/cache` over `~/go/pkg/mod` and `~/.cache/go-build`. Both stop claiming the key the compiling jobs need.

No retries are added and no tool source changes.

## Found, not fixed

The Makefile runs `go install github.com/iwahbe/helpmakego@v0.1.0` from a top-level `$(shell ...)`, so *every* `make` target does a module download, including in jobs with no Go set up at all: `lint-markdown`, `lint-scripts`, `lint-dark-logos`, `test-infra`, `check-links.yml` and `run-browser-tests.yml`. It degrades gracefully — a failed install leaves `$(shell ${HELPMAKEGO} …)` empty, the target loses its prerequisites and still builds — so those jobs do not fail on it, and the jobs that do compile Go now cache `helpmakego` along with everything else. Giving the pure-lint jobs a Go toolchain to warm one tiny module is a bigger change than the flake justifies.

`test-ci-scripts.yml` and `scripts/generate-versioned-docs.sh` still pin the `registry-mirror-tools` commit in two places; the workflow's copy is now a job-level env var with a comment, but nothing enforces that they agree.

## Test plan

1. Automated tests
    - `actionlint` 1.7.12 over `.github/workflows`: findings are the pre-existing custom runner labels and shellcheck notes on scripts this change does not touch, none on the edited lines.
    - `yaml.safe_load` on each of the 11 edited files: all parse.
    - `go build ./...` in `tools/resourcedocsgen` and `tools/mktutorial`: both build.
2. Manual checks
    - Read `actions/setup-go` at `main` to confirm the default dependency file, the key format, the absence of `restore-keys`, that the key uses the installed Go version, and that a restore failure is a warning rather than a job failure.
    - Checked step order in every edited workflow so `cache-dependency-path` and `go-version-file` resolve against a checked-out tree.
    - The `Set up Go` step added to the metadata matrix carries the same `if: steps.skip-run.outputs.skip != 1` guard as the checkout and build steps around it, so skipped packages still skip.
