### PR TITLE
[registry] Say why a community package check failed

### DIFF
--- a/scripts/ci/community-package/fact_sheet.py
+++ b/scripts/ci/community-package/fact_sheet.py
@@ -92,19 +92,27 @@ def render(manifest: Manifest) -> str:
             listed = "✅"
         else:
             listed = "⚠️" if manifest.green else "❌"
-        lines.append(f"| publisher listed | {listed} | `{manifest.publisher}` in publisher-names.json |")
+        lines.append(f"| publisher listed | {listed} | `{manifest.publisher}` is a key in publisher-names.json |")
     lines += ["", f"Owner `{manifest.owner}`"]
 
     if manifest.publisher and not manifest.publisherKnown:
-        lines += ["", f"**Publisher** ❌ `{manifest.publisher}` is not in `publisher-names.json`. Add "
+        lines += ["", f"**Publisher** ❌ no entry for `{manifest.publisher}`. `publisher-names.json` maps the "
+                      "`publisher` string in a provider's schema (the key) to that publisher's slug in the "
+                      "registry backend (the value, which goes into an API path). Add "
                       f"`\"{manifest.publisher}\": \"<slug>\"` to "
-                      "`tools/resourcedocsgen/pkg/publishers/publisher-names.json` in this PR; without it the "
-                      "registry-backend schema fetch fails and falls back to VCS. If this publisher already "
-                      "ships under a different slug, use that slug as the value so the two do not split."]
+                      "`tools/resourcedocsgen/pkg/publishers/publisher-names.json` in this PR; the key and the "
+                      "value are usually the same. If this publisher already ships under a slug, use that one "
+                      "so the two do not split. Without the entry the schema fetch from the registry backend "
+                      "fails and falls back to VCS."]
 
     findings = manifest.docLint
     lines.append("")
-    if findings:
+    if not manifest.indexPresent:
+        lines.append("**Doc-lint** ❌ the provider repo has no `docs/_index.md` at the reviewed commit. "
+                     "It is the package's front page in the registry, so it is required, and "
+                     "`resourcedocsgen` cannot generate metadata without it. Add it upstream, cut a "
+                     "release, then comment `/check`.")
+    elif findings:
         lines.append(f"**Doc-lint: {len(findings)} finding(s)** (advisory; these break the registry render surfaces):")
         lines += [f"- `docs/_index.md:{f.line}` {f.kind}: `{f.text}`" for f in findings]
     else:
@@ -129,6 +137,19 @@ def render(manifest: Manifest) -> str:
                 fence,
                 "</details>",
             ]
+
+    if not manifest.generation and manifest.generationError:
+        lines += [
+            "",
+            "<details><summary>❌ docs generate failed</summary>",
+            "",
+            "`resourcedocsgen metadata from-github`",
+            "",
+            "```",
+            manifest.generationError.replace("```", "ˋˋˋ"),
+            "```",
+            "</details>",
+        ]
 
     for result in [r for r in manifest.installMatrix if r.result == "fail" and r.error]:
         escaped = result.error.replace("```", "ˋˋˋ")

--- a/scripts/ci/community-package/models.py
+++ b/scripts/ci/community-package/models.py
@@ -63,6 +63,8 @@ class Manifest:
     generation: bool = True
     docs: list[DocFile] = field(default_factory=list)
     error: str = ""
+    generationError: str = ""
+    indexPresent: bool = True
     publisher: str = ""
     publisherKnown: bool = True
     docSourceURL: str = ""

--- a/scripts/ci/community-package/resourcedocsgen.py
+++ b/scripts/ci/community-package/resourcedocsgen.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 BINARY = Path(os.environ.get("RESOURCEDOCSGEN") or "tools/resourcedocsgen/resourcedocsgen")
@@ -12,9 +13,16 @@ def ensure_built() -> None:
         subprocess.run(["go", "build", "-C", "tools/resourcedocsgen"], check=True)
 
 
-def generate_metadata(slug: str, schema_file: str, tag: str, into: Path | None = None) -> bool:
+def generate_metadata(slug: str, schema_file: str, tag: str, into: Path | None = None) -> tuple[bool, str]:
     args = [str(BINARY), "metadata", "from-github",
             "--repoSlug", slug, "--schemaFile", schema_file, "--version", tag]
     if into is not None:
         args += ["--metadataDir", str(into / "data"), "--packageDocsDir", str(into / "content")]
-    return subprocess.run(args, capture_output=True, text=True).returncode == 0
+    run = subprocess.run(args, capture_output=True, text=True)
+    if run.returncode == 0:
+        return True, ""
+    output = ((run.stderr or "") + (run.stdout or "")).strip()
+    print(f"::group::docs generate FAILED, resourcedocsgen metadata from-github {slug}@{tag}", file=sys.stderr)
+    print(output, file=sys.stderr)
+    print("::endgroup::", file=sys.stderr)
+    return False, output[-600:]

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -238,10 +238,12 @@ class ReportTargetTests(unittest.TestCase):
 
 def _manifest(green: bool = True, warnings: bool = False, findings: list[DocFinding] | None = None,
               installs: list[InstallResult] | None = None, docs: list[DocFile] | None = None,
-              publisher: str = "", publisherKnown: bool = True) -> Manifest:
+              publisher: str = "", publisherKnown: bool = True, generation: bool = True,
+              generationError: str = "", indexPresent: bool = True) -> Manifest:
     return Manifest("x/pulumi-demo", "s.json", "demo", Version("v1.0.0", "0" * 40), "x",
-                    installs or [], findings or [], green=green, warnings=warnings, docs=docs or [],
-                    publisher=publisher, publisherKnown=publisherKnown)
+                    installs or [], findings or [], green=green, warnings=warnings,
+                    generation=generation, docs=docs or [], generationError=generationError,
+                    indexPresent=indexPresent, publisher=publisher, publisherKnown=publisherKnown)
 
 
 class FactSheetTests(unittest.TestCase):
@@ -259,12 +261,12 @@ class FactSheetTests(unittest.TestCase):
         out = fact_sheet.render(_manifest(warnings=True, publisher="Aten Security", publisherKnown=False))
         self.assertIn("publisher listed", out)
         self.assertIn("⚠️", out)
-        self.assertIn("not in `publisher-names.json`", out)
+        self.assertIn("no entry for `Aten Security`", out)
 
     def test_known_publisher_shows_row_without_warning_note(self) -> None:
         out = fact_sheet.render(_manifest(publisher="Aten Security", publisherKnown=True))
         self.assertIn("publisher listed", out)
-        self.assertNotIn("not in `publisher-names.json`", out)
+        self.assertNotIn("no entry for", out)
 
     def test_red_render_with_install_failure(self) -> None:
         out = fact_sheet.render(_manifest(
@@ -276,6 +278,22 @@ class FactSheetTests(unittest.TestCase):
         self.assertIn("pip download x==1", out)
         self.assertIn("No matching distribution", out)
         self.assertIn("<details>", out)
+
+    def test_generation_failure_shows_the_generator_output(self) -> None:
+        out = fact_sheet.render(_manifest(
+            green=False, generation=False,
+            generationError="finding remote file at .../docs/_index.md: 404 Not Found"))
+        self.assertIn("docs generate failed", out)
+        self.assertIn("404 Not Found", out)
+
+    def test_generation_failure_without_output_adds_no_empty_block(self) -> None:
+        out = fact_sheet.render(_manifest(green=False, generation=False))
+        self.assertNotIn("docs generate failed", out)
+
+    def test_missing_index_is_reported_instead_of_a_clean_doc_lint(self) -> None:
+        out = fact_sheet.render(_manifest(green=False, generation=False, indexPresent=False))
+        self.assertIn("no `docs/_index.md`", out)
+        self.assertNotIn("Doc-lint** ✅ clean", out)
 
     def test_doc_fence_outgrows_backticks(self) -> None:
         self.assertEqual(fact_sheet._fence_longer_than_any_run_in("no ticks"), "```")
@@ -387,7 +405,7 @@ class VerifyPackageYamlTests(unittest.TestCase):
     def test_sheet_renders_without_a_commit(self) -> None:
         manifest = self._verify({"name": "stripe", "publisher": "stripe", "version": "0.4.0"}, publishers={})
         sheet = fact_sheet.render(manifest)
-        self.assertIn("not in `publisher-names.json`", sheet)
+        self.assertIn("no entry for `stripe`", sheet)
         self.assertNotIn("/commit/", sheet)
 
 

--- a/scripts/ci/community-package/verify_entry.py
+++ b/scripts/ci/community-package/verify_entry.py
@@ -74,7 +74,8 @@ def verify(entry: Entry) -> Manifest:
     docs = [d for d in (index, install_doc) if d is not None]
 
     with tempfile.TemporaryDirectory() as scratch:
-        generated = resourcedocsgen.generate_metadata(entry.repoSlug, entry.schemaFile, tag, into=Path(scratch))
+        generated, generation_error = resourcedocsgen.generate_metadata(
+            entry.repoSlug, entry.schemaFile, tag, into=Path(scratch))
 
     installs = sdk_install_probe.probe_installs(name, tag, schema)
     findings = doc_lint.find_issues(index.content if index else "")
@@ -96,6 +97,8 @@ def verify(entry: Entry) -> Manifest:
         warnings=warnings,
         generation=generated,
         docs=docs,
+        generationError=generation_error,
+        indexPresent=index is not None,
         publisher=publisher,
         publisherKnown=publisher_known,
     )


### PR DESCRIPTION
The fact-sheet showed `docs generate ❌` and nothing else. The generator's output
was captured and thrown away, so neither the sheet nor the workflow log said what
went wrong. It is now kept and shown in a `<details>` block.

The sheet also said "Doc-lint ✅ clean" when the provider repo has no
`docs/_index.md` at all, because an empty file lints clean. It now names the
missing file.

The publisher message said `shirasakaren` "is not in publisher-names.json" on a PR
that had just added that string to the file, as a value. It now says what the file
maps: a schema's `publisher` string (the key) to that publisher's registry slug
(the value).

All three show on https://github.com/pulumi/registry/pull/12144.

## Test plan

1. Automated tests
   - `test_community_package.py`: generator output reaches the sheet, empty output
     adds no block, a missing index replaces the clean doc-lint line
2. Manual checks
   - Ran the generator against `shirasakaren/pulumi-biznetgio@v0.1.2` and got the
     404 on `docs/_index.md` that the sheet now prints

