### PR TITLE
[test] Smoke-test the fork Sentinel reporter (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To add a community package, open a pull request that adds a single entry to [`co
 
 A **dynamically bridged** Terraform provider is different: if you consume it with `pulumi package add terraform-provider <name>` and there is no provider repo or committed schema, it cannot be added by pull request, because those are listed through a separate Pulumi pipeline. Open a ["New Package"](https://github.com/pulumi/registry/issues/new?template=new-package.yml) issue to request one. Use the same issue to request a package you don't maintain, or to discuss before opening a PR.
 
-For assistance, please reach out on the [Pulumi community Slack](https://slack.pulumi.com/) or get in touch with us via this [contact form](https://pulumi.com/contact/?form=registry).
+For assistance, please reach out on the [Pulumi community Slack](https://slack.pulumi.com/) or get in touch via this [contact form](https://pulumi.com/contact/?form=registry).
 
 ### Adding a Pulumi Package that you have authored
 


### PR DESCRIPTION
Throwaway fork PR to verify that #12160 actually lets a fork PR reach a `Sentinel` verdict. Will be closed once the result is in — do not merge.

What it exercises:

- Opened from `borisschlosser/registry`, so `Sentinel Tower` in `pull-request.yml` is skipped (head repo != base repo) and the `Sentinel` status must come from `sentinel-fork.yml` instead.
- Touches only `README.md`, so the reporter's CI-path guard (`.github/`, `scripts/ci/`, `Makefile`) does not fire.
- Once the `Pull request` run concludes `success`, `Sentinel for fork pull requests` should resolve this PR by head sha against the open PR list (the #12160 fix) and write `Sentinel` on the head commit.

Success looks like: `gh api repos/pulumi/registry/commits/<head>/status` lists a `Sentinel` context with state `success`, and this PR leaves `mergeStateStatus: BLOCKED`.

Context: #12158 added the reporter, #12160 fixed the PR lookup that made it fail on every fork run, and #12144 was the fork PR that stayed blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9GnMyEUo5uzMAmBqRK9K4