### PR TITLE
[TEST - DO NOT MERGE] CI test fixture for #12307

### DIFF
--- a/TEST-DELETE-ME-outside-allowlist.md
+++ b/TEST-DELETE-ME-outside-allowlist.md
@@ -1,0 +1,1 @@
+This file exists to prove the community package check refuses a PR that touches anything outside the allowlist. Delete me.

--- a/community-packages/package-list.json
+++ b/community-packages/package-list.json
@@ -403,6 +403,10 @@
     {
       "repoSlug": "shirasakaren/pulumi-biznetgio",
       "schemaFile": "provider/cmd/pulumi-resource-biznetgio/schema.json"
+    },
+    {
+      "repoSlug": "incsteps/pulumi-provider-multipass",
+      "schemaFile": "schema.json"
     }
   ]
 }

--- a/tools/resourcedocsgen/pkg/publishers/publisher-names.json
+++ b/tools/resourcedocsgen/pkg/publishers/publisher-names.json
@@ -163,5 +163,6 @@
     "volcenginecc": "volcenginecc",
     "vmware": "vmware",
     "wavefront": "wavefront",
-    "zenduty": "zenduty"
+    "zenduty": "zenduty",
+    "Incremental Steps": "incsteps"
 }


### PR DESCRIPTION
**This is a test fixture, not a contribution. Do not merge and do not review.**

It reproduces the exact two-file diff of #12177 so that the reworked community package check in #12307 can be dispatched against a pull request we own, instead of a contributor's.

Expected result once #12307's workflow runs here:

- the fact-sheet arrives with no `workflow_run` event, posted by the check's own second job
- `publisher listed` passes, because `fetch-pr` now copies `publisher-names.json` from the head
- `schema version` passes, because the `v` is stripped from both sides
- `docs generate` fails on the absent `docs/_index.md` upstream, and says so on the first line instead of showing the tail of a Go stack trace

I will close this once #12307 is verified.