### PR TITLE
[registry] Let a fork PR reach a Sentinel verdict

### DIFF
--- a/.github/workflows/sentinel-fork.yml
+++ b/.github/workflows/sentinel-fork.yml
@@ -1,0 +1,45 @@
+name: Sentinel for fork pull requests
+
+on:
+  workflow_run:
+    workflows: ["Pull request"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  report:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Refuse a pull request that could have rewritten the run it is reporting
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')"
+          if [ -z "$pr" ]; then
+            echo "No pull request for $HEAD_SHA."
+            exit 1
+          fi
+          changed="$(gh api "repos/$REPO/pulls/$pr/files?per_page=100" --jq '.[].filename')"
+          if echo "$changed" | grep -qE '^(\.github/|scripts/ci/|Makefile$)'; then
+            echo "PR #$pr changes CI, so its own run cannot vouch for it. Not writing Sentinel."
+            exit 1
+          fi
+
+      - uses: guibranco/github-status-action-v2@77639353504055053524efa7a3719aaf0b731ce9 # v1.2.4
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'Sentinel'
+          description: 'All required checks passed'
+          state: 'success'
+          sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
`Sentinel` is the only required status check on master, and the job that writes it is
guarded on `head.repo.full_name == github.repository`. On a fork PR that job is
skipped, so the status is never written and the PR sits on `mergeStateStatus: BLOCKED`
with nothing that can unblock it. https://github.com/pulumi/registry/pull/12144 has
been in that state since it opened: every check green, one status absent.

The guard cannot simply be dropped. GitHub caps the `GITHUB_TOKEN` at read-only for a
`pull_request` run from a fork, and a `permissions:` block cannot raise it, so the job
would run and then fail posting the status. This repo already works around that
elsewhere: `community-package-report.yml` exists because the check workflow "token is
read-only so it cannot comment", and the fact-sheet step in `check-publish` carries
the same fork guard.

So the status is written from the base repo instead, on `workflow_run`, where the
token can write. The reporter adds nothing of its own: it fires only when a fork
`pull_request` run of `Pull request` concluded `success`, and reports that.

A fork PR supplies the workflow file its own run executes, so a PR that rewrote
`pull-request.yml` down to nothing would conclude `success` trivially. That is what
the sentinel pattern exists to prevent, and read-only tokens are what prevent it
today. The reporter therefore refuses any PR touching `.github/`, `scripts/ci/` or
the `Makefile`, which no community package PR does.

`pull-request.yml` is untouched, so our own PRs keep the path they have now. If this
reporter is wrong, fork PRs stay blocked exactly as they are today.

## Test plan

1. Automated tests
   - `actionlint` is clean on the new workflow
2. Manual checks
   - The fork run on #12144 concluded `success` with `Build and deploy preview`, `Send
     slack notification` and `Sentinel Tower` skipped and all eleven other jobs green,
     so the reporter fires for it
   - `gh api repos/pulumi/registry/commits/<head>/status` on that PR lists only
     `Update Changelog`, confirming no `Sentinel` status exists today
   - `workflow_run` only runs the default branch copy of a workflow, so this cannot be
     exercised until it merges

