### PR TITLE
Add Files.com community provider (jschady/pulumi-filescom)

### DIFF
--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -403,6 +403,10 @@
     {
       "repoSlug": "shirasakaren/pulumi-biznetgio",
       "schemaFile": "provider/cmd/pulumi-resource-biznetgio/schema.json"
+    },
+    {
+      "repoSlug": "jschady/pulumi-filescom",
+      "schemaFile": "provider/cmd/pulumi-resource-filescom/schema.json"
     }
   ]
 }

--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -96,6 +96,7 @@
     "jfrog": "jfrog",
     "johnneerdael": "johnneerdael",
     "joneshf": "joneshf",
+    "jschady": "jschady",
     "juju": "juju",
     "k-yomo": "k-yomo",
     "kislerdm": "kislerdm",


### PR DESCRIPTION
This adds `jschady/pulumi-filescom`, a statically bridged provider. It wraps the [Files.com provider for Terraform](https://github.com/Files-com/terraform-provider-files), pinned at `v0.1.882`.

The provider carries 60 resources and 80 data sources. The provider repository is Apache 2.0, and the upstream MIT license stays with the upstream code in `LICENSE-upstream`.

`jschady` is a new publisher, so this pull request also adds the display name.