### PR TITLE
[registry] Find the fork pull request the Sentinel run belongs to

### DIFF
--- a/.github/workflows/sentinel-fork.yml
+++ b/.github/workflows/sentinel-fork.yml
@@ -25,9 +25,10 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')"
+          pr="$(gh api --paginate "repos/$REPO/pulls?state=open&per_page=100" \
+            --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" | head -1)"
           if [ -z "$pr" ]; then
-            echo "No pull request for $HEAD_SHA."
+            echo "No open pull request has $HEAD_SHA as its head."
             exit 1
           fi
           changed="$(gh api "repos/$REPO/pulls/$pr/files?per_page=100" --jq '.[].filename')"


### PR DESCRIPTION
The reporter added in #12158 fails before it writes anything. It resolves the pull
request with `repos/{repo}/commits/{sha}/pulls`, and that endpoint returns nothing for
a fork head commit, so every fork run ends on `No pull request for <sha>` and #12144 is
still BLOCKED.

It now matches the head sha against the open pull requests instead, which is what the
community package tooling already does for the same reason. Checked against the live
data: the commits endpoint returns 0 results for `3db197a0`, and the open pull request
match returns 12144.

## Test plan

1. Automated tests
   - `actionlint` is clean on the workflow
2. Manual checks
   - Ran the step body verbatim against `pulumi/registry` with
     `HEAD_SHA=3db197a04737287093bc4d108508033bde648d8d`: it resolves PR 12144, reads
     its two changed files, and neither matches the CI path guard, so it reaches the
     status write
   - `workflow_run` runs only the default branch copy, so this cannot be exercised
     until it merges. Once merged, re-running the `Pull request` workflow on a fork PR
     is enough to fire it; the contributor does not need to push again

