### PR TITLE
[registry] Run the community package check without an approval click

### DIFF
--- a/.github/workflows/community-package-check-command.yml
+++ b/.github/workflows/community-package-check-command.yml
@@ -1,6 +1,6 @@
-# Handles a `/check` comment by re-triggering the check workflow against current upstream.
+# Handles a `/check` comment by dispatching the check workflow against current upstream.
 # This job runs with the base repo's permissions, so it must never check out or run the PR's
-# code; it only kicks off the rerun. Allowed for the PR author or a maintainer, with a cooldown.
+# code; it only starts the check. Allowed for the PR author or a maintainer, with a cooldown.
 name: Community package /check command
 
 on:
@@ -17,21 +17,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  rerun:
+  dispatch:
     if: >-
       github.event.issue.pull_request != null &&
-      (github.event.comment.body == '/check' || startsWith(github.event.comment.body, '/check '))
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '/check')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - name: Authorize, rate-limit, rerun
+      - name: Authorize, rate-limit, dispatch
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PR: ${{ github.event.issue.number }}
           ASSOC: ${{ github.event.comment.author_association }}
           COMMENTER: ${{ github.event.comment.user.login }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
           COOLDOWN_MINUTES: "10"
         run: python3 scripts/ci/community-package/cli.py check-command

--- a/.github/workflows/community-package-check.yml
+++ b/.github/workflows/community-package-check.yml
@@ -8,12 +8,28 @@ on:
   pull_request:
     paths:
       - community-packages/package-list.json
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: The pull request to check
+        required: true
+      head:
+        description: >-
+          The head commit of that pull request, abbreviated to 12 characters. It only names the
+          run, and the sweep matches that name to avoid dispatching the same check twice, so it
+          has to stay exactly what github_api.dispatch_run_label builds.
+        required: true
+
+run-name: >-
+  ${{ inputs.pr && format('Community package check · PR #{0} · {1}', inputs.pr, inputs.head)
+  || 'Community package check' }}
 
 permissions:
   contents: read
+  pull-requests: read  # the dispatched run reads the PR's package list over the API
 
 concurrency:
-  group: community-check-${{ github.event.pull_request.number }}
+  group: community-check-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 jobs:
@@ -47,12 +63,33 @@ jobs:
           echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
 
       - name: Record the PR number so the reporter posts to the right PR
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+        env:
+          PR: ${{ github.event.pull_request.number || inputs.pr }}
+        run: echo "$PR" > pr-number.txt
+
+      - name: Fetch the pull request's package list
+        if: inputs.pr
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ inputs.pr }}
+        run: |
+          python3 scripts/ci/community-package/cli.py fetch-pr --pr "$PR" \
+            --changed-files pr-changed-files.txt
 
       - name: Verify the added entry and write the fact-sheet
         env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/ci/community-package/cli.py check --diff "origin/${{ github.base_ref }}"
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || inputs.head }}
+          REPO: ${{ github.repository }}
+          PR: ${{ inputs.pr }}
+          BASE_REF: ${{ github.base_ref || github.event.repository.default_branch }}
+        run: |
+          if [ -n "$PR" ]; then
+            python3 scripts/ci/community-package/cli.py check --diff "origin/$BASE_REF" \
+              --changed-files pr-changed-files.txt
+          else
+            python3 scripts/ci/community-package/cli.py check --diff "origin/$BASE_REF"
+          fi
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/community-package-sweep.yml
+++ b/.github/workflows/community-package-sweep.yml
@@ -1,0 +1,32 @@
+# Dispatches the check workflow for community package PRs whose own check GitHub refused to
+# start. This job only dispatches: it never runs a contributor's code, and it holds no secrets.
+# community-package-policy.yml fails CI if a secret is added here.
+name: Community package check sweep
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: community-check-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Dispatch a check for every unchecked community package PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python3 scripts/ci/community-package/cli.py sweep

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -531,7 +531,8 @@ All workflow files live in `.github/workflows/`.
 | `check-links.yml` | Scheduled jobs: Check links | Every Monday 3:00 PM UTC |
 | `run-browser-tests.yml` | Scheduled jobs: Run browser tests | Daily 2:00 PM UTC |
 | `generate-package-metadata.yml` | Check for Community Package Updates | Daily 5:30 AM + 5:30 PM UTC + push to `master` touching `package-list.json` |
-| `community-package-check.yml` | Community package check | PR touching `community-packages/package-list.json` |
+| `community-package-check.yml` | Community package check | PR touching `community-packages/package-list.json`, or a `workflow_dispatch` naming a PR |
+| `community-package-sweep.yml` | Community package check sweep | Every 15 minutes |
 | `community-package-report.yml` | Community package report | `workflow_run` after the check completes |
 | `community-package-check-command.yml` | Community package /check command | `/check` comment on a package PR |
 | `community-package-preview-command.yml` | Community package /preview command | `/preview` comment on a package PR |
@@ -736,7 +737,8 @@ The check pipeline gives a contributor who adds one entry to `community-packages
 
 - **`community-package-check.yml`** (secret-free, runs on forks): for each added entry, reads the package's schema and docs at its latest GitHub release, then probes without executing the package's code — installs the plugin (blocking), resolves the npm/PyPI/Go SDKs and lints the docs (advisory). Writes a fact-sheet artifact. The plugin install is the only blocking check, alongside successful docs generation and a present `docs/_index.md`.
 - **`community-package-report.yml`** (`workflow_run`, write token, no secrets, no contributor code): downloads the fact-sheet artifact and posts it as a sticky PR comment, keyed to the PR number recorded by the check.
-- **`community-package-check-command.yml`** (`issue_comment`): re-runs the check when the author or a maintainer comments `/check`, authorized and rate-limited.
+- **`community-package-check-command.yml`** (`issue_comment`): dispatches a fresh check run when the author or a maintainer comments `/check` on its own line, authorized and rate-limited. It dispatches rather than re-runs, so the check also reaches a PR whose own run GitHub parked.
+- **`community-package-sweep.yml`** (schedule, every 15 minutes): a fork PR from a first-time contributor parks its `pull_request` run in `action_required` until a maintainer approves it, which leaves the contributor with no fact-sheet and nothing for `/check` to re-run. The sweep dispatches a check for any open package-list PR whose run GitHub refused to start, once per head commit. A dispatched run starts in the base repo, so GitHub does not gate it, and it carries the same permissions and produces the same fact-sheet as the gated one. The sweep only dispatches: it never runs a contributor's code.
 - **`community-package-preview-command.yml`** (`issue_comment`): builds an on-demand site preview when a maintainer comments `/preview`. A fork's own `pull_request` build gets no secrets, so this maintainer-triggered run stands in for it: it materializes the fork's entry as data and reuses the `build-and-deploy-preview` action, never running the fork's code.
 - **`community-package-policy.yml`**: runs the toolchain's unit tests and `mypy --strict`, including the plane-separation test, as a required check.
 

--- a/scripts/ci/community-package/cli.py
+++ b/scripts/ci/community-package/cli.py
@@ -2,6 +2,8 @@
 """Command-line entry point for the community package tooling. Each subcommand is one CI step:
 
     check           verify the added entry and write a fact-sheet (runs on the PR)
+    fetch-pr        bring a dispatched PR's package list into the tree, before the token-free check
+    sweep           dispatch a check for PRs whose own check GitHub would not start
     check-publish   verify the packages a publish PR writes (runs on every publish path)
     preview         materialize a fork PR's entry so its site preview can be built
     report          post the fact-sheet as a sticky PR comment
@@ -45,10 +47,11 @@ def _files_outside_allowlist(changed: list[str]) -> list[str]:
     return [f for f in changed if f and f not in ALLOWED_PATHS]
 
 
-def _offending_files(base_ref: str) -> list[str]:
-    changed = subprocess.run(["git", "diff", "--name-only", f"{base_ref}...HEAD"],
-                             capture_output=True, text=True).stdout
-    return _files_outside_allowlist(changed.splitlines())
+def _changed_files(base_ref: str, listed_in: str | None) -> list[str]:
+    if listed_in:
+        return Path(listed_in).read_text().splitlines()
+    return subprocess.run(["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+                          capture_output=True, text=True).stdout.splitlines()
 
 
 def _rejection_sheet(offending: list[str]) -> str:
@@ -75,7 +78,7 @@ def _write_sheet(out: Path, name: str, sheet: str) -> None:
 
 def run_check(args: argparse.Namespace) -> int:
     out = Path(args.out)
-    offending = _offending_files(args.diff)
+    offending = _files_outside_allowlist(_changed_files(args.diff, args.changed_files))
     if offending:
         _write_sheet(out, "000.factsheet.md", _rejection_sheet(offending))
         return 1
@@ -111,6 +114,14 @@ def run_preview(args: argparse.Namespace) -> int:
             print(f"no published release for {entry.repoSlug}; skipping its preview metadata")
             continue
         resourcedocsgen.generate_metadata(entry.repoSlug, entry.schemaFile, tag)
+    return 0
+
+
+def run_fetch_pr(args: argparse.Namespace) -> int:
+    pull = github_api.pull_request(args.pr)
+    head = github_api.file_content_at(github_api.repo(), str(package_list.PATH), str(pull["head"]["sha"]))
+    package_list.PATH.write_text(head)
+    Path(args.changed_files).write_text("\n".join(github_api.pull_request_files(args.pr)) + "\n")
     return 0
 
 
@@ -155,8 +166,14 @@ def main(argv: list[str]) -> int:
 
     check = sub.add_parser("check")
     check.add_argument("--diff", metavar="BASEREF", required=True)
+    check.add_argument("--changed-files", metavar="PATH")
     check.add_argument("--out", default=".")
     check.set_defaults(run=run_check)
+
+    fetch_pr = sub.add_parser("fetch-pr")
+    fetch_pr.add_argument("--pr", type=int, required=True)
+    fetch_pr.add_argument("--changed-files", metavar="PATH", required=True)
+    fetch_pr.set_defaults(run=run_fetch_pr)
 
     check_publish = sub.add_parser("check-publish")
     check_publish.add_argument("--diff", metavar="BASEREF", required=True)
@@ -168,6 +185,7 @@ def main(argv: list[str]) -> int:
     preview.set_defaults(run=run_preview)
 
     sub.add_parser("report").set_defaults(run=lambda _: comment_commands.report())
+    sub.add_parser("sweep").set_defaults(run=lambda _: comment_commands.sweep())
     sub.add_parser("check-command").set_defaults(run=lambda _: comment_commands.check_command())
     sub.add_parser("preview-command").set_defaults(run=lambda _: comment_commands.preview_command())
     sub.add_parser("preview-failed").set_defaults(run=lambda _: comment_commands.preview_failed())

--- a/scripts/ci/community-package/comment_commands.py
+++ b/scripts/ci/community-package/comment_commands.py
@@ -12,8 +12,31 @@ def _authorized(mode: str, commenter: str, author: str, association: str) -> boo
     return association in ("OWNER", "MEMBER", "COLLABORATOR")
 
 
-def _within_cooldown(pr: int, comment_id: str, sha: str, check_name: str, cooldown: int) -> bool:
-    elapsed = github_api.minutes_since_check_run(sha, check_name)
+CHECK_WORKFLOW = "community-package-check.yml"
+PACKAGE_LIST = "community-packages/package-list.json"
+
+
+def _invokes(body: str, command: str) -> bool:
+    fenced = False
+    for raw in body.splitlines():
+        line = raw.strip()
+        if line.startswith("```"):
+            fenced = not fenced
+        elif not fenced and not line.startswith(">"):
+            if line == command or line.startswith(command + " "):
+                return True
+    return False
+
+
+def _minutes_since_last_check(pr: int, sha: str) -> int | None:
+    elapsed = [minutes for minutes in (github_api.minutes_since_check_run(sha, r"^check$"),
+                                       github_api.minutes_since_dispatch(CHECK_WORKFLOW, pr))
+               if minutes is not None]
+    return min(elapsed) if elapsed else None
+
+
+def _within_cooldown(pr: int, comment_id: str, sha: str, cooldown: int) -> bool:
+    elapsed = _minutes_since_last_check(pr, sha)
     if elapsed is not None and elapsed < cooldown:
         github_api.add_reaction(comment_id, "eyes")
         github_api.post_comment(pr, f"⏳ Rate limited. Last ran {elapsed} min ago; "
@@ -26,21 +49,17 @@ def check_command() -> int:
     pr, comment_id = int(os.environ["PR"]), os.environ["COMMENT_ID"]
     commenter, association = os.environ["COMMENTER"], os.environ["ASSOC"]
     cooldown = int(os.environ.get("COOLDOWN_MINUTES", "10"))
+    if not _invokes(os.environ.get("COMMENT_BODY", ""), "/check"):
+        return 0
     author, sha = github_api.pull_request_head(pr)
 
     if not _authorized("author-or-maintainer", commenter, author, association):
         github_api.add_reaction(comment_id, "-1")
         return 0
-    if _within_cooldown(pr, comment_id, sha, r"^check$", cooldown):
+    if _within_cooldown(pr, comment_id, sha, cooldown):
         return 0
 
-    run_id = github_api.latest_check_workflow_run("community-package-check.yml", sha)
-    if run_id is None:
-        github_api.add_reaction(comment_id, "confused")
-        github_api.post_comment(pr, f"No check run found for `{sha[:12]}`. Push any commit to trigger one.")
-        return 0
-
-    github_api.rerun_workflow(run_id)
+    github_api.dispatch_check(CHECK_WORKFLOW, pr, sha)
     github_api.add_reaction(comment_id, "+1")
     sticky = github_api.fact_sheet_comment(pr)
     if sticky:
@@ -48,6 +67,30 @@ def check_command() -> int:
                                     f"The [fact-sheet]({sticky['html_url']}) updates in place when it finishes.")
     else:
         github_api.post_comment(pr, f"🔁 Checking `{sha[:12]}`. A fact-sheet comment appears when it finishes.")
+    return 0
+
+
+def _github_started_the_check(status: str | None) -> bool:
+    return status is not None and status != "action_required"
+
+
+def sweep() -> int:
+    """Dispatch a check for every community package PR whose own check GitHub would not start.
+
+    A fork PR from a first-time contributor leaves its `pull_request` run in `action_required`
+    until a maintainer approves it. A `workflow_dispatch` run is not gated, holds no more
+    privilege than the gated one, and produces the same fact-sheet.
+    """
+    for pull in github_api.open_pull_requests():
+        pr, sha = int(pull["number"]), str(pull["head"]["sha"])
+        if PACKAGE_LIST not in github_api.pull_request_files(pr):
+            continue
+        if _github_started_the_check(github_api.pull_request_run_status(CHECK_WORKFLOW, sha)):
+            continue
+        if github_api.dispatch_exists(CHECK_WORKFLOW, github_api.dispatch_run_label(pr, sha)):
+            continue
+        github_api.dispatch_check(CHECK_WORKFLOW, pr, sha)
+        print(f"dispatched a check for PR #{pr} at {sha[:12]}")
     return 0
 
 

--- a/scripts/ci/community-package/github_api.py
+++ b/scripts/ci/community-package/github_api.py
@@ -101,21 +101,86 @@ def fact_sheet_comment(pr: int) -> dict[str, Any] | None:
     return None
 
 
+def _minutes_since(timestamp: str) -> int:
+    moment = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    return int((datetime.now(timezone.utc) - moment).total_seconds() // 60)
+
+
 def minutes_since_check_run(sha: str, name_pattern: str) -> int | None:
     runs = [r for r in request(f"/repos/{repo()}/commits/{sha}/check-runs")["check_runs"]
             if re.search(name_pattern, r["name"])]
     if not runs:
         return None
-    most_recent = max(runs, key=lambda r: str(r["started_at"]))["started_at"]
-    started = datetime.strptime(most_recent, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-    return int((datetime.now(timezone.utc) - started).total_seconds() // 60)
+    return _minutes_since(str(max(runs, key=lambda r: str(r["started_at"]))["started_at"]))
 
 
-def latest_check_workflow_run(workflow_file: str, sha: str) -> int | None:
+def pull_request_files(pr: int) -> list[str]:
+    # The allowlist gate reads this list, so a truncated first page would let unlisted files
+    # through unseen. Walk every page.
+    names: list[str] = []
+    page = 1
+    while True:
+        batch = request(f"/repos/{repo()}/pulls/{pr}/files?per_page=100&page={page}")
+        names += [str(f["filename"]) for f in batch]
+        if len(batch) < 100:
+            return names
+        page += 1
+
+
+def _short(sha: str) -> str:
+    return sha[:12]
+
+
+def dispatch_run_label(pr: int, sha: str) -> str:
+    return f"Community package check · PR #{pr} · {_short(sha)}"
+
+
+def dispatch_check(workflow_file: str, pr: int, sha: str) -> None:
+    """Dispatch a check named exactly `dispatch_run_label`, which is the sweep's dedupe key.
+
+    The workflow interpolates the `head` input into its `run-name`, so the input has to carry
+    the same short sha the label does; otherwise no run ever matches and the sweep dispatches
+    the same check again on every pass.
+    """
+    dispatch_workflow(workflow_file, {"pr": str(pr), "head": _short(sha)})
+
+
+def _dispatched_runs(workflow_file: str) -> list[dict[str, Any]]:
+    return list(request(f"/repos/{repo()}/actions/workflows/{workflow_file}/runs"
+                        f"?event=workflow_dispatch&per_page=100")["workflow_runs"])
+
+
+def _run_title(run: dict[str, Any]) -> str:
+    # `name` is the workflow's own name; an evaluated `run-name:` arrives as `display_title`.
+    return str(run.get("display_title") or run.get("name") or "")
+
+
+def dispatch_exists(workflow_file: str, label: str) -> bool:
+    return any(_run_title(run) == label for run in _dispatched_runs(workflow_file))
+
+
+def minutes_since_dispatch(workflow_file: str, pr: int) -> int | None:
+    mine = [r for r in _dispatched_runs(workflow_file) if f"PR #{pr} ·" in _run_title(r)]
+    if not mine:
+        return None
+    return _minutes_since(str(max(mine, key=lambda r: str(r["created_at"]))["created_at"]))
+
+
+def pull_request_run_status(workflow_file: str, sha: str) -> str | None:
+    """The run's live status, or its conclusion once it has one.
+
+    An approval-gated run surfaces either as `status: action_required` or, once GitHub closes
+    it out, as `status: completed` with `conclusion: action_required`. The sweep has to see
+    both, or it skips forever exactly the PRs it exists to unblock.
+    """
     runs = request(f"/repos/{repo()}/actions/workflows/{workflow_file}/runs"
                    f"?event=pull_request&head_sha={sha}")["workflow_runs"]
-    return int(runs[0]["id"]) if runs else None
+    if not runs:
+        return None
+    return str(runs[0].get("conclusion") or runs[0]["status"])
 
 
-def rerun_workflow(run_id: int) -> None:
-    request(f"/repos/{repo()}/actions/runs/{run_id}/rerun", "POST")
+def dispatch_workflow(workflow_file: str, inputs: dict[str, str]) -> None:
+    ref = os.environ.get("DEFAULT_BRANCH") or "master"
+    request(f"/repos/{repo()}/actions/workflows/{workflow_file}/dispatches", "POST",
+            {"ref": ref, "inputs": inputs})

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).parent))
 import cli  # noqa: E402
 import comment_commands  # noqa: E402
@@ -341,6 +343,169 @@ class FactSheetTests(unittest.TestCase):
         self.assertNotIn("docs generate", out)
 
 
+class SweepTests(unittest.TestCase):
+    def _sweep(self, status: str | None, files: list[str] | None = None,
+               already: bool = False) -> list[tuple[str, dict[str, str]]]:
+        dispatched: list[tuple[str, dict[str, str]]] = []
+        with patch.object(github_api, "open_pull_requests",
+                          lambda: [{"number": 7, "head": {"sha": "a" * 40}}]), \
+             patch.object(github_api, "pull_request_files",
+                          lambda pr: files if files is not None else [comment_commands.PACKAGE_LIST]), \
+             patch.object(github_api, "pull_request_run_status", lambda w, s: status), \
+             patch.object(github_api, "dispatch_exists", lambda w, label: already), \
+             patch.object(github_api, "dispatch_workflow",
+                          lambda w, inputs: dispatched.append((w, inputs))):
+            comment_commands.sweep()
+        return dispatched
+
+    def test_dispatches_when_github_parked_the_run(self) -> None:
+        self.assertEqual(self._sweep("action_required"),
+                         [(comment_commands.CHECK_WORKFLOW, {"pr": "7", "head": "a" * 12})])
+
+    def test_dispatches_when_no_run_exists(self) -> None:
+        self.assertEqual(len(self._sweep(None)), 1)
+
+    def test_skips_a_run_that_started_on_its_own(self) -> None:
+        self.assertEqual(self._sweep("in_progress"), [])
+        self.assertEqual(self._sweep("completed"), [])
+
+    def test_skips_a_pr_that_does_not_touch_the_package_list(self) -> None:
+        self.assertEqual(self._sweep("action_required", files=["README.md"]), [])
+
+    def test_dispatches_each_head_once(self) -> None:
+        self.assertEqual(self._sweep("action_required", already=True), [])
+
+    def test_run_label_is_stable_per_head(self) -> None:
+        self.assertEqual(github_api.dispatch_run_label(7, "a" * 40),
+                         "Community package check · PR #7 · " + "a" * 12)
+
+
+class DispatchLabelTests(unittest.TestCase):
+    """The run name is the only dedupe key the sweep has, so the two halves must agree."""
+
+    def _dispatched(self) -> dict[str, str]:
+        sent: list[dict[str, str]] = []
+        with patch.object(github_api, "dispatch_workflow", lambda w, inputs: sent.append(inputs)):
+            github_api.dispatch_check("w.yml", 7, "a" * 40)
+        return sent[0]
+
+    def test_the_dispatched_head_reproduces_the_label(self) -> None:
+        inputs = self._dispatched()
+        run_name = f"Community package check · PR #{inputs['pr']} · {inputs['head']}"
+        self.assertEqual(run_name, github_api.dispatch_run_label(7, "a" * 40))
+
+    def test_a_run_is_matched_by_its_display_title(self) -> None:
+        label = github_api.dispatch_run_label(7, "a" * 40)
+        runs = [{"name": "Community package check", "display_title": label,
+                 "created_at": "2020-01-01T00:00:00Z"}]
+        with patch.object(github_api, "_dispatched_runs", lambda w: runs):
+            self.assertTrue(github_api.dispatch_exists("w.yml", label))
+            self.assertIsNotNone(github_api.minutes_since_dispatch("w.yml", 7))
+
+    def test_a_run_for_another_pr_is_not_matched(self) -> None:
+        runs = [{"display_title": github_api.dispatch_run_label(8, "a" * 40)}]
+        with patch.object(github_api, "_dispatched_runs", lambda w: runs):
+            self.assertFalse(github_api.dispatch_exists("w.yml", github_api.dispatch_run_label(7, "a" * 40)))
+            self.assertIsNone(github_api.minutes_since_dispatch("w.yml", 7))
+
+
+class WorkflowRunStatusTests(unittest.TestCase):
+    def _status(self, run: dict[str, Any] | None) -> str | None:
+        with patch.object(github_api, "repo", lambda: "x/y"), \
+             patch.object(github_api, "request", lambda p: {"workflow_runs": [run] if run else []}):
+            return github_api.pull_request_run_status("w.yml", "a" * 40)
+
+    def test_a_parked_run_is_reported_from_its_status(self) -> None:
+        self.assertEqual(self._status({"status": "action_required"}), "action_required")
+
+    def test_a_parked_run_is_reported_from_its_conclusion(self) -> None:
+        self.assertEqual(self._status({"status": "completed", "conclusion": "action_required"}),
+                         "action_required")
+
+    def test_a_running_check_is_not_parked(self) -> None:
+        self.assertEqual(self._status({"status": "in_progress", "conclusion": None}), "in_progress")
+
+    def test_no_run_reports_none(self) -> None:
+        self.assertIsNone(self._status(None))
+
+
+class PullRequestFilesTests(unittest.TestCase):
+    def test_every_page_is_read(self) -> None:
+        pages = {1: [{"filename": f"f{i}"} for i in range(100)],
+                 2: [{"filename": "last"}]}
+
+        def fake(path: str) -> list[dict[str, Any]]:
+            return pages[int(path.rsplit("page=", 1)[1])]
+
+        with patch.object(github_api, "repo", lambda: "x/y"), \
+             patch.object(github_api, "request", fake):
+            self.assertEqual(len(github_api.pull_request_files(7)), 101)
+
+
+class CommandInvocationTests(unittest.TestCase):
+    def test_a_bare_command_invokes(self) -> None:
+        self.assertTrue(comment_commands._invokes("/check", "/check"))
+
+    def test_a_command_on_its_own_line_invokes(self) -> None:
+        self.assertTrue(comment_commands._invokes("- [x] SDKs published\n\n/check\n", "/check"))
+
+    def test_arguments_after_the_command_invoke(self) -> None:
+        self.assertTrue(comment_commands._invokes("/check please", "/check"))
+
+    def test_the_fact_sheet_mentioning_the_command_does_not_invoke(self) -> None:
+        self.assertFalse(comment_commands._invokes(
+            "**Not ready.** Fix upstream, then comment `/check` to re-run.", "/check"))
+
+    def test_a_fenced_command_does_not_invoke(self) -> None:
+        self.assertFalse(comment_commands._invokes("Run this:\n```\n/check\n```\n", "/check"))
+
+    def test_a_quoted_command_does_not_invoke(self) -> None:
+        self.assertFalse(comment_commands._invokes("> /check\n\nI already tried that.", "/check"))
+
+
+class CheckCommandTests(unittest.TestCase):
+    def _run(self, minutes_check: int | None, minutes_dispatch: int | None) -> list[dict[str, str]]:
+        dispatched: list[dict[str, str]] = []
+        os.environ.update(PR="7", COMMENT_ID="1", COMMENTER="ren", ASSOC="NONE", COMMENT_BODY="/check")
+        with patch.object(github_api, "pull_request_head", lambda pr: ("ren", "b" * 40)), \
+             patch.object(github_api, "minutes_since_check_run", lambda s, n: minutes_check), \
+             patch.object(github_api, "minutes_since_dispatch", lambda w, pr: minutes_dispatch), \
+             patch.object(github_api, "add_reaction", lambda *a: None), \
+             patch.object(github_api, "post_comment", lambda *a: None), \
+             patch.object(github_api, "fact_sheet_comment", lambda pr: None), \
+             patch.object(github_api, "dispatch_workflow",
+                          lambda w, inputs: dispatched.append(inputs)):
+            comment_commands.check_command()
+        for name in ("PR", "COMMENT_ID", "COMMENTER", "ASSOC", "COMMENT_BODY"):
+            del os.environ[name]
+        return dispatched
+
+    def test_author_dispatches_a_check(self) -> None:
+        self.assertEqual(self._run(None, None), [{"pr": "7", "head": "b" * 12}])
+
+    def test_a_recent_dispatch_rate_limits(self) -> None:
+        self.assertEqual(self._run(None, 2), [])
+
+    def test_a_recent_automatic_run_rate_limits(self) -> None:
+        self.assertEqual(self._run(2, None), [])
+
+    def test_an_old_check_does_not_rate_limit(self) -> None:
+        self.assertEqual(len(self._run(60, 90)), 1)
+
+
+class ChangedFilesTests(unittest.TestCase):
+    def test_a_listing_replaces_the_git_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            listing = Path(scratch) / "changed.txt"
+            listing.write_text("community-packages/package-list.json\nREADME.md\n")
+            self.assertEqual(cli._changed_files("origin/master", str(listing)),
+                             ["community-packages/package-list.json", "README.md"])
+
+
+def _community_workflows() -> list[Path]:
+    return sorted((Path(__file__).resolve().parents[3] / ".github/workflows").glob("community-package-*.yml"))
+
+
 _SECRET = re.compile(r"secrets\.|ESC_ACTION|esc-action|ANTHROPIC_API_KEY|PULUMI_BOT_TOKEN|id-token: *write")
 _RUNS_CODE = re.compile(
     r"cli\.py check(?![-\w])|npm (install|ci)|pip (install|download)|go get|go mod download|pulumi plugin install")
@@ -350,8 +515,17 @@ class SecretCodeSeparationTests(unittest.TestCase):
     """No community-package workflow may both hold a secret and run a contributor's code, or a
     malicious package could read the secret."""
 
+    def test_no_step_holds_a_token_beside_contributor_code(self) -> None:
+        for workflow in _community_workflows():
+            for job in yaml.safe_load(workflow.read_text())["jobs"].values():
+                for step in job.get("steps", []):
+                    if "GITHUB_TOKEN" not in (step.get("env") or {}):
+                        continue
+                    self.assertNotRegex(step.get("run", ""), _RUNS_CODE,
+                                        f"{workflow.name}: step '{step.get('name')}' holds a token and runs code")
+
     def test_no_workflow_mixes_secrets_with_contributor_code(self) -> None:
-        workflows = sorted((Path(__file__).resolve().parents[3] / ".github/workflows").glob("community-package-*.yml"))
+        workflows = _community_workflows()
         self.assertTrue(workflows, "no community-package workflows found")
         for workflow in workflows:
             text, name = workflow.read_text(), workflow.name


### PR DESCRIPTION
A fork PR from a first-time contributor parks its `pull_request` run in
`action_required`, so the contributor sees no fact-sheet and `/check` has nothing
to re-run. Approving by hand was the only way through.

The check workflow now also takes a `workflow_dispatch` with a PR number.
Dispatched runs start in the base repo, so GitHub does not gate them. `/check`
dispatches one instead of re-running the parked run, and a new sweep workflow
dispatches one every 15 minutes for any open PR whose run GitHub refused to start.
The sweep does nothing else, and a dispatched run has the same permissions and
produces the same fact-sheet as the gated one.

A dispatched run is checked out at the default branch, so it needs the PR's package
list fetched over the API. That happens in its own step, which holds the token and
nothing else; the step that probes the advertised SDKs still holds no credentials.
A new test walks every community package workflow and fails if any single step both
holds `GITHUB_TOKEN` and runs a contributor's package.

`/check` also only fired when the entire comment was the command, so a contributor
who ended a longer message with it got nothing. That happened on #12144. It now
fires when the command is alone on any line of the comment, skipping fenced blocks
and quoted lines so the fact-sheet's own "comment `/check` to re-run" does not
trigger it. Bot comments no longer start the job at all.

Note that `workflow_dispatch` only ever runs the copy of a workflow on the default
branch, so this cannot be exercised until it merges.

## Review fixes

The sweep's dedupe key is the dispatched run's name, and two bugs meant it could
never match, which would have re-dispatched a check for every parked PR every 15
minutes forever:

- The label abbreviated the sha to 12 characters while both dispatch sites sent the
  full 40. `github_api.dispatch_check` now builds the inputs and the label from the
  same helper, and a test asserts the dispatched `head` reproduces the label.
- The match read the run's `name`, which is the workflow's name. An evaluated
  `run-name:` arrives as `display_title`, which the match now prefers.

Also:

- `pull_request_files` stopped at the first 100 files. The allowlist gate reads that
  list, so a PR with more than 100 changed files could have slipped unlisted files
  past it. It paginates now.
- A parked run can surface as `status: completed` with `conclusion: action_required`,
  which the sweep read as started and skipped forever. It now folds the conclusion in.
- The dispatched run reads the PR over the API, so the workflow adds
  `pull-requests: read`.
- `BUILD-AND-DEPLOY.md` documents the sweep and the new `/check` behavior.

## Test plan

1. Automated tests
   - `test_community_package.py`: the sweep dispatches for a parked or missing run,
     skips one that started on its own, skips PRs that do not touch the package list,
     and dispatches each head commit once
   - the dispatched `head` input and `dispatch_run_label` agree, a run is matched by
     its `display_title`, and a run for another PR is not
   - a parked run is recognized from either its status or its conclusion
   - `pull_request_files` reads every page
   - `/check` dispatches, and rate-limits on either a recent automatic run or a
     recent dispatch
   - the command fires from its own line, with arguments, and not from prose, a
     fenced block or a quote
   - the step-level token check fails when `GITHUB_TOKEN` is added to the probe step
     (verified by making that edit and watching it fail)
2. Manual checks
   - Replayed the three real comments on
     https://github.com/pulumi/registry/pull/12144 through the parser: the
     fact-sheet does not fire it, and both the checklist ending in `/check` and the
     bare `/check` do
   - After merge, comment `/check` on that PR and confirm a fact-sheet appears with
     no approval click, and that the sweep dispatches at most one run per head
