### PR TITLE
Add Biznet GIO community provider (shirasakaren/pulumi-biznetgio)

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -399,6 +399,10 @@
     {
       "repoSlug": "atensecurity/pulumi-thoth",
       "schemaFile": "provider/cmd/pulumi-resource-thoth/schema.json"
+    },
+    {
+      "repoSlug": "shirasakaren/pulumi-biznetgio",
+      "schemaFile": "provider/cmd/pulumi-resource-biznetgio/schema.json"
     }
   ]
 }

--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -143,6 +143,7 @@
     "rootlyhq": "rootly",
     "rpothin": "rpothin",
     "selectel": "selectel",
+    "shirasakaren": "shirasakaren",
     "spectrocloud": "spectrocloud",
     "splightplatform": "splightplatform",
     "stackitcloud": "stackitcloud",
@@ -162,6 +163,5 @@
     "volcenginecc": "volcenginecc",
     "vmware": "vmware",
     "wavefront": "wavefront",
-    "zenduty": "zenduty",
-    "Shirasaka Ren": "shirasakaren"
+    "zenduty": "zenduty"
 }

--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -162,5 +162,6 @@
     "volcenginecc": "volcenginecc",
     "vmware": "vmware",
     "wavefront": "wavefront",
-    "zenduty": "zenduty"
+    "zenduty": "zenduty",
+    "Shirasaka Ren": "shirasakaren"
 }


### PR DESCRIPTION
Adds `shirasakaren/pulumi-biznetgio`, a community provider for Biznet GIO cloud (NEO Metal, NEO Lite/Lite Pro, NEO GPU, Object Storage).

- Native Go provider: https://github.com/shirasakaren/pulumi-biznetgio
- Schema at `provider/cmd/pulumi-resource-biznetgio/schema.json`
- Publisher `shirasakaren` fixed in `publisher-names.json` (was keyed by display name instead of the schema's publisher slug)

### Connection to the provider

Maintainer — GitHub handle `@shirasakaren` is me.

### Status vs. the last review

- Added `docs/_index.md` and `docs/installation-configuration.md` to the provider repo, verified locally with `resourcedocsgen metadata from-github` against the real tag
- Fixed the `publisher-names.json` key
- NuGet and Maven Central are now live — found and fixed real bugs in the release pipeline for both (a broken package icon and a signing key never published to a keyserver), not just missing credentials
- Carried the billing note into `docs/_index.md`
- Removed the stray 40MB binary, dropped the "masih development" description
- Listed version: **v0.1.7**

Ready for `/check`.
