### PR TITLE
[registry] Give the /preview command its ESC configuration

### DIFF
--- a/.github/workflows/community-package-preview-command.yml
+++ b/.github/workflows/community-package-preview-command.yml
@@ -18,6 +18,12 @@ permissions:
   pull-requests: write
   id-token: write
 
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-registry
+
 concurrency:
   group: community-package-preview-${{ github.event.issue.number || inputs.pr }}
   cancel-in-progress: true

--- a/scripts/ci/pull-request.sh
+++ b/scripts/ci/pull-request.sh
@@ -2,13 +2,15 @@
 
 set -o errexit -o pipefail
 
-# See if we have the requisite credentials. If not, we might be in a fork. In that case,
-# run a PR build, but skip all the deployment stuff.
-if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${PULUMI_ACCESS_TOKEN:-}" ]; then
-    echo "Missing secret tokens, possibly due to a forked PR."
-    echo "Running a build, but will skip the sync to S3 and Pulumi preview."
-    ./scripts/ci/build.sh
-    exit
+missing=()
+for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY PULUMI_ACCESS_TOKEN; do
+    [ -n "${!name:-}" ] || missing+=("${name}")
+done
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "Cannot build a preview: ${missing[*]} not set."
+    echo "The calling workflow needs the ESC_ACTION_* environment variables so that"
+    echo "pulumi/esc-action opens github-secrets/pulumi-registry, and an OIDC role for AWS."
+    exit 1
 fi
 
 aws sts get-caller-identity


### PR DESCRIPTION
`pulumi/esc-action` reads `ESC_ACTION_*` from the environment. Every other workflow
that uses it sets those four variables; the /preview command workflow never did, so
the action installed the Pulumi CLI, opened no environment, and exited green having
exported no secrets. Its log says as much: `input environment or
ESC_ACTION_ENVIRONMENT: undefined`. The build step then ran with an empty
`PULUMI_ACCESS_TOKEN`.

`pull-request.sh` read that as "probably a fork" and called `build.sh` with no mode
argument, which `build.sh` rejects. So the run spent four minutes generating docs
and then died on `Unknown mode, ''`. That branch could not have worked with
any input; it now names the variables that are missing and stops.

Seen on https://github.com/pulumi/registry/actions/runs/32257730466.

## Test plan

1. Automated tests
   - `shellcheck scripts/ci/pull-request.sh` is clean
   - the community package policy tests pass with the workflow now holding ESC
     configuration: it carries a secret but runs no contributor code
2. Manual checks
   - After merge, comment `/preview` on a community package PR and confirm the
     preview URL posts

