### PR TITLE
Fix duplicated "Packages" crumb in registry breadcrumbs

### DIFF
--- a/cypress/e2e/structured-data.cy.js
+++ b/cypress/e2e/structured-data.cy.js
@@ -107,8 +107,10 @@ describe("Registry", () => {
                     expect(crumb, "BreadcrumbList block").to.exist;
                     const names = crumb.itemListElement.map(i => i.name);
                     // Literal equality proves no embedded quote characters.
+                    // The trail mirrors the visible breadcrumb: Registry > Packages > <package>.
                     expect(names[0]).to.equal("Registry");
-                    expect(names[1]).to.equal("AWS");
+                    expect(names[1]).to.equal("Packages");
+                    expect(names[2]).to.equal("AWS");
                 });
             });
         });

--- a/themes/default/layouts/partials/registry/breadcrumb.html
+++ b/themes/default/layouts/partials/registry/breadcrumb.html
@@ -20,7 +20,7 @@
                 {{ else if eq $lastUrlSlug "how-to-guides" }}
                     How-to Guides
                 {{ else if eq $lastUrlSlug "registry" }}
-                    Packages
+                    Registry
                 {{ else }}
                     {{ .p1.LinkTitle }}
                 {{ end }}

--- a/themes/default/layouts/partials/registry/structured-data.html
+++ b/themes/default/layouts/partials/registry/structured-data.html
@@ -70,14 +70,22 @@
 
 {{/* ---------- BreadcrumbList (every registry page) ---------- */}}
 {{ $crumbs := slice (dict "@type" "ListItem" "position" 1 "name" "Registry" "item" (absURL "registry/")) }}
+{{/*
+    Mirrors the visible trail rendered by registry/breadcrumb.html:
+    Registry > Packages > <package> > <section>. The Packages crumb is keyed off
+    the URL rather than $pkg so the /registry/packages/ index gets it too.
+*/}}
+{{ if and (ge $segCount 2) (eq (index $segments 0) "registry") (eq (index $segments 1) "packages") }}
+    {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 2 "name" "Packages" "item" (absURL "registry/packages/")) }}
+{{ end }}
 {{ if $pkg }}
-    {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 2 "name" $pkg.title "item" (printf "%sregistry/packages/%s/" (absURL "") $packageName)) }}
+    {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 3 "name" $pkg.title "item" (printf "%sregistry/packages/%s/" (absURL "") $packageName)) }}
     {{ if or (eq $kind "api-docs-root") (eq $kind "api-docs-leaf") }}
-        {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 3 "name" "API Docs" "item" (printf "%sregistry/packages/%s/api-docs/" (absURL "") $packageName)) }}
+        {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 4 "name" "API Docs" "item" (printf "%sregistry/packages/%s/api-docs/" (absURL "") $packageName)) }}
     {{ else if eq $kind "install" }}
-        {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 3 "name" "Installation & Configuration" "item" (printf "%sregistry/packages/%s/installation-configuration/" (absURL "") $packageName)) }}
+        {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 4 "name" "Installation & Configuration" "item" (printf "%sregistry/packages/%s/installation-configuration/" (absURL "") $packageName)) }}
     {{ else if eq $kind "how-to" }}
-        {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 3 "name" "How-to Guides" "item" (printf "%sregistry/packages/%s/how-to-guides/" (absURL "") $packageName)) }}
+        {{ $crumbs = $crumbs | append (dict "@type" "ListItem" "position" 4 "name" "How-to Guides" "item" (printf "%sregistry/packages/%s/how-to-guides/" (absURL "") $packageName)) }}
     {{ end }}
 {{ end }}
 {{ $breadcrumb := dict "@context" "https://schema.org" "@type" "BreadcrumbList" "itemListElement" $crumbs }}


### PR DESCRIPTION
Every registry package page rendered its breadcrumb as `Packages / Packages / Kubernetes`. The `/registry/` crumb was hardcoded to the literal string "Packages", colliding with the real `/registry/packages/` section page whose own `linktitle` is also "Packages". The root crumb is now labeled "Registry" — the name the JSON-LD BreadcrumbList and the Algolia ancestor mapping in `scripts/search/page.js` already use.

Also syncs the JSON-LD BreadcrumbList, which was missing the Packages level, so the structured data mirrors what's visible on the page.

## Changes

- `registry/breadcrumb.html` — label the `/registry/` crumb "Registry"
- `registry/structured-data.html` — add the Packages crumb to the BreadcrumbList and renumber positions; keyed off the URL rather than the package data so `/registry/packages/` gets it too
- `structured-data.cy.js` — update the BreadcrumbList name assertions

## Verification

| Page | Visible | JSON-LD |
|---|---|---|
| `/registry/packages/` | Registry › Packages | 1:Registry › 2:Packages |
| `/registry/packages/kubernetes/` | + Kubernetes | + 3:Kubernetes |
| `…/installation-configuration/` | + Installation & Configuration | + 4:Installation & Configuration |
| `…/eks/api-docs/` | + API Docs | + 4:API Docs |

`make lint` clean.

Fixes #11874