### PR TITLE
[registry] Drop the OIDC dependency from the publish check

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -170,16 +170,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@3af4859af8a73a362fb599b944124097d4bb80c5 # v3
       - name: Check out branch
         uses: actions/checkout@v7
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - run: uv run --with requests,pyyaml scripts/ci/push-registry.py --dry-run
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+      - run: uv run --with pyyaml scripts/ci/publish_to_registry.py --validate-all
 
   test-provider-api-docs:
     name: Test Provider API Docs

--- a/scripts/ci/publish_to_registry.py
+++ b/scripts/ci/publish_to_registry.py
@@ -236,6 +236,21 @@ def publish_with_retry(specs: list[str], config: Config) -> bool:
     return False
 
 
+def validate_all(repo_root: Path) -> int:
+    package_dir = repo_root / "themes/default/data/registry/packages"
+    yaml_files = sorted(str(p.relative_to(repo_root)) for p in package_dir.glob("*.yaml"))
+    specs, errors = build_specs(yaml_files, repo_root)
+
+    print(f"{len(yaml_files)} package YAML files, {len(specs)} publishable specs")
+    if not errors:
+        return 0
+
+    print(f"\n{len(errors)} package(s) could not be turned into a publish spec:")
+    for error in errors:
+        print(f"  - {error}")
+    return 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Publish changed packages to the registry"
@@ -262,7 +277,15 @@ def main() -> int:
         nargs="*",
         help="Package specs to publish (default: detect from git diff)",
     )
+    parser.add_argument(
+        "--validate-all",
+        action="store_true",
+        help="Build a spec for every package YAML and report errors without publishing",
+    )
     args = parser.parse_args()
+
+    if args.validate_all:
+        return validate_all(args.repo_root.resolve())
 
     if not os.environ.get("PULUMI_API_URL"):
         print("Error: PULUMI_API_URL environment variable is required")

--- a/scripts/ci/test_publish_to_registry.py
+++ b/scripts/ci/test_publish_to_registry.py
@@ -15,6 +15,7 @@ from publish_to_registry import (
     get_changed_packages,
     load_publishers,
     publish_with_retry,
+    validate_all,
 )
 
 
@@ -237,6 +238,39 @@ publisher: Pulumi
         self.assertIsNone(result.spec)
         self.assertIsNotNone(result.error)
         self.assertIn("Failed to parse", result.error)
+
+
+class TestValidateAll(unittest.TestCase):
+    def _repo_with_packages(self, scratch: str, names: list[str]) -> Path:
+        repo_root = Path(scratch)
+        package_dir = repo_root / "themes/default/data/registry/packages"
+        package_dir.mkdir(parents=True)
+        for name in names:
+            (package_dir / f"{name}.yaml").write_text("")
+        return repo_root
+
+    @patch("publish_to_registry.build_specs")
+    def test_passes_when_every_package_builds_a_spec(self, mock_build_specs):
+        mock_build_specs.return_value = (["pulumi/pulumi/aws@6.50.0"], [])
+        with tempfile.TemporaryDirectory() as scratch:
+            self.assertEqual(validate_all(self._repo_with_packages(scratch, ["aws"])), 0)
+
+    @patch("publish_to_registry.build_specs")
+    def test_fails_when_a_package_cannot_build_a_spec(self, mock_build_specs):
+        mock_build_specs.return_value = ([], ["broken.yaml: missing version"])
+        with tempfile.TemporaryDirectory() as scratch:
+            self.assertEqual(validate_all(self._repo_with_packages(scratch, ["broken"])), 1)
+
+    @patch("publish_to_registry.build_specs")
+    def test_checks_every_package_yaml_not_just_changed_ones(self, mock_build_specs):
+        mock_build_specs.return_value = ([], [])
+        with tempfile.TemporaryDirectory() as scratch:
+            validate_all(self._repo_with_packages(scratch, ["gcp", "aws"]))
+        changed_files = mock_build_specs.call_args.args[0]
+        self.assertEqual(changed_files, [
+            "themes/default/data/registry/packages/aws.yaml",
+            "themes/default/data/registry/packages/gcp.yaml",
+        ])
 
 
 class TestBuildSpecs(unittest.TestCase):


### PR DESCRIPTION
`Test Live Registry Publish` opens with `pulumi/esc-action`, and GitHub never issues
an OIDC token to a `pull_request` run from a fork. The job fails at its first step on
every community PR with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`, and
the four steps after it are skipped. Seen on
https://github.com/pulumi/registry/pull/12144.

The token was there for `push-registry.py --dry-run`. `publish_to_registry.py
--validate-all` builds a spec for every package YAML off disk instead, with no network
call and no credential, so it runs the same on a fork PR as on one of ours. That keeps
the check where it matters: a fork PR adding a package is the input it validates.

Guarding the job on `head.repo.full_name == github.repository`, the way the preview job
does, would have skipped it for exactly that population.

`validate_all` is taken from #11998, which removes the legacy publish path wholesale.
This lands the piece that unblocks contributors now; that PR is still a draft.

## Test plan

1. Automated tests
   - `test_publish_to_registry.py`: validate_all passes when every package builds a
     spec, fails when one does not, and reads every package YAML rather than only the
     changed ones
2. Manual checks
   - `python3 scripts/ci/publish_to_registry.py --validate-all` against a clean master
     prints `309 package YAML files, 279 publishable specs` and exits 0

