### PR TITLE
Post the priority digest with a bot token, to a channel ID

### DIFF
--- a/.github/workflows/priority-digest.yml
+++ b/.github/workflows/priority-digest.yml
@@ -37,7 +37,8 @@ jobs:
           ${{ inputs.dry-run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          SLACK_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.SLACK_ACCESS_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.SLACK_TEAM_CHANNEL }}
 
   notify:
     if: failure()

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -785,9 +785,9 @@ Auto-merge is currently disabled (commented out in the workflow).
 
 **Trigger**: Daily at 3:00 PM UTC; also `workflow_dispatch` with a `dry-run` input
 
-Runs `scripts/ci/priority_digest.py`, which searches GitHub for open issues labelled `p0` or `p1` across `pulumi/registry` and `pulumi/terraform-to-pulumi-registry-pipeline`, then posts them to #team-iac-cloud, oldest first, with each issue's age and assignee.
+Runs `scripts/ci/priority_digest.py`, which searches GitHub for open issues labelled `p0` or `p1` across `pulumi/registry` and `pulumi/terraform-to-pulumi-registry-pipeline`, then posts them to Slack, oldest first, with each issue's age and assignee.
 
-Replaces a Metabase subscription that posted the same query as a screenshot. Uses `PULUMI_BOT_TOKEN` and `SLACK_WEBHOOK_URL` from ESC; no other configuration. `--dry-run` prints the message to the job log instead of posting.
+Replaces a Metabase subscription that posted the same query as a screenshot. Uses `PULUMI_BOT_TOKEN` and `SLACK_ACCESS_TOKEN` from ESC and posts via `chat.postMessage` to the channel ID in the `SLACK_TEAM_CHANNEL` repository variable; the bot must be a member of that channel. `--dry-run` prints the message to the job log instead of posting.
 
 #### `export-repo-secrets.yml` — Sync GitHub Secrets → ESC
 
@@ -1139,8 +1139,9 @@ The `export-repo-secrets.yml` workflow provides a manual escape hatch to sync Gi
 | `PULUMI_DOCS_STACK_NAME` | GitHub var | build | Pulumi docs stack reference |
 | `DEPLOYMENT_ENVIRONMENT` | GitHub var | build, cleanup | e.g., `testing` or `production` |
 | `NODE_OPTIONS` | Hardcoded | build, browser tests | `--max_old_space_size=8192` |
-| `SLACK_ACCESS_TOKEN` | ESC | link check, cleanup | Slack Web API token for posting messages |
-| `SLACK_WEBHOOK_URL` | ESC | notify jobs, priority digest | Slack incoming webhook for failure alerts and the daily digest |
+| `SLACK_ACCESS_TOKEN` | ESC | link check, cleanup, priority digest | Slack Web API token for posting messages |
+| `SLACK_WEBHOOK_URL` | ESC | notify jobs | Slack incoming webhook for failure alerts |
+| `SLACK_TEAM_CHANNEL` | GitHub var | priority digest | Slack channel ID the digest posts to |
 | `ASSET_BUNDLE_ID` | `build.sh` (computed) | Hugo templates | Unique suffix for CSS/JS cache-busting |
 | `CSS_BUNDLE` / `JS_BUNDLE` | `build.sh` (computed) | Hugo templates | Paths to versioned asset bundles |
 

--- a/scripts/ci/priority_digest.py
+++ b/scripts/ci/priority_digest.py
@@ -106,7 +106,7 @@ def post(channel, message):
     response.raise_for_status()
     body = response.json()
     if not body.get("ok"):
-        sys.exit(f"Slack rejected the message: {body.get('error')}")
+        sys.exit(f"Slack rejected the message: {body.get('error') or response.text.strip()}")
 
 
 def main():

--- a/scripts/ci/priority_digest.py
+++ b/scripts/ci/priority_digest.py
@@ -98,19 +98,15 @@ def log_counts(issues):
 
 def post(channel, message):
     response = requests.post(
-        require_env("SLACK_WEBHOOK_URL"),
-        json={
-            "channel": channel,
-            "text": message,
-            "username": "registrybot",
-            "icon_url": "https://www.pulumi.com/logos/brand/avatar-on-white.png",
-            "mrkdwn": True,
-            "unfurl_links": False,
-        },
+        "https://slack.com/api/chat.postMessage",
+        headers={"Authorization": f"Bearer {require_env('SLACK_ACCESS_TOKEN')}"},
+        json={"channel": channel, "text": message, "mrkdwn": True, "unfurl_links": False},
         timeout=30,
     )
-    if response.status_code != 200 or response.text.strip() != "ok":
-        sys.exit(f"Slack rejected the message: {response.status_code} {response.text.strip()}")
+    response.raise_for_status()
+    body = response.json()
+    if not body.get("ok"):
+        sys.exit(f"Slack rejected the message: {body.get('error')}")
 
 
 def main():
@@ -119,13 +115,11 @@ def main():
         description="""Post the open P0 and P1 registry issues to Slack, oldest first
 
         GITHUB_TOKEN must be set to read issues.
-        SLACK_WEBHOOK_URL must be set to post.
-        SLACK_CHANNEL may be set. Defaults to #team-iac-cloud.
+        SLACK_ACCESS_TOKEN and SLACK_CHANNEL must be set to post.
         """,
         epilog="This is a Pulumi internal tool - it is not intended for external use")
     parser.add_argument("--dry-run", action="store_true", help="Print the message instead of posting it")
-    parser.add_argument("--channel", default=os.getenv("SLACK_CHANNEL", "#team-iac-cloud"),
-                        help="Slack channel to post to, as #name.")
+    parser.add_argument("--channel", default=os.getenv("SLACK_CHANNEL"), help="Slack channel ID.")
 
     args = parser.parse_args()
 
@@ -136,7 +130,7 @@ def main():
     if args.dry_run:
         print(message)
     else:
-        post(args.channel, message)
+        post(args.channel or require_env("SLACK_CHANNEL"), message)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_priority_digest.py
+++ b/scripts/ci/test_priority_digest.py
@@ -6,6 +6,8 @@ import unittest
 from datetime import datetime, timezone
 from unittest import mock
 
+import requests
+
 from priority_digest import describe, escape, post, render, repository_of
 
 
@@ -100,6 +102,8 @@ class TestPost(unittest.TestCase):
         self.assertEqual(kwargs["headers"]["Authorization"], "Bearer xoxb-test")
         self.assertEqual(kwargs["json"]["channel"], "C0123456789")
         self.assertEqual(kwargs["json"]["text"], "hello")
+        self.assertIs(kwargs["json"]["mrkdwn"], True)
+        self.assertIs(kwargs["json"]["unfurl_links"], False)
 
     @mock.patch("priority_digest.requests.post")
     def test_fails_with_the_error_slack_gives(self, post_mock):
@@ -109,6 +113,23 @@ class TestPost(unittest.TestCase):
             post("C0123456789", "hello")
 
         self.assertIn("not_in_channel", str(raised.exception))
+
+    @mock.patch("priority_digest.requests.post")
+    def test_falls_back_to_the_raw_response_when_slack_gives_no_error(self, post_mock):
+        post_mock.return_value.json.return_value = {"ok": False}
+        post_mock.return_value.text = "  bad gateway  "
+
+        with self.assertRaises(SystemExit) as raised:
+            post("C0123456789", "hello")
+
+        self.assertIn("bad gateway", str(raised.exception))
+
+    @mock.patch("priority_digest.requests.post")
+    def test_raises_on_http_errors(self, post_mock):
+        post_mock.return_value.raise_for_status.side_effect = requests.HTTPError("503 Server Error")
+
+        with self.assertRaises(requests.HTTPError):
+            post("C0123456789", "hello")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_priority_digest.py
+++ b/scripts/ci/test_priority_digest.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Unit tests for priority_digest.py"""
 
+import os
 import unittest
 from datetime import datetime, timezone
+from unittest import mock
 
-from priority_digest import describe, escape, render, repository_of
+from priority_digest import describe, escape, post, render, repository_of
 
 
 NOW = datetime(2026, 8, 14, 12, 0, 0, tzinfo=timezone.utc)
@@ -79,6 +81,34 @@ class TestRender(unittest.TestCase):
     def test_counts_every_issue_in_the_header(self):
         message = render([issue(number=n) for n in range(25)], NOW)
         self.assertIn("|25 open>", message)
+
+
+class TestPost(unittest.TestCase):
+    def setUp(self):
+        environment = mock.patch.dict(os.environ, {"SLACK_ACCESS_TOKEN": "xoxb-test"})
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    @mock.patch("priority_digest.requests.post")
+    def test_posts_through_the_web_api_as_the_bot(self, post_mock):
+        post_mock.return_value.json.return_value = {"ok": True}
+
+        post("C0123456789", "hello")
+
+        (url,), kwargs = post_mock.call_args
+        self.assertEqual(url, "https://slack.com/api/chat.postMessage")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer xoxb-test")
+        self.assertEqual(kwargs["json"]["channel"], "C0123456789")
+        self.assertEqual(kwargs["json"]["text"], "hello")
+
+    @mock.patch("priority_digest.requests.post")
+    def test_fails_with_the_error_slack_gives(self, post_mock):
+        post_mock.return_value.json.return_value = {"ok": False, "error": "not_in_channel"}
+
+        with self.assertRaises(SystemExit) as raised:
+            post("C0123456789", "hello")
+
+        self.assertIn("not_in_channel", str(raised.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`Scheduled jobs: Priority digest` has failed every run since 2026-08-21 (first: https://github.com/pulumi/registry/actions/runs/32495917947) with:

```
Slack rejected the message: 404 channel_not_found
```

It posted through the legacy incoming webhook's `channel` override, by name, and the target channel was renamed. The override resolves the name it is given against current names only, so the post has been going to a name that no longer exists.

## What

- `scripts/ci/priority_digest.py`: `post()` now calls `chat.postMessage` with `SLACK_ACCESS_TOKEN` (the bot token the link checker already uses from ESC) and checks the API's `ok` field (it returns HTTP 200 on failure). The `username`/`icon_url` override is dropped: bot posts carry the app's own identity.
- The channel is a channel **ID**, taken from `SLACK_CHANNEL`, which the workflow sets from the `SLACK_TEAM_CHANNEL` repository variable. An ID survives renames, and nothing about the channel lives in the code.
- `test_priority_digest.py` covers the request `post()` sends and the `ok: false` failure path.

Tracked in #12181.

## Before merging

1. ~~Invite the bot to the target channel; it is not a member today, and a bot can only post where it has been added (`not_in_channel` otherwise).~~ Done.
2. ~~Run `Scheduled jobs: Priority digest` via `workflow_dispatch` on this branch (dry-run off) and confirm the digest arrives.~~ Done: https://github.com/pulumi/registry/actions/runs/32961421697 posted the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1TRPjAnd8ggqDYGHcMSDh
