### PR TITLE
[registry] Post the preview link when /preview built it

### DIFF
--- a/.github/actions/build-and-deploy-preview/action.yml
+++ b/.github/actions/build-and-deploy-preview/action.yml
@@ -55,16 +55,11 @@ runs:
         PR: ${{ inputs.pr }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         REPO: ${{ github.repository }}
-        EVENT_NAME: ${{ github.event_name }}
       run: |
-        # A native pull_request run already keys `make ci-pull-request` to this PR; only the
-        # comment-triggered path (issue_comment / workflow_dispatch) needs the event shimmed.
-        if [ "$EVENT_NAME" != "pull_request" ]; then
-          gh api "repos/$REPO/pulls/$PR" > /tmp/pr.json
-          jq -n --slurpfile pr /tmp/pr.json '{number: $pr[0].number, pull_request: $pr[0]}' > /tmp/pr-event.json
-          echo "GITHUB_EVENT_NAME=pull_request" >> "$GITHUB_ENV"
-          echo "GITHUB_EVENT_PATH=/tmp/pr-event.json" >> "$GITHUB_ENV"
-        fi
+        {
+          echo "PREVIEW_PR=$PR"
+          echo "PREVIEW_HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR" --jq .head.sha)"
+        } >> "$GITHUB_ENV"
         python3 scripts/ci/community-package/cli.py preview --pr "$PR"
 
     - name: Validate JSON file syntax

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -268,7 +268,9 @@ changed_pages_section() {
 
 # Returns the Git SHA of the HEAD commit. For pull requests, we take this from GitHub event metadata, since in that case, the HEAD commit will contain the SHA of the merge commit with the base branch.
 git_sha() {
-    if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; then
+    if [[ -n "${PREVIEW_HEAD_SHA:-}" ]]; then
+        echo "$PREVIEW_HEAD_SHA"
+    elif [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; then
         echo "$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request.head.sha")"
     else
         echo "$(git rev-parse HEAD)"
@@ -300,10 +302,9 @@ origin_bucket_metadata_filepath() {
 build_identifier() {
     local identifier
 
-    # For CI builds, we use the GitHub Actions event to generate more readable identifiers.
-    # - For pull_request actions, return "pr-<number>-<git-sha>"
-    # - For others, return "<event-name>-<git-sha>".
-    if [[ ! -z "$GITHUB_EVENT_NAME" && ! -z "$GITHUB_EVENT_PATH" ]]; then
+    if [[ -n "${PREVIEW_PR:-}" ]]; then
+        identifier="pr-${PREVIEW_PR}-$(git_sha_short)"
+    elif [[ ! -z "$GITHUB_EVENT_NAME" && ! -z "$GITHUB_EVENT_PATH" ]]; then
         identifier="$GITHUB_EVENT_NAME"
 
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then

--- a/scripts/ci/sync.sh
+++ b/scripts/ci/sync.sh
@@ -161,19 +161,25 @@ PREVIEW_COMMENT_MARKER="<!-- registry-preview-link -->"
 
 # Posts (or updates) the pinned preview comment on the PR.
 post_preview_comment() {
-    if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" || -z "${GITHUB_TOKEN:-}" ]]; then
-        log "No GitHub event or token available; skipping the preview comment."
+    if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+        log "No GitHub token available; skipping the preview comment."
         return 0
     fi
 
     local event pr_comment_api_url repo_api_url pr_number
-    event="$(cat "$GITHUB_EVENT_PATH")"
-    pr_comment_api_url="$(echo "$event" | jq -r '.pull_request._links.comments.href // empty')"
-    repo_api_url="$(echo "$event" | jq -r '.pull_request.base.repo.url // empty')"
-    pr_number="$(echo "$event" | jq -r '.number // empty')"
+    if [[ -n "${PREVIEW_PR:-}" ]]; then
+        pr_number="$PREVIEW_PR"
+        repo_api_url="${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}"
+        pr_comment_api_url="${repo_api_url}/issues/${pr_number}/comments"
+    elif [[ -n "${GITHUB_EVENT_PATH:-}" && -f "${GITHUB_EVENT_PATH}" ]]; then
+        event="$(cat "$GITHUB_EVENT_PATH")"
+        pr_comment_api_url="$(echo "$event" | jq -r '.pull_request._links.comments.href // empty')"
+        repo_api_url="$(echo "$event" | jq -r '.pull_request.base.repo.url // empty')"
+        pr_number="$(echo "$event" | jq -r '.number // empty')"
+    fi
 
     if [[ -z "$pr_comment_api_url" || -z "$repo_api_url" || -z "$pr_number" ]]; then
-        log "Event payload is missing pull request details; skipping the preview comment."
+        log "No pull request to comment on; skipping the preview comment."
         return 0
     fi
 

--- a/scripts/ci/test-preview-comment.sh
+++ b/scripts/ci/test-preview-comment.sh
@@ -236,6 +236,25 @@ expect "an API error payload falls back to creating a comment" \
 
 unset -f curl
 
+echo "== preview identity =="
+
+expect "an explicit preview PR names the bucket after it" \
+    "pr-12144-abcdef12" \
+    "$(PREVIEW_PR=12144 PREVIEW_HEAD_SHA=abcdef1234567890 build_identifier)"
+
+expect "an explicit head sha wins over the checked-out commit" \
+    "abcdef1234567890" \
+    "$(PREVIEW_HEAD_SHA=abcdef1234567890 git_sha)"
+
+pr_event_file="$(mktemp)"
+echo '{"pull_request": {"head": {"sha": "0123456789abcdef"}}}' > "$pr_event_file"
+
+expect "without one, a pull_request event still decides the sha" \
+    "0123456789abcdef" \
+    "$(GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH="$pr_event_file" git_sha)"
+
+rm -f "$pr_event_file"
+
 echo
 if [[ "$failures" -gt 0 ]]; then
     echo "${failures} test(s) failed."


### PR DESCRIPTION
A `/preview` run builds and deploys, then posts nothing. The build is fine; the
comment is skipped with `Event payload is missing pull request details`, because
`sync.sh` reads the PR out of `GITHUB_EVENT_PATH` and an `issue_comment` payload
has `.issue.number`, not `.number`.

The preview action tried to cover that by writing `GITHUB_EVENT_NAME` and
`GITHUB_EVENT_PATH` to `$GITHUB_ENV`. Those are runner-provided variables and the
runner re-injects them for every step, so neither took effect. The bucket for
https://github.com/pulumi/registry/actions/runs/32271355918 came out
`registry--origin-issue-comment-15e541a1`, which is `build_identifier` reading the
unshimmed event name.

It now passes `PREVIEW_PR` and `PREVIEW_HEAD_SHA` instead, which nothing re-injects.
`sync.sh` uses them to address the comment, and `git_sha` returns the PR head rather
than whatever master pointed at.

That second part also fixes cleanup. `pull-request-closed.sh` deletes preview buckets
by looking up each PR commit, and a comment-triggered preview registered its bucket
under a master commit, so no PR commit ever matched and the bucket stayed. Its name
now matches the native path too: `pr-12144-<sha>` rather than `issue-comment-<sha>`.

## Test plan

1. Automated tests
   - `scripts/ci/test-preview-comment.sh`: an explicit preview PR names the bucket,
     an explicit head sha wins over the checked-out commit, and a `pull_request`
     event still decides the sha without one
   - `shellcheck` reports nothing new on the three changed scripts
2. Manual checks
   - After merge, comment `/preview` on
     https://github.com/pulumi/registry/pull/12144 and confirm the link posts. The
     current run is finished and live at
     http://registry--origin-issue-comment-15e541a1.s3-website.us-west-2.amazonaws.com/registry/packages/biznetgio/

