### PR TITLE
Document previewing registry changes, split by audience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ api-docs/%: .make/content/registry/packages/$$*/api-docs ;
 		--baseSchemasOutDir ./static/registry/packages \
 		--baseLLMDocsOutDir ./llm-docs-out/registry/packages \
 		$*
-	CONTENT_DIR=$(CURDIR)/content/registry/packages STATIC_DIR=$(CURDIR)/static/registry/packages ./scripts/generate-versioned-docs.sh $*
+	$(if $(SKIP_VERSIONED_DOCS),,CONTENT_DIR=$(CURDIR)/content/registry/packages STATIC_DIR=$(CURDIR)/static/registry/packages ./scripts/generate-versioned-docs.sh $*)
 	@mkdir -p "$(@D)"
 	@touch $@
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,14 @@ This repository does not contain the content of the API docs packages. We genera
 To build the API docs for a single package, run:
 
 ``` bash
-make .make/content/registry/packages/<package_name>/api-docs
+make SKIP_VERSIONED_DOCS=1 api-docs/<package_name>
 ```
 
+`SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which requires a Pulumi-internal tool. Leave it set unless you are specifically working on versioned docs.
+
 Run `make bin/resourcedocsgen && ./bin/resourcedocsgen --help` for help regarding its use or [see the `resourcedocsgen` README](tools/resourcedocsgen/README.md).
+
+To preview a provider whose schema changes aren't published yet, or to see your changes on a live preview site, see [Previewing Registry Changes](./docs/previewing-registry-changes.md).
 
 ## Submitting, merging and releasing
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ make SKIP_VERSIONED_DOCS=1 api-docs/<package_name>
 
 Run `make bin/resourcedocsgen && ./bin/resourcedocsgen --help` for help regarding its use or [see the `resourcedocsgen` README](tools/resourcedocsgen/README.md).
 
-To preview a provider whose schema changes aren't published yet, or to see your changes on a live preview site, see [Previewing Registry Changes](./docs/previewing-registry-changes.md).
+Two guides cover previewing in more depth: [Previewing your package's docs](./docs/previewing-package-docs.md), if you're publishing a package and want to see how a release will render beforehand, and [Previewing registry changes](./docs/previewing-registry-changes.md), if you're changing this repository and want to check it against published packages.
 
 ## Submitting, merging and releasing
 

--- a/docs/previewing-package-docs.md
+++ b/docs/previewing-package-docs.md
@@ -1,0 +1,179 @@
+# Previewing your package's docs
+
+Your package's section of the Pulumi Registry is assembled from the following sources:
+
+- **Your provider's schema** becomes the API docs — a page per resource and function, plus the nav tree beside them.
+- **`docs/_index.md` in your provider repo** becomes the Overview page at `/registry/packages/<package>/`. See [The Overview page](./overview-page.md) for what belongs in it.
+- **`docs/installation-configuration.md` in your provider repo**, if you have one, becomes the Install & config page. It's optional: most packages keep this material in the Overview instead.
+- **Guides committed to this repository**, under `themes/default/content/registry/packages/<package>/how-to-guides/`, become the How-to guides section. You can add as many as you like, and this is where anything longer-form goes — the AWS [6.0](https://www.pulumi.com/registry/packages/aws/how-to-guides/6-0-migration/) and [7.0](https://www.pulumi.com/registry/packages/aws/how-to-guides/7-0-migration/) migration guides are two of these.
+- **The package's metadata**, at `themes/default/data/registry/packages/<package>.yaml`, records the version to render, the URL to fetch the schema from, and the title, publisher, logo, and category the site displays.
+
+The sidebar links a fixed set of paths, so where a page lands decides whether readers can find it. It shows Overview, then Install & config if `installation-configuration.md` exists, then How-to guides if the `how-to-guides/` directory exists — with a count of the guides in it — then API Docs. (Four more paths are hardcoded for packages that predate this arrangement: `version-guide`, `from-classic`, `from-v1-to-v2`, and `from-v2-to-v3`, all used by Azure Native.) A Markdown file anywhere else under the package still renders at its own URL, but nothing links to it: `gcp/service-account.md` is one of those, reachable only from links in the GCP Install & config page.
+
+Guides are the one part of a package's docs contributed directly to `pulumi/registry`, and you don't have to work at Pulumi or own the provider to add one. Open a pull request adding your page under `themes/default/content/registry/packages/<package>/how-to-guides/` — many of the guides there were written by people outside Pulumi. Nothing in the publish pipeline touches that directory, since `resourcedocsgen` only ever rewrites `_index.md` and `installation-configuration.md`, so a merged guide survives your next release. Working from a fork changes one thing: CI won't build a preview for you, so preview the guide locally and ask a maintainer to comment `/preview` on the pull request if you want a URL to share.
+
+None of this renders when you tag a release. Your version is picked up later — by a `repository_dispatch` from your release workflow, or one of the twice-daily polls for community packages — which opens a pull request here updating your package's metadata, and the site rebuilds when that merges. So by default, the first time you see your docs rendered is after they're live for everyone. The rest of this document is how to see them sooner. If you're changing the registry itself rather than publishing a package, see [Previewing registry changes](./previewing-registry-changes.md) instead.
+
+## Prerequisites
+
+You need a working checkout of this repository, which you set up once by following [Using this repository](../README.md#using-this-repository) in the README:
+
+```bash
+mise trust && mise install
+make ensure
+make build-assets
+```
+
+## Preview a release locally
+
+A release may change more than the schema. For example, a major version typically comes with a rewritten Overview, updated provider configuration, and a new migration guide, and you want to read them as one package rather than one file at a time.
+
+You can assemble all of it locally because Hugo serves this repository's root `content/` and `static/` directories alongside the theme's, and a file in the root `content/` wins over the committed copy of the same page. That directory is git-ignored, so you can put your whole release there — schema output and hand-written pages together — without touching a tracked file or risking a stray commit.
+
+Set three variables first, so the commands in this section work for any provider:
+
+```bash
+PKG=cloudamqp                          # your package's name in the registry
+PROVIDER_REPO=~/src/pulumi-cloudamqp   # wherever your provider repo is checked out
+VERSION=v9.9.9                         # the version to render as; any valid semver
+```
+
+1. Build the docs generator. It compiles to `./bin/resourcedocsgen`:
+
+    ```bash
+    make bin/resourcedocsgen
+    ```
+
+1. Get your provider's schema, and point `SCHEMA` at it. If your provider bridges a Terraform provider — anything built from [`pulumi-tf-provider-boilerplate`](https://github.com/pulumi/pulumi-tf-provider-boilerplate) — the `tfgen` target writes it into the provider repo. (Newer provider repos alias the same target as `make schema`.)
+
+    ```bash
+    make -C "$PROVIDER_REPO" tfgen
+    SCHEMA="$PROVIDER_REPO/provider/cmd/pulumi-resource-$PKG/schema.json"
+    ```
+
+    For any other provider, including a component provider, build the plugin binary — `make provider` in most repos — and ask it for its schema:
+
+    ```bash
+    pulumi package get-schema "$PROVIDER_REPO/bin/pulumi-resource-$PKG" > "/tmp/$PKG-schema.json"
+    SCHEMA="/tmp/$PKG-schema.json"
+    ```
+
+1. From the root of this repository, generate the API docs from that schema:
+
+    ```bash
+    ./bin/resourcedocsgen docs \
+        --schemaFile "$SCHEMA" \
+        --version "$VERSION" \
+        --docsOutDir "./content/registry/packages/$PKG/api-docs" \
+        --packageTreeJSONOutDir ./static/registry/packages/navs
+    ```
+
+    `--docsOutDir` takes the generated Markdown — one page per resource and function, plus an index — and the site expects it under `content/registry/packages/<package>/api-docs`.
+
+    `--packageTreeJSONOutDir` takes a single `<package>.json` describing the package's resource tree. The nav on the left of every API docs page fetches it in the browser from `/registry/packages/navs/<package>.json`, so it has to land in `static/registry/packages/navs`.
+
+    `--version` is required and must be valid semver. It's recorded as the package's version and doesn't affect which schema you render — `--schemaFile` already decided that — so use the version you plan to release.
+
+1. Copy in the pages you've written, into the paths the sidebar looks for:
+
+    ```bash
+    mkdir -p "content/registry/packages/$PKG"
+    cp "$PROVIDER_REPO/docs/_index.md" "content/registry/packages/$PKG/"
+    cp "$PROVIDER_REPO/docs/installation-configuration.md" "content/registry/packages/$PKG/"   # if you have one
+    ```
+
+    A migration guide or any other long-form page goes under `how-to-guides/`. That directory needs its own `_index.md`: without one, your guide still renders at its URL, but the section page doesn't exist and nothing appears in the sidebar. Create it if the package has no guides yet:
+
+    ```bash
+    mkdir -p "content/registry/packages/$PKG/how-to-guides"
+    cat > "content/registry/packages/$PKG/how-to-guides/_index.md" <<EOF
+    ---
+    title: $PKG How-to Guides
+    meta_desc: Guides for the Pulumi $PKG package.
+    layout: package
+    ---
+    EOF
+    cp ~/my-migration-guide.md "content/registry/packages/$PKG/how-to-guides/"
+    ```
+
+    Guides need front matter with `title`, `meta_desc`, and `layout: package`; copy the shape from [an existing one](https://github.com/pulumi/registry/blob/master/themes/default/content/registry/packages/aws/how-to-guides/7-0-migration.md). These copies are local stand-ins. When the release is real, the Overview and Install & config pages are fetched from your release tag automatically, and guides are contributed to `pulumi/registry` by pull request.
+
+1. Start the site locally:
+
+    ```bash
+    make serve
+    ```
+
+Your package is at `http://localhost:1313/registry/packages/$PKG/`, with the sidebar linking the Overview, Install & config, How-to guides, and API docs pages you just assembled. Re-run the generator after each schema change, and re-copy after editing a page; the running Hugo server picks up both.
+
+To remove the generated package preview, delete `content/registry/packages/$PKG/`.
+
+## Render the page the way the registry will build it
+
+The previous section assembles a preview out of local files, but it bypasses the package metadata: the version, title, publisher, logo, category, and the install snippets that depend on them all come from `themes/default/data/registry/packages/<package>.yaml`, which none of those commands read.
+
+To exercise the path that CI runs, set `schema_file_url` in that `<package>.yaml` to a schema on your branch and let `make` do the whole job. Do this when you want to confirm the metadata-driven parts of the page, and when you want [a preview you can share](#share-a-preview), since the same edit is what makes CI build one. It needs a package that's already in the registry; if yours isn't, stay with the previous section and see [Adding a new package](./adding-a-new-package.md).
+
+1. Put the schema somewhere public. Most providers commit their `schema.json`, so pushing your branch is enough: the raw URL is `https://raw.githubusercontent.com/<org>/<repo>/<branch>/provider/cmd/pulumi-resource-<name>/schema.json`. Providers whose schema is too large to commit, such as Azure Native, need it uploaded to S3 or another public host.
+
+1. In `themes/default/data/registry/packages/<package>.yaml`, set `schema_file_url` to that URL, and set `version` to a semver version that has never been published to the Pulumi Registry service, such as `v9.9.9`.
+
+    Both edits are required, because `resourcedocsgen` prefers the published schema: it asks `api.pulumi.com` for the package at `version` first, and falls back to `schema_file_url` only when that lookup 404s. Leave `version` at a published value and you'll get the published schema and none of your changes, with nothing in the output to say so.
+
+1. Generate the docs and start the site:
+
+    ```bash
+    PKG=cloudamqp   # your package's name in the registry
+    make SKIP_VERSIONED_DOCS=1 "api-docs/$PKG"
+    make serve
+    ```
+
+    `SKIP_VERSIONED_DOCS=1` skips the older-major-version snapshots, which need a Pulumi-internal tool that most contributors can't install. Leave it set unless you're specifically working on versioned docs.
+
+This workflow edits a tracked file, unlike the previous one. Revert it before committing anything else, unless you're opening the throwaway pull request described next:
+
+```bash
+git checkout -- "themes/default/data/registry/packages/$PKG.yaml"
+```
+
+### Picking up a new commit on your branch
+
+`resourcedocsgen` won't regenerate output it believes is current. It records what it generated from in a `.generated` file next to the pages — the contents of the package YAML, plus the generator's own build — and skips the package when neither has changed, logging `Skipping (output is fresh)`. Push a new commit to your branch and the schema behind `schema_file_url` changes while the YAML doesn't, so it skips and you keep reading the old docs.
+
+`make -B` doesn't fix this. The target's sentinel is an intermediate file that Make deletes after each run, so the recipe already re-runs every time; the skip happens inside the generator. Delete the `.generated` file instead:
+
+```bash
+rm "content/registry/packages/$PKG/api-docs/.generated"
+make SKIP_VERSIONED_DOCS=1 "api-docs/$PKG"
+```
+
+## Share a preview
+
+To send someone a rendered preview of unreleased docs, open a pull request against this repository containing only the `schema_file_url` and `version` edit from the previous section. CI builds the full site from your branch's schema and posts a pinned comment holding the preview URL and a list of the changed pages.
+
+Close that pull request when you're done rather than merging it — it exists to produce a URL, not to change the registry. Your real version lands through the [normal publish pipeline](./architecture.md#registry-package-updates) when you tag a release.
+
+A pull request that adds a how-to guide is the opposite case: that one you do merge, and its preview shows the guide in place.
+
+Neither kind of pull request gets a preview from a fork, because the preview job only runs for branches pushed to this repository. Ask a Pulumi maintainer to build you one by commenting `/preview` on the pull request.
+
+## Troubleshooting
+
+**Your Overview page is missing, though the API docs render.** Nothing generates the Overview page from your schema. Copy `docs/_index.md` into `content/registry/packages/<package>/`, as described in [Preview a release locally](#preview-a-release-locally).
+
+**A page you added doesn't appear in the sidebar.** The sidebar only links a fixed set of paths. Long-form pages belong in `how-to-guides/`, and that directory needs an `_index.md` of its own before the sidebar shows the section at all. The paths the sidebar links are listed at the top of this document.
+
+**The API docs render, but the nav on the left is empty.** That nav is fetched in the browser from `/registry/packages/navs/<package>.json`, and it fails quietly when the file is missing. Confirm `static/registry/packages/navs/<package>.json` exists — that's what `--packageTreeJSONOutDir` writes.
+
+**`make api-docs/<package>` fails with `registry-mirror-discover ... Repository not found`.** The build tried to generate versioned docs, which uses a tool that lives in a Pulumi-internal repository. Re-run with `SKIP_VERSIONED_DOCS=1`.
+
+**The generator logs `Skipping (output is fresh)` and your changes don't appear.** Its output cache thinks the pages are current. See [Picking up a new commit on your branch](#picking-up-a-new-commit-on-your-branch).
+
+**Hugo isn't on port 1313.** `make serve` doesn't pass `--port`, so Hugo binds a random free port when 1313 is already taken. Read the port off the server's own startup output rather than assuming it.
+
+## Learn more
+
+- [The Overview page](./overview-page.md) — what belongs in the `docs/_index.md` you author in your provider repo.
+- [Adding a new package](./adding-a-new-package.md) — getting a package into the registry in the first place.
+- [Architecture](./architecture.md#registry-package-updates) — how a tagged release becomes a published page, and what rebuilds the site.
+- [Previewing registry changes](./previewing-registry-changes.md) — the other direction: changing this repository and checking it against published packages.

--- a/docs/previewing-registry-changes.md
+++ b/docs/previewing-registry-changes.md
@@ -1,0 +1,173 @@
+# Previewing Registry Changes
+
+This guide covers how to see Pulumi Registry pages — including provider API docs —
+before they are published, whether the change lives in a provider's schema, in this
+repository's templates, or in a pull request.
+
+Pick a route based on what you changed:
+
+| What you changed | Route |
+|---|---|
+| A provider schema you have locally, and it isn't released yet | [Local preview from a schema file](#local-preview-from-a-schema-file) |
+| A package that is already published in the registry (templates, layouts, CSS, metadata) | [Local preview of a published package](#local-preview-of-a-published-package) |
+| A provider schema you can publish to a public URL (e.g. a branch on GitHub) | [Local preview from a branch schema](#local-preview-from-a-branch-schema) |
+| Anything you're ready to push to `pulumi/registry` | [Pull request preview](#pull-request-preview) |
+
+## Prerequisites
+
+All local routes assume you've set the repository up once:
+
+```bash
+mise trust && mise install
+make ensure
+make build-assets
+```
+
+See [the README](../README.md#using-this-repository) for details.
+
+Generated docs land in git-ignored directories (`content/` and `static/registry/` at
+the repository root), so nothing from these routes should ever end up in a commit.
+
+## Local preview from a schema file
+
+Use this when you're changing a provider and want to see how its API docs will render
+before you cut a release. It reads a `schema.json` straight off your disk, so nothing
+needs to be pushed or published.
+
+1. Build the docs generator:
+
+    ```bash
+    make bin/resourcedocsgen
+    ```
+
+2. Generate your provider's schema in the provider repo. For a bridged provider that's
+   usually `make generate_schema`, which writes
+   `provider/cmd/pulumi-resource-<name>/schema.json`.
+
+3. From the root of this repository, run `resourcedocsgen docs` against that file,
+   writing into the two locations Hugo serves from:
+
+    ```bash
+    ./bin/resourcedocsgen docs \
+        --schemaFile ../pulumi-aws/provider/cmd/pulumi-resource-aws/schema.json \
+        --version v9.9.9 \
+        --docsOutDir ./content/registry/packages/aws/api-docs \
+        --packageTreeJSONOutDir ./static/registry/packages/navs
+    ```
+
+    `--version` is required and must be valid semver. Use a dummy version higher than
+    anything published so it's obvious in the rendered page that you're looking at a
+    local build.
+
+4. The package's landing pages (`_index.md` and `installation-configuration.md`) are
+   committed under `themes/default/content/registry/packages/<package>/` and are used
+   as-is. If you're previewing a package that isn't in the registry yet, create that
+   directory and add the two files by hand, copying them from your provider repo's
+   `docs/` folder.
+
+5. Serve the site:
+
+    ```bash
+    make serve
+    ```
+
+    Your pages are at `http://localhost:1313/registry/packages/<package>/api-docs/`.
+
+Re-run step 3 after each schema change; the running Hugo server picks up the new files.
+If you're also changing CSS or JavaScript under `themes/default/theme`, use
+`make serve-all` instead so assets rebuild too.
+
+## Local preview of a published package
+
+Use this when the schema is already published and you're changing something on this
+side — a docs template, a Hugo layout, the theme, or a package's YAML metadata.
+
+```bash
+make SKIP_VERSIONED_DOCS=1 api-docs/aws
+make serve
+```
+
+`make api-docs/<package>` reads
+`themes/default/data/registry/packages/<package>.yaml`, fetches the corresponding
+schema, and writes to `content/registry/packages/<package>/` at the repository root.
+
+`SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which
+requires a Pulumi-internal tool that most contributors can't install. Leave it set
+unless you are specifically working on versioned docs.
+
+To force a rebuild after a change the generator can't see (it caches on the package
+YAML and its own build), delete the sentinel file:
+
+```bash
+rm content/registry/packages/aws/api-docs/.generated
+```
+
+## Local preview from a branch schema
+
+Use this when you want the full registry pipeline — metadata, nav tree, published
+schema file, and all — but against a schema that only exists on a branch.
+
+1. Publish the schema to a public URL. For most providers the schema is committed, so
+   pushing your branch is enough; the raw URL looks like
+   `https://raw.githubusercontent.com/<org>/<repo>/<branch>/provider/cmd/pulumi-resource-<name>/schema.json`.
+   For providers whose schema is too large to commit (Azure Native, for example),
+   upload it to S3 or any other public host.
+
+2. Edit `themes/default/data/registry/packages/<package>.yaml`:
+
+    - Set `schema_file_url` to the URL from step 1.
+    - Set `version` to a semver version that has **not** been published to the Pulumi
+      Registry service — a bumped dummy version such as `v9.9.9`.
+
+    Both edits are required. `resourcedocsgen` asks `api.pulumi.com` for the package at
+    `version` first and only falls back to `schema_file_url` when that lookup 404s. If
+    you leave `version` at a published value you'll silently get the published schema
+    and none of your changes.
+
+3. Generate and serve:
+
+    ```bash
+    make SKIP_VERSIONED_DOCS=1 api-docs/<package>
+    make serve
+    ```
+
+Revert the YAML edit before committing.
+
+## Pull request preview
+
+Every pull request against `pulumi/registry` gets a full site build published to a
+per-commit S3 bucket. CI maintains a single pinned comment on the PR containing:
+
+- the preview URL for the current commit, and
+- a **Changed pages** list linking directly to the pages your PR affects.
+
+The comment is updated in place on each build rather than added per commit, and the
+preview buckets are deleted when the PR closes.
+
+If your change is in a provider repo rather than here, you can still get a preview by
+opening a PR against this repository with the
+[branch schema](#local-preview-from-a-branch-schema) edits applied — the same YAML
+change works in CI. Don't merge that PR; it exists to produce the preview.
+
+For a community package pull request, a Pulumi maintainer can comment `/preview` to
+build a live preview of the package's pages.
+
+## Troubleshooting
+
+**`registry-mirror-discover ... Repository not found`** — `make api-docs/<package>`
+tried to build the versioned-docs tool, which lives in a Pulumi-internal repository.
+Re-run with `SKIP_VERSIONED_DOCS=1`.
+
+**`Skipping (output is fresh)` and your changes don't appear** — the generator caches on
+the package YAML plus its own build identity, so a change to a remote schema alone
+won't invalidate it. Delete
+`content/registry/packages/<package>/api-docs/.generated` and re-run.
+
+**Pages 404 in the local server** — check that the nav tree JSON was written to
+`static/registry/packages/navs/<package>.json` and that
+`themes/default/content/registry/packages/<package>/_index.md` exists. The API docs
+pages hang off that landing page.
+
+**Hugo isn't on port 1313** — `make serve` doesn't pass `--port`, so Hugo binds a
+random free port when 1313 is already taken. Read the port off the server's own
+startup output rather than assuming it.

--- a/docs/previewing-registry-changes.md
+++ b/docs/previewing-registry-changes.md
@@ -35,9 +35,9 @@ Use this when you're changing a provider and want to see how its API docs will r
     make bin/resourcedocsgen
     ```
 
-2. Generate your provider's schema in the provider repo. For a bridged provider that's usually `make generate_schema`, which writes `provider/cmd/pulumi-resource-<name>/schema.json`.
+1. Generate your provider's schema in the provider repo. For a bridged provider that's usually `make generate_schema`, which writes `provider/cmd/pulumi-resource-<name>/schema.json`.
 
-3. From the root of this repository, run `resourcedocsgen docs` against that file, writing into the two locations Hugo serves from:
+1. From the root of this repository, run `resourcedocsgen docs` against that file, writing into the two locations Hugo serves from:
 
     ```bash
     ./bin/resourcedocsgen docs \
@@ -49,9 +49,9 @@ Use this when you're changing a provider and want to see how its API docs will r
 
     `--version` is required and must be valid semver. Use a dummy version higher than anything published so it's obvious in the rendered page that you're looking at a local build.
 
-4. The package's landing pages (`_index.md` and `installation-configuration.md`) are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. If you're previewing a package that isn't in the registry yet, create that directory and add the two files by hand, copying them from your provider repo's `docs/` folder.
+1. The package's landing pages (`_index.md` and `installation-configuration.md`) are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. If you're previewing a package that isn't in the registry yet, create that directory and add the two files by hand, copying them from your provider repo's `docs/` folder.
 
-5. Serve the site:
+1. Serve the site:
 
     ```bash
     make serve
@@ -86,14 +86,14 @@ Use this when you want the full registry pipeline — metadata, nav tree, publis
 
 1. Publish the schema to a public URL. For most providers the schema is committed, so pushing your branch is enough; the raw URL looks like `https://raw.githubusercontent.com/<org>/<repo>/<branch>/provider/cmd/pulumi-resource-<name>/schema.json`. For providers whose schema is too large to commit (Azure Native, for example), upload it to S3 or any other public host.
 
-2. Edit `themes/default/data/registry/packages/<package>.yaml`:
+1. Edit `themes/default/data/registry/packages/<package>.yaml`:
 
     - Set `schema_file_url` to the URL from step 1.
     - Set `version` to a semver version that has **not** been published to the Pulumi Registry service — a bumped dummy version such as `v9.9.9`.
 
     Both edits are required. `resourcedocsgen` asks `api.pulumi.com` for the package at `version` first and only falls back to `schema_file_url` when that lookup 404s. If you leave `version` at a published value you'll silently get the published schema and none of your changes.
 
-3. Generate and serve:
+1. Generate and serve:
 
     ```bash
     make SKIP_VERSIONED_DOCS=1 api-docs/<package>

--- a/docs/previewing-registry-changes.md
+++ b/docs/previewing-registry-changes.md
@@ -1,8 +1,6 @@
 # Previewing Registry Changes
 
-This guide covers how to see Pulumi Registry pages — including provider API docs —
-before they are published, whether the change lives in a provider's schema, in this
-repository's templates, or in a pull request.
+This guide covers how to see Pulumi Registry pages — including provider API docs — before they are published, whether the change lives in a provider's schema, in this repository's templates, or in a pull request.
 
 Pick a route based on what you changed:
 
@@ -25,14 +23,11 @@ make build-assets
 
 See [the README](../README.md#using-this-repository) for details.
 
-Generated docs land in git-ignored directories (`content/` and `static/registry/` at
-the repository root), so nothing from these routes should ever end up in a commit.
+Generated docs land in git-ignored directories (`content/` and `static/registry/` at the repository root), so nothing from these routes should ever end up in a commit.
 
 ## Local preview from a schema file
 
-Use this when you're changing a provider and want to see how its API docs will render
-before you cut a release. It reads a `schema.json` straight off your disk, so nothing
-needs to be pushed or published.
+Use this when you're changing a provider and want to see how its API docs will render before you cut a release. It reads a `schema.json` straight off your disk, so nothing needs to be pushed or published.
 
 1. Build the docs generator:
 
@@ -40,12 +35,9 @@ needs to be pushed or published.
     make bin/resourcedocsgen
     ```
 
-2. Generate your provider's schema in the provider repo. For a bridged provider that's
-   usually `make generate_schema`, which writes
-   `provider/cmd/pulumi-resource-<name>/schema.json`.
+2. Generate your provider's schema in the provider repo. For a bridged provider that's usually `make generate_schema`, which writes `provider/cmd/pulumi-resource-<name>/schema.json`.
 
-3. From the root of this repository, run `resourcedocsgen docs` against that file,
-   writing into the two locations Hugo serves from:
+3. From the root of this repository, run `resourcedocsgen docs` against that file, writing into the two locations Hugo serves from:
 
     ```bash
     ./bin/resourcedocsgen docs \
@@ -55,15 +47,9 @@ needs to be pushed or published.
         --packageTreeJSONOutDir ./static/registry/packages/navs
     ```
 
-    `--version` is required and must be valid semver. Use a dummy version higher than
-    anything published so it's obvious in the rendered page that you're looking at a
-    local build.
+    `--version` is required and must be valid semver. Use a dummy version higher than anything published so it's obvious in the rendered page that you're looking at a local build.
 
-4. The package's landing pages (`_index.md` and `installation-configuration.md`) are
-   committed under `themes/default/content/registry/packages/<package>/` and are used
-   as-is. If you're previewing a package that isn't in the registry yet, create that
-   directory and add the two files by hand, copying them from your provider repo's
-   `docs/` folder.
+4. The package's landing pages (`_index.md` and `installation-configuration.md`) are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. If you're previewing a package that isn't in the registry yet, create that directory and add the two files by hand, copying them from your provider repo's `docs/` folder.
 
 5. Serve the site:
 
@@ -73,30 +59,22 @@ needs to be pushed or published.
 
     Your pages are at `http://localhost:1313/registry/packages/<package>/api-docs/`.
 
-Re-run step 3 after each schema change; the running Hugo server picks up the new files.
-If you're also changing CSS or JavaScript under `themes/default/theme`, use
-`make serve-all` instead so assets rebuild too.
+Re-run step 3 after each schema change; the running Hugo server picks up the new files. If you're also changing CSS or JavaScript under `themes/default/theme`, use `make serve-all` instead so assets rebuild too.
 
 ## Local preview of a published package
 
-Use this when the schema is already published and you're changing something on this
-side — a docs template, a Hugo layout, the theme, or a package's YAML metadata.
+Use this when the schema is already published and you're changing something on this side — a docs template, a Hugo layout, the theme, or a package's YAML metadata.
 
 ```bash
 make SKIP_VERSIONED_DOCS=1 api-docs/aws
 make serve
 ```
 
-`make api-docs/<package>` reads
-`themes/default/data/registry/packages/<package>.yaml`, fetches the corresponding
-schema, and writes to `content/registry/packages/<package>/` at the repository root.
+`make api-docs/<package>` reads `themes/default/data/registry/packages/<package>.yaml`, fetches the corresponding schema, and writes to `content/registry/packages/<package>/` at the repository root.
 
-`SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which
-requires a Pulumi-internal tool that most contributors can't install. Leave it set
-unless you are specifically working on versioned docs.
+`SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which requires a Pulumi-internal tool that most contributors can't install. Leave it set unless you are specifically working on versioned docs.
 
-To force a rebuild after a change the generator can't see (it caches on the package
-YAML and its own build), delete the sentinel file:
+To force a rebuild after a change the generator can't see (it caches on the package YAML and its own build), delete the sentinel file:
 
 ```bash
 rm content/registry/packages/aws/api-docs/.generated
@@ -104,25 +82,16 @@ rm content/registry/packages/aws/api-docs/.generated
 
 ## Local preview from a branch schema
 
-Use this when you want the full registry pipeline — metadata, nav tree, published
-schema file, and all — but against a schema that only exists on a branch.
+Use this when you want the full registry pipeline — metadata, nav tree, published schema file, and all — but against a schema that only exists on a branch.
 
-1. Publish the schema to a public URL. For most providers the schema is committed, so
-   pushing your branch is enough; the raw URL looks like
-   `https://raw.githubusercontent.com/<org>/<repo>/<branch>/provider/cmd/pulumi-resource-<name>/schema.json`.
-   For providers whose schema is too large to commit (Azure Native, for example),
-   upload it to S3 or any other public host.
+1. Publish the schema to a public URL. For most providers the schema is committed, so pushing your branch is enough; the raw URL looks like `https://raw.githubusercontent.com/<org>/<repo>/<branch>/provider/cmd/pulumi-resource-<name>/schema.json`. For providers whose schema is too large to commit (Azure Native, for example), upload it to S3 or any other public host.
 
 2. Edit `themes/default/data/registry/packages/<package>.yaml`:
 
     - Set `schema_file_url` to the URL from step 1.
-    - Set `version` to a semver version that has **not** been published to the Pulumi
-      Registry service — a bumped dummy version such as `v9.9.9`.
+    - Set `version` to a semver version that has **not** been published to the Pulumi Registry service — a bumped dummy version such as `v9.9.9`.
 
-    Both edits are required. `resourcedocsgen` asks `api.pulumi.com` for the package at
-    `version` first and only falls back to `schema_file_url` when that lookup 404s. If
-    you leave `version` at a published value you'll silently get the published schema
-    and none of your changes.
+    Both edits are required. `resourcedocsgen` asks `api.pulumi.com` for the package at `version` first and only falls back to `schema_file_url` when that lookup 404s. If you leave `version` at a published value you'll silently get the published schema and none of your changes.
 
 3. Generate and serve:
 
@@ -135,39 +104,23 @@ Revert the YAML edit before committing.
 
 ## Pull request preview
 
-Every pull request against `pulumi/registry` gets a full site build published to a
-per-commit S3 bucket. CI maintains a single pinned comment on the PR containing:
+Every pull request against `pulumi/registry` gets a full site build published to a per-commit S3 bucket. CI maintains a single pinned comment on the PR containing:
 
 - the preview URL for the current commit, and
 - a **Changed pages** list linking directly to the pages your PR affects.
 
-The comment is updated in place on each build rather than added per commit, and the
-preview buckets are deleted when the PR closes.
+The comment is updated in place on each build rather than added per commit, and the preview buckets are deleted when the PR closes.
 
-If your change is in a provider repo rather than here, you can still get a preview by
-opening a PR against this repository with the
-[branch schema](#local-preview-from-a-branch-schema) edits applied — the same YAML
-change works in CI. Don't merge that PR; it exists to produce the preview.
+If your change is in a provider repo rather than here, you can still get a preview by opening a PR against this repository with the [branch schema](#local-preview-from-a-branch-schema) edits applied — the same YAML change works in CI. Don't merge that PR; it exists to produce the preview.
 
-For a community package pull request, a Pulumi maintainer can comment `/preview` to
-build a live preview of the package's pages.
+For a community package pull request, a Pulumi maintainer can comment `/preview` to build a live preview of the package's pages.
 
 ## Troubleshooting
 
-**`registry-mirror-discover ... Repository not found`** — `make api-docs/<package>`
-tried to build the versioned-docs tool, which lives in a Pulumi-internal repository.
-Re-run with `SKIP_VERSIONED_DOCS=1`.
+**`registry-mirror-discover ... Repository not found`** — `make api-docs/<package>` tried to build the versioned-docs tool, which lives in a Pulumi-internal repository. Re-run with `SKIP_VERSIONED_DOCS=1`.
 
-**`Skipping (output is fresh)` and your changes don't appear** — the generator caches on
-the package YAML plus its own build identity, so a change to a remote schema alone
-won't invalidate it. Delete
-`content/registry/packages/<package>/api-docs/.generated` and re-run.
+**`Skipping (output is fresh)` and your changes don't appear** — the generator caches on the package YAML plus its own build identity, so a change to a remote schema alone won't invalidate it. Delete `content/registry/packages/<package>/api-docs/.generated` and re-run.
 
-**Pages 404 in the local server** — check that the nav tree JSON was written to
-`static/registry/packages/navs/<package>.json` and that
-`themes/default/content/registry/packages/<package>/_index.md` exists. The API docs
-pages hang off that landing page.
+**Pages 404 in the local server** — check that the nav tree JSON was written to `static/registry/packages/navs/<package>.json` and that `themes/default/content/registry/packages/<package>/_index.md` exists. The API docs pages hang off that landing page.
 
-**Hugo isn't on port 1313** — `make serve` doesn't pass `--port`, so Hugo binds a
-random free port when 1313 is already taken. Read the port off the server's own
-startup output rather than assuming it.
+**Hugo isn't on port 1313** — `make serve` doesn't pass `--port`, so Hugo binds a random free port when 1313 is already taken. Read the port off the server's own startup output rather than assuming it.

--- a/docs/previewing-registry-changes.md
+++ b/docs/previewing-registry-changes.md
@@ -1,17 +1,24 @@
-# Previewing Registry Changes
+# Previewing registry changes
 
-Registry pages are generated from provider schemas and from this repository's templates, so a change to either isn't visible until it's published. You can render the affected pages locally first, or have a preview site built from a pull request.
+Every package page under `pulumi.com/registry` is assembled at build time from these sources:
 
-Pick the section that matches what you changed:
+- **Provider schemas**, downloaded during the build, which become the API docs — a page per resource and function, plus the nav tree beside them.
+- **`docs/_index.md` from each provider's repo**, fetched at publish time and committed here under `themes/default/content/registry/packages/<package>/`, which becomes the package's Overview page. An `installation-configuration.md` beside it, where a package has one, becomes the Install & config page.
+- **Guides written directly in this repository**, under that same directory's `how-to-guides/`, which become the How-to guides section — the AWS migration guides, the Kubernetes FAQ, and so on.
+- **Per-package metadata**, at `themes/default/data/registry/packages/<package>.yaml`, which records each package's version, schema URL, title, publisher, logo, and category.
+- **This repository's layouts, templates, and theme**, which render every one of those into the pages readers see.
 
-- [Local preview from a schema file](#local-preview-from-a-schema-file) — a provider schema you have on disk that isn't released yet.
-- [Local preview of a published package](#local-preview-of-a-published-package) — a package already in the registry: a docs template, a Hugo layout, the theme, or a package's YAML metadata.
-- [Local preview from a branch schema](#local-preview-from-a-branch-schema) — a provider schema you can put at a public URL, such as a branch on GitHub.
-- [Pull request preview](#pull-request-preview) — anything you're ready to push to `pulumi/registry`.
+A build of this repository produces the whole registry, not one package: `make api-docs` regenerates every package's API docs from its current schema, and Hugo renders all of them into a single site. CI caches per-package output, so packages whose metadata hasn't changed are restored from the previous build rather than regenerated — but the site it publishes always contains every package. That's why a change to a shared layout or theme file lands on all 300-odd packages at once.
+
+Your change reaches the live site when it merges to `master`: the push workflow rebuilds the site and swaps the CloudFront origin to the new build — see [Publish](./architecture.md#publish).
+
+Until then, `make serve` on its own won't show you much. The Overview pages and guides are committed, but every API docs page is generated during the build and isn't in your checkout, so the packages you most want to look at have nothing under them. This document covers how to generate one locally and how to get a shareable preview from a pull request.
+
+If you're a package author who wants to see how your next release will render, see [Previewing your package's docs](./previewing-package-docs.md) instead.
 
 ## Prerequisites
 
-The local sections below assume you've set the repository up once:
+You need a working checkout, which you set up once by following [Using this repository](../README.md#using-this-repository) in the README:
 
 ```bash
 mise trust && mise install
@@ -19,111 +26,59 @@ make ensure
 make build-assets
 ```
 
-See [the README](../README.md#using-this-repository) for details.
+## Render a package locally
 
-## Local preview from a schema file
-
-Use this when you're changing a provider and want to see how its API docs will render before you cut a release.
-
-1. Build the docs generator:
-
-    ```bash
-    make bin/resourcedocsgen
-    ```
-
-1. Generate your provider's schema in the provider repo. For a bridged provider that's usually `make schema`, which writes `provider/cmd/pulumi-resource-<name>/schema.json`.
-
-1. From the root of this repository, run `resourcedocsgen docs` against that file, writing into the two locations Hugo serves from:
-
-    ```bash
-    ./bin/resourcedocsgen docs \
-        --schemaFile ../pulumi-aws/provider/cmd/pulumi-resource-aws/schema.json \
-        --version v9.9.9 \
-        --docsOutDir ./content/registry/packages/aws/api-docs \
-        --packageTreeJSONOutDir ./static/registry/packages/navs
-    ```
-
-    `--version` is required and must be valid semver. Use a dummy version higher than anything published so it's obvious in the rendered page that you're looking at a local build.
-
-    Both output directories are git-ignored, so nothing you generate here can end up in a commit.
-
-1. The package's landing pages are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. Only `_index.md` is required; `installation-configuration.md` is an optional split for packages whose install and config content outgrows the overview — see [The Overview page](./overview-page.md) and [Publishing packages](https://www.pulumi.com/docs/iac/guides/building-extending/packages/publishing-packages/#overview-installation--configuration). If you're previewing a package that isn't in the registry yet, create that directory and copy `_index.md` into it from your provider repo's `docs/` folder. `resourcedocsgen docs` doesn't write these pages — `resourcedocsgen metadata from-urls` fetches them from the provider repo, and the publish workflow is what runs it.
-
-1. Serve the site:
-
-    ```bash
-    make serve
-    ```
-
-    Your pages are at `http://localhost:1313/registry/packages/<package>/api-docs/`.
-
-Re-run step 3 after each schema change; the running Hugo server picks up the new files. If you're also changing CSS or JavaScript under `themes/default/theme`, use `make serve-all` instead so assets rebuild too.
-
-## Local preview of a published package
-
-Use this when the schema is already published and you're changing something on this side — a docs template, a Hugo layout, the theme, or a package's YAML metadata.
+Pick a package that exercises what you changed, generate its docs, and serve the site:
 
 ```bash
 make SKIP_VERSIONED_DOCS=1 api-docs/aws
 make serve
 ```
 
-`make api-docs/<package>` reads `themes/default/data/registry/packages/<package>.yaml`, fetches the corresponding schema, and writes to `content/registry/packages/<package>/` at the repository root, which is git-ignored. `make serve` then serves the whole site as usual, so the package lands at `http://localhost:1313/registry/packages/<package>/` — see [Troubleshooting](#troubleshooting) if that port doesn't answer.
+The `api-docs/<package>` target reads `themes/default/data/registry/packages/<package>.yaml`, downloads the schema that file points at, and writes the pages to `content/registry/packages/<package>/api-docs` and the nav tree to `static/registry/packages/navs/<package>.json`. Hugo serves this repository's root `content/` and `static/` directories alongside the theme's, which is why generated pages appear on the local site; both are git-ignored, so nothing you generate can end up in a commit. Your package is then at `http://localhost:1313/registry/packages/<package>/`.
 
-`SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which requires a Pulumi-internal tool that most contributors can't install. Leave it set unless you are specifically working on versioned docs.
+`SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which needs a Pulumi-internal tool that most contributors can't install. Leave it set unless you're specifically working on versioned docs.
+
+Generation takes a while for large packages, so generate one small package plus one large one rather than the whole registry — `make build` rebuilds everything, but it needs 32 GB of RAM and a lot of patience. `random` and `aws` are a reasonable pair.
+
+If you're changing CSS or JavaScript under `themes/default/theme`, use `make serve-all` in place of `make serve` so assets rebuild as you edit.
 
 ### Forcing a rebuild
 
-`resourcedocsgen` caches on the package YAML plus its own build identity, recorded in a `.generated` file next to the output. A schema that changed behind an unchanged `schema_file_url` therefore looks fresh to it, and it logs `Skipping (output is fresh)` instead of regenerating.
+`resourcedocsgen` won't regenerate output it believes is current. It records what it generated from in a `.generated` file next to the pages — the contents of the package YAML, plus the generator's own build — and skips the package when neither has changed, logging `Skipping (output is fresh)`. Editing the generator invalidates that, but editing a schema behind an unchanged URL doesn't.
 
-`make -B` does not help here: the Make target's sentinel is an intermediate file that Make deletes after each run, so the recipe already re-runs every time and the skip happens inside the generator. Delete the sentinel and re-run:
+`make -B` doesn't fix this. The target's sentinel is an intermediate file that Make deletes after each run, so the recipe already re-runs every time; the skip happens inside the generator. Delete the `.generated` file instead:
 
 ```bash
 rm content/registry/packages/aws/api-docs/.generated
 make SKIP_VERSIONED_DOCS=1 api-docs/aws
 ```
 
-## Local preview from a branch schema
+Changes to layouts, templates, and theme assets don't need any of this. Hugo re-renders those from the pages you've already generated.
 
-Use this when you want the full registry pipeline — metadata, nav tree, published schema file, and all — but against a schema that only exists on a branch.
+## Preview a pull request
 
-1. Publish the schema to a public URL. For most providers the schema is committed, so pushing your branch is enough; the raw URL looks like `https://raw.githubusercontent.com/<org>/<repo>/<branch>/provider/cmd/pulumi-resource-<name>/schema.json`. For providers whose schema is too large to commit (Azure Native, for example), upload it to S3 or any other public host.
+A pull request whose branch lives in `pulumi/registry` gets a full site build — every package, generated the same way `master` generates them — published to a per-commit S3 bucket. CI keeps a single pinned comment on the PR holding the preview URL for the current commit and a **Changed pages** list linking straight to the pages your PR affects. That comment is updated in place on each build rather than added per commit, and the bucket is deleted when the PR closes.
 
-1. Edit `themes/default/data/registry/packages/<package>.yaml`:
+This is the only practical way to check a change against the whole registry rather than the handful of packages you generated locally, so it's worth pushing a draft PR early for anything touching shared layouts or the theme.
 
-    - Set `schema_file_url` to the URL from step 1.
-    - Set `version` to a semver version that has **not** been published to the Pulumi Registry service — a bumped dummy version such as `v9.9.9`.
-
-    Both edits are required. `resourcedocsgen` asks `api.pulumi.com` for the package at `version` first and only falls back to `schema_file_url` when that lookup 404s. If you leave `version` at a published value you'll silently get the published schema and none of your changes.
-
-1. Generate and serve:
-
-    ```bash
-    make SKIP_VERSIONED_DOCS=1 api-docs/<package>
-    make serve
-    ```
-
-Revert the YAML edit before committing.
-
-## Pull request preview
-
-A pull request whose branch lives in `pulumi/registry` gets a full site build published to a per-commit S3 bucket. CI maintains a single pinned comment on the PR containing:
-
-- the preview URL for the current commit, and
-- a **Changed pages** list linking directly to the pages your PR affects.
-
-The comment is updated in place on each build rather than added per commit, and the preview buckets are deleted when the PR closes.
-
-**Pull requests from forks don't get this automatically.** The preview job only runs for branches pushed to this repository, so if you're contributing from a fork, use the local sections above. A Pulumi maintainer can build you one on demand by commenting `/preview` on the pull request.
-
-If your change is in a provider repo rather than here, you can still get a preview by opening a PR against this repository with the [branch schema](#local-preview-from-a-branch-schema) edits applied — the same YAML change works in CI. Don't merge that PR; it exists to produce the preview.
+Pull requests from forks don't get a preview automatically, because the preview job only runs for branches pushed to this repository. If you're contributing from a fork, preview locally, or ask a Pulumi maintainer to build you one by commenting `/preview` on the pull request.
 
 ## Troubleshooting
 
-**`registry-mirror-discover ... Repository not found`** — `make api-docs/<package>` tried to build the versioned-docs tool, which lives in a Pulumi-internal repository. Re-run with `SKIP_VERSIONED_DOCS=1`.
+**`make api-docs/<package>` fails with `registry-mirror-discover ... Repository not found`.** The build tried to generate versioned docs, which uses a tool that lives in a Pulumi-internal repository. Re-run with `SKIP_VERSIONED_DOCS=1`.
 
-**`Skipping (output is fresh)` and your changes don't appear** — see [Forcing a rebuild](#forcing-a-rebuild).
+**The generator logs `Skipping (output is fresh)` and your changes don't appear.** Its output cache thinks the pages are current. See [Forcing a rebuild](#forcing-a-rebuild).
 
-**Pages 404 in the local server** — check that the nav tree JSON was written to `static/registry/packages/navs/<package>.json` and that `themes/default/content/registry/packages/<package>/_index.md` exists. The API docs pages hang off that landing page.
+**The API docs render, but the nav on the left is empty.** That nav is fetched in the browser from `/registry/packages/navs/<package>.json`, and it fails quietly when the file is missing. Confirm `static/registry/packages/navs/<package>.json` exists.
 
-**Hugo isn't on port 1313** — `make serve` doesn't pass `--port`, so Hugo binds a random free port when 1313 is already taken. Read the port off the server's own startup output rather than assuming it.
+**A package page is empty apart from its Overview.** Its API docs haven't been generated in this checkout. Run `make SKIP_VERSIONED_DOCS=1 api-docs/<package>`.
+
+**Hugo isn't on port 1313.** `make serve` doesn't pass `--port`, so Hugo binds a random free port when 1313 is already taken. Read the port off the server's own startup output rather than assuming it.
+
+## Learn more
+
+- [Architecture](./architecture.md) — where each source of registry content comes from, and how a build reaches production.
+- [Using this repository](../README.md#using-this-repository) — one-time setup and the everyday build commands.
+- [`resourcedocsgen`](../tools/resourcedocsgen/README.md) — every flag the generator accepts.
+- [Previewing your package's docs](./previewing-package-docs.md) — the other direction: publishing a package and checking it before release.

--- a/docs/previewing-registry-changes.md
+++ b/docs/previewing-registry-changes.md
@@ -49,7 +49,7 @@ Use this when you're changing a provider and want to see how its API docs will r
 
     `--version` is required and must be valid semver. Use a dummy version higher than anything published so it's obvious in the rendered page that you're looking at a local build.
 
-1. The package's landing pages (`_index.md` and `installation-configuration.md`) are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. If you're previewing a package that isn't in the registry yet, create that directory and add the two files by hand, copying them from your provider repo's `docs/` folder.
+1. The package's landing pages are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. Only `_index.md` is required; `installation-configuration.md` is an optional split for packages whose install and config content outgrows the overview — see [The Overview page](./overview-page.md). If you're previewing a package that isn't in the registry yet, create that directory and copy `_index.md` into it from your provider repo's `docs/` folder. `resourcedocsgen docs` doesn't write these pages — `resourcedocsgen metadata from-urls` fetches them from the provider repo, and the publish workflow is what runs it.
 
 1. Serve the site:
 

--- a/docs/previewing-registry-changes.md
+++ b/docs/previewing-registry-changes.md
@@ -1,19 +1,17 @@
 # Previewing Registry Changes
 
-This guide covers how to see Pulumi Registry pages — including provider API docs — before they are published, whether the change lives in a provider's schema, in this repository's templates, or in a pull request.
+Registry pages are generated from provider schemas and from this repository's templates, so a change to either isn't visible until it's published. You can render the affected pages locally first, or have a preview site built from a pull request.
 
-Pick a route based on what you changed:
+Pick the section that matches what you changed:
 
-| What you changed | Route |
-|---|---|
-| A provider schema you have locally, and it isn't released yet | [Local preview from a schema file](#local-preview-from-a-schema-file) |
-| A package that is already published in the registry (templates, layouts, CSS, metadata) | [Local preview of a published package](#local-preview-of-a-published-package) |
-| A provider schema you can publish to a public URL (e.g. a branch on GitHub) | [Local preview from a branch schema](#local-preview-from-a-branch-schema) |
-| Anything you're ready to push to `pulumi/registry` | [Pull request preview](#pull-request-preview) |
+- [Local preview from a schema file](#local-preview-from-a-schema-file) — a provider schema you have on disk that isn't released yet.
+- [Local preview of a published package](#local-preview-of-a-published-package) — a package already in the registry: a docs template, a Hugo layout, the theme, or a package's YAML metadata.
+- [Local preview from a branch schema](#local-preview-from-a-branch-schema) — a provider schema you can put at a public URL, such as a branch on GitHub.
+- [Pull request preview](#pull-request-preview) — anything you're ready to push to `pulumi/registry`.
 
 ## Prerequisites
 
-All local routes assume you've set the repository up once:
+The local sections below assume you've set the repository up once:
 
 ```bash
 mise trust && mise install
@@ -23,11 +21,9 @@ make build-assets
 
 See [the README](../README.md#using-this-repository) for details.
 
-Generated docs land in git-ignored directories (`content/` and `static/registry/` at the repository root), so nothing from these routes should ever end up in a commit.
-
 ## Local preview from a schema file
 
-Use this when you're changing a provider and want to see how its API docs will render before you cut a release. It reads a `schema.json` straight off your disk, so nothing needs to be pushed or published.
+Use this when you're changing a provider and want to see how its API docs will render before you cut a release.
 
 1. Build the docs generator:
 
@@ -35,7 +31,7 @@ Use this when you're changing a provider and want to see how its API docs will r
     make bin/resourcedocsgen
     ```
 
-1. Generate your provider's schema in the provider repo. For a bridged provider that's usually `make generate_schema`, which writes `provider/cmd/pulumi-resource-<name>/schema.json`.
+1. Generate your provider's schema in the provider repo. For a bridged provider that's usually `make schema`, which writes `provider/cmd/pulumi-resource-<name>/schema.json`.
 
 1. From the root of this repository, run `resourcedocsgen docs` against that file, writing into the two locations Hugo serves from:
 
@@ -49,7 +45,9 @@ Use this when you're changing a provider and want to see how its API docs will r
 
     `--version` is required and must be valid semver. Use a dummy version higher than anything published so it's obvious in the rendered page that you're looking at a local build.
 
-1. The package's landing pages are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. Only `_index.md` is required; `installation-configuration.md` is an optional split for packages whose install and config content outgrows the overview — see [The Overview page](./overview-page.md). If you're previewing a package that isn't in the registry yet, create that directory and copy `_index.md` into it from your provider repo's `docs/` folder. `resourcedocsgen docs` doesn't write these pages — `resourcedocsgen metadata from-urls` fetches them from the provider repo, and the publish workflow is what runs it.
+    Both output directories are git-ignored, so nothing you generate here can end up in a commit.
+
+1. The package's landing pages are committed under `themes/default/content/registry/packages/<package>/` and are used as-is. Only `_index.md` is required; `installation-configuration.md` is an optional split for packages whose install and config content outgrows the overview — see [The Overview page](./overview-page.md) and [Publishing packages](https://www.pulumi.com/docs/iac/guides/building-extending/packages/publishing-packages/#overview-installation--configuration). If you're previewing a package that isn't in the registry yet, create that directory and copy `_index.md` into it from your provider repo's `docs/` folder. `resourcedocsgen docs` doesn't write these pages — `resourcedocsgen metadata from-urls` fetches them from the provider repo, and the publish workflow is what runs it.
 
 1. Serve the site:
 
@@ -70,14 +68,19 @@ make SKIP_VERSIONED_DOCS=1 api-docs/aws
 make serve
 ```
 
-`make api-docs/<package>` reads `themes/default/data/registry/packages/<package>.yaml`, fetches the corresponding schema, and writes to `content/registry/packages/<package>/` at the repository root.
+`make api-docs/<package>` reads `themes/default/data/registry/packages/<package>.yaml`, fetches the corresponding schema, and writes to `content/registry/packages/<package>/` at the repository root, which is git-ignored. `make serve` then serves the whole site as usual, so the package lands at `http://localhost:1313/registry/packages/<package>/` — see [Troubleshooting](#troubleshooting) if that port doesn't answer.
 
 `SKIP_VERSIONED_DOCS=1` skips generating the older-major-version snapshots, which requires a Pulumi-internal tool that most contributors can't install. Leave it set unless you are specifically working on versioned docs.
 
-To force a rebuild after a change the generator can't see (it caches on the package YAML and its own build), delete the sentinel file:
+### Forcing a rebuild
+
+`resourcedocsgen` caches on the package YAML plus its own build identity, recorded in a `.generated` file next to the output. A schema that changed behind an unchanged `schema_file_url` therefore looks fresh to it, and it logs `Skipping (output is fresh)` instead of regenerating.
+
+`make -B` does not help here: the Make target's sentinel is an intermediate file that Make deletes after each run, so the recipe already re-runs every time and the skip happens inside the generator. Delete the sentinel and re-run:
 
 ```bash
 rm content/registry/packages/aws/api-docs/.generated
+make SKIP_VERSIONED_DOCS=1 api-docs/aws
 ```
 
 ## Local preview from a branch schema
@@ -104,22 +107,22 @@ Revert the YAML edit before committing.
 
 ## Pull request preview
 
-Every pull request against `pulumi/registry` gets a full site build published to a per-commit S3 bucket. CI maintains a single pinned comment on the PR containing:
+A pull request whose branch lives in `pulumi/registry` gets a full site build published to a per-commit S3 bucket. CI maintains a single pinned comment on the PR containing:
 
 - the preview URL for the current commit, and
 - a **Changed pages** list linking directly to the pages your PR affects.
 
 The comment is updated in place on each build rather than added per commit, and the preview buckets are deleted when the PR closes.
 
-If your change is in a provider repo rather than here, you can still get a preview by opening a PR against this repository with the [branch schema](#local-preview-from-a-branch-schema) edits applied — the same YAML change works in CI. Don't merge that PR; it exists to produce the preview.
+**Pull requests from forks don't get this automatically.** The preview job only runs for branches pushed to this repository, so if you're contributing from a fork, use the local sections above. A Pulumi maintainer can build you one on demand by commenting `/preview` on the pull request.
 
-For a community package pull request, a Pulumi maintainer can comment `/preview` to build a live preview of the package's pages.
+If your change is in a provider repo rather than here, you can still get a preview by opening a PR against this repository with the [branch schema](#local-preview-from-a-branch-schema) edits applied — the same YAML change works in CI. Don't merge that PR; it exists to produce the preview.
 
 ## Troubleshooting
 
 **`registry-mirror-discover ... Repository not found`** — `make api-docs/<package>` tried to build the versioned-docs tool, which lives in a Pulumi-internal repository. Re-run with `SKIP_VERSIONED_DOCS=1`.
 
-**`Skipping (output is fresh)` and your changes don't appear** — the generator caches on the package YAML plus its own build identity, so a change to a remote schema alone won't invalidate it. Delete `content/registry/packages/<package>/api-docs/.generated` and re-run.
+**`Skipping (output is fresh)` and your changes don't appear** — see [Forcing a rebuild](#forcing-a-rebuild).
 
 **Pages 404 in the local server** — check that the nav tree JSON was written to `static/registry/packages/navs/<package>.json` and that `themes/default/content/registry/packages/<package>/_index.md` exists. The API docs pages hang off that landing page.
 


### PR DESCRIPTION
Makes the internal "Preview registry changes" playbook public, split into two guides because it was mixing two unrelated jobs: previewing a package release before publishing it, and checking a change to this repository against packages already published.

- `docs/previewing-package-docs.md` — for package authors. Renders a schema on disk, stages a whole release locally, and gets a shareable preview.
- `docs/previewing-registry-changes.md` — for contributors here. Generates one package to work against, and covers the PR preview build.

Both open with the sources a registry page is assembled from, including how-to guides — which anyone can contribute here by pull request without owning the provider, and which the publish pipeline never overwrites.

## Changes

- Two guides, each pointing at the other, written in the style of `pulumi/docs`.
- `api-docs/<pkg>` now honors `SKIP_VERSIONED_DOCS`, matching the bulk target. Without it the target fails on a fresh checkout: `generate-versioned-docs.sh` installs `registry-mirror-discover` from the private `pulumi/registry-mirror-tools` ahead of the `is_blessed` filter that would skip it. CI is unaffected.
- README's single-package command pointed at the internal `.make/` sentinel path; switched to the `make api-docs/<pkg>` alias.

## Corrections found while verifying

Three claims in the first draft were wrong, each checked against a Hugo build:

- A missing nav JSON empties the sidebar rather than 404ing the page — it's fetched client-side and the error is swallowed.
- A missing `_index.md` costs the Overview page; the API docs still render.
- A `how-to-guides/` directory needs its own `_index.md`, or the guide renders with no section page and no sidebar entry. The original instructions would have produced an invisible guide.

Also verified that a file in the git-ignored root `content/` overrides the committed copy of the same page, which is what makes staging an entire release locally possible — schema output, Overview, install-config, and guides together, without touching a tracked file.

**One suggestion I did not take:** `make -B` in place of deleting `.generated`. The target's sentinel is an intermediate file Make deletes after each run, so the recipe already re-runs and the skip happens inside `resourcedocsgen`. Verified: `make -B SKIP_VERSIONED_DOCS=1 api-docs/random` still logs `Skipping (output is fresh)`.

Left out deliberately: consolidating with `docs/adding-a-new-package.md`. Adding a package and previewing a change are different jobs; a single source of truth deserves its own pass. Also filed the case for sourcing a provider's whole `docs/` folder on #3391 rather than acting on it here.

`make lint-markdown` passes. Since it only scans `themes/default/content`, I also checked every bash block with `bash -n` and verified all links and anchors resolve.

Fixes #11638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrrKUFU2J8AnQx5qX44Ma5
