### PR TITLE
[ci] Build resourcedocsgen once and parallelize the package matrix

### DIFF
--- a/.github/workflows/generate-package-metadata.yml
+++ b/.github/workflows/generate-package-metadata.yml
@@ -24,6 +24,19 @@ jobs:
         id: esc-secrets
         uses: pulumi/esc-action@3af4859af8a73a362fb599b944124097d4bb80c5 # v3
       - uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/resourcedocsgen/go.mod
+          cache-dependency-path: tools/resourcedocsgen/go.sum
+      - name: Build resourcedocsgen once for the whole matrix
+        run: go build -C tools/resourcedocsgen
+      - name: Upload resourcedocsgen for the matrix jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: resourcedocsgen
+          path: tools/resourcedocsgen/resourcedocsgen
+          retention-days: 1
       - id: set-matrix
         run: echo "matrix=$(python generate_package_list.py)" >> $GITHUB_OUTPUT
         working-directory: community-packages
@@ -42,10 +55,9 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # GitHub recommends only issuing 1 API request per second, and never
-      # concurrently.  For more information, see:
+      # Bounded to stay inside GitHub's secondary rate limits:
       # https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
-      max-parallel: 1
+      max-parallel: 8
       matrix: ${{fromJson(needs.generate-packages-list.outputs.matrix)}}
     steps:
       - name: Fetch secrets from ESC
@@ -82,15 +94,15 @@ jobs:
       - name: Check out registry repo
         if: steps.skip-run.outputs.skip != 1
         uses: actions/checkout@v7
-      - name: Set up Go
+      - name: Download resourcedocsgen
         if: steps.skip-run.outputs.skip != 1
-        uses: actions/setup-go@v6
+        uses: actions/download-artifact@v8
         with:
-          go-version-file: tools/resourcedocsgen/go.mod
-          cache-dependency-path: tools/resourcedocsgen/go.sum
-      - name: Sleep to prevent hitting secondary rate limits
+          name: resourcedocsgen
+          path: tools/resourcedocsgen
+      - name: Restore the executable bit the artifact upload drops
         if: steps.skip-run.outputs.skip != 1
-        run: sleep 1
+        run: chmod +x tools/resourcedocsgen/resourcedocsgen
       - name: Check for a new version
         if: steps.skip-run.outputs.skip != 1
         id: version
@@ -99,8 +111,7 @@ jobs:
         run: |
           max_attempts=3
           for attempt in $(seq "$max_attempts"); do
-            if go build -C tools/resourcedocsgen &&
-              provider_version=$(./tools/resourcedocsgen/resourcedocsgen pkgversion --repoSlug "$REPO_SLUG"); then
+            if provider_version=$(./tools/resourcedocsgen/resourcedocsgen pkgversion --repoSlug "$REPO_SLUG"); then
               {
                 echo 'PROVIDER_VERSION<<EOF'
                 echo "$provider_version"
@@ -117,9 +128,6 @@ jobs:
       - name: Display new version
         if: env.PROVIDER_VERSION
         run: echo ${{ env.PROVIDER_VERSION}}
-      - name: Build resourcedocsgen
-        if: env.PROVIDER_VERSION
-        run: go build -C tools/resourcedocsgen
       - name: Read package name at the release version
         # The skip-dedup read above resolves the name at HEAD, because the
         # release version isn't known yet at that point. Re-read it here pinned


### PR DESCRIPTION
Run https://github.com/pulumi/registry/actions/runs/31774707423 took 2h50m. The
matrix ran with `max-parallel: 1`, and each of its 100 jobs spent roughly 75 of
its 96 seconds compiling resourcedocsgen from a cold cache in order to make a
single API call.

`generate-packages-list` now compiles the binary once and uploads it as an
artifact that each matrix job downloads. `actions/upload-artifact` does not
preserve the executable bit, so the job restores it with `chmod +x`. The matrix
job no longer builds Go code, so it drops the `setup-go` step this branch's
parent added to it.

`max-parallel` moves from 1 to 8. Packages do not contend: each writes its own
YAML file and pushes its own `<provider>/publish-metadata` branch.

## Test plan

1. Automated checks
   - `actionlint` on the workflow reports no findings beyond the pre-existing `SC2086` notices on `$GITHUB_OUTPUT`
2. Dry run: https://github.com/pulumi/registry/actions/runs/31816343510
   - Dispatched from a throwaway branch holding this commit with `Create registry PR` swapped for an `echo`, so no package PRs were opened. The branch has since been deleted; the run is retained
   - 9m39s end to end, down from 2h50m. All 100 matrix jobs green, `notify` skipped
   - `generate-packages-list` compiled the binary in 75s and uploaded it in 4s
   - Matrix jobs ran 8 at a time. Mean job 31s (min 18s, max 89s), against 96s each when every job compiled
   - `Download resourcedocsgen` took 1s, and the binary ran without a permissions error after the `chmod +x`
   - Six packages had a new release and exercised the full path through version check, metadata generation and the stubbed PR step: grafana, dynatrace, runpod-native, and the three defang packages
