### PR TITLE
[registry] Probe the Java SDK, and say which SDKs the check probes

### DIFF
--- a/scripts/ci/community-package/fact_sheet.py
+++ b/scripts/ci/community-package/fact_sheet.py
@@ -7,6 +7,12 @@ from models import Manifest
 _RESULT_ICON = {"pass": "✅", "fail": "❌", "absent": "➖", "rejected": "🚫"}
 
 
+def _english_list(items: list[str]) -> str:
+    if len(items) == 1:
+        return items[0]
+    return ", ".join(items[:-1]) + " and " + items[-1]
+
+
 def _run_link() -> str | None:
     run_id = os.environ.get("GITHUB_RUN_ID")
     if not run_id:
@@ -96,6 +102,12 @@ def render(manifest: Manifest) -> str:
     if manifest.schemaVersion:
         lines.append(f"| schema version | {'✅' if manifest.schemaVersionMatches else '❌'} "
                      f"| `{manifest.schemaVersion}` in `{manifest.schemaFile}` |")
+    probed = [r.language for r in manifest.installMatrix
+              if r.language != "plugin" and r.result in ("pass", "fail")]
+    if probed:
+        lines += ["", "The check resolves an SDK only when the schema names where to find it, so "
+                      f"it probed {_english_list(probed)}. A `➖` row means the schema advertises "
+                      "that SDK but carries no coordinate to look up."]
     lines += ["", f"Owner `{manifest.owner}`"]
 
     if manifest.publisher and not manifest.publisherKnown:

--- a/scripts/ci/community-package/sdk_install_probe.py
+++ b/scripts/ci/community-package/sdk_install_probe.py
@@ -47,6 +47,26 @@ def _python_resolves(package: str, version: str) -> tuple[bool, str]:
     return False, err
 
 
+SAFE_COORDINATE = re.compile(r"^[A-Za-z0-9._-]+$")
+MAVEN_CENTRAL = "https://repo1.maven.org/maven2"
+
+
+def _maven_artifact_exists(base_package: str, artifact: str, version: str) -> tuple[bool, str]:
+    group = base_package.replace(".", "/")
+    url = f"{MAVEN_CENTRAL}/{group}/{artifact}/{version}/"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            if resp.status == 200:
+                return True, ""
+    except urllib.error.HTTPError as e:
+        return False, (f"{url} returned {e.code}. The schema advertises a Java SDK at "
+                       f"{base_package}:{artifact}, but Maven Central does not carry that version. "
+                       "Publish it there, or drop the `java` block from the schema.")
+    except urllib.error.URLError as e:
+        return False, f"could not reach Maven Central: {e.reason}"
+    return False, f"{url} did not return 200"
+
+
 def _go_module_resolves(import_path: str, tag: str) -> tuple[bool, str]:
     with tempfile.TemporaryDirectory() as td:
         ok, err = _run(["go", "mod", "init", "probe"], cwd=td)
@@ -108,5 +128,15 @@ def probe_installs(name: str, tag: str, schema: dict[str, Any]) -> list[InstallR
 
     go_import = languages.get("go", {}).get("importBasePath")
     probe("go", go_import, lambda: _go_module_resolves(go_import, tag), f"go get {go_import}@{tag}")
+
+    base_package = (languages.get("java") or {}).get("basePackage") or ""
+    if base_package and SAFE_COORDINATE.match(base_package) and SAFE_COORDINATE.match(name):
+        ok, error = _maven_artifact_exists(base_package, name, version)
+        record("java", f"{base_package}:{name}:{version} on Maven Central", ok, error)
+    elif base_package:
+        results.append(InstallResult("java", "(rejected: unsafe coordinate)", "rejected"))
+
+    if "csharp" in languages:
+        results.append(InstallResult("dotnet", "(no package id in the schema to check)", "absent"))
 
     return results

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -844,3 +844,75 @@ class SweepFailureIssueTests(unittest.TestCase):
     def test_a_pull_request_is_never_mistaken_for_the_issue(self) -> None:
         pr = {"number": 6, "body": comment_commands.SWEEP_FAILURE_MARKER, "pull_request": {}}
         self.assertEqual(len(self._alert([pr])), 1)
+
+
+class JavaProbeTests(unittest.TestCase):
+    def _probe(self, schema: dict[str, Any], exists: bool = True) -> list[InstallResult]:
+        seen: list[str] = []
+
+        def fake(base: str, artifact: str, version: str) -> tuple[bool, str]:
+            seen.append(f"{base}:{artifact}:{version}")
+            return (True, "") if exists else (False, "404")
+
+        with patch.object(sdk_install_probe, "_maven_artifact_exists", fake), \
+             patch.object(sdk_install_probe, "_run", lambda *a, **k: (True, "")), \
+             patch.object(sdk_install_probe, "_python_resolves", lambda *a: (True, "")), \
+             patch.object(sdk_install_probe, "_go_module_resolves", lambda *a: (True, "")):
+            results = sdk_install_probe.probe_installs("ovh", "v2.19.1", schema)
+        self.seen = seen
+        return results
+
+    def _row(self, results: list[InstallResult], language: str) -> InstallResult | None:
+        return next((r for r in results if r.language == language), None)
+
+    def test_a_declared_base_package_is_looked_up_on_maven_central(self) -> None:
+        results = self._probe({"name": "ovh", "language": {"java": {"basePackage": "com.ovhcloud.pulumi"}}})
+        self.assertEqual(self.seen, ["com.ovhcloud.pulumi:ovh:2.19.1"])
+        row = self._row(results, "java")
+        self.assertIsNotNone(row)
+        self.assertEqual(row.result if row else "", "pass")
+        self.assertFalse(row.blocking if row else True)
+
+    def test_an_unpublished_java_sdk_fails_without_blocking(self) -> None:
+        results = self._probe({"name": "ovh", "language": {"java": {"basePackage": "com.pulumiverse"}}},
+                              exists=False)
+        row = self._row(results, "java")
+        self.assertEqual(row.result if row else "", "fail")
+        self.assertFalse(row.blocking if row else True)
+
+    def test_an_empty_base_package_is_not_probed(self) -> None:
+        results = self._probe({"name": "ovh", "language": {"java": {"basePackage": ""}}})
+        self.assertEqual(self.seen, [])
+        self.assertIsNone(self._row(results, "java"))
+
+    def test_a_crafted_base_package_is_rejected_without_a_request(self) -> None:
+        results = self._probe({"name": "ovh", "language": {"java": {"basePackage": "com.x/../etc"}}})
+        self.assertEqual(self.seen, [])
+        self.assertEqual((self._row(results, "java") or InstallResult("", "", "pass")).result, "rejected")
+
+
+class DotnetRowTests(unittest.TestCase):
+    def _results(self, languages: dict[str, Any]) -> list[InstallResult]:
+        with patch.object(sdk_install_probe, "_run", lambda *a, **k: (True, "")):
+            return sdk_install_probe.probe_installs("demo", "v1.0.0", {"name": "demo", "language": languages})
+
+    def test_a_declared_dotnet_sdk_is_shown_as_untestable(self) -> None:
+        row = next(r for r in self._results({"csharp": {"respectSchemaVersion": True}})
+                   if r.language == "dotnet")
+        self.assertEqual(row.result, "absent")
+        self.assertIn("no package id", row.command)
+
+    def test_no_dotnet_row_when_the_schema_does_not_declare_it(self) -> None:
+        self.assertNotIn("dotnet", [r.language for r in self._results({})])
+
+
+class ProbedLanguagesNoteTests(unittest.TestCase):
+    def test_the_sheet_names_what_it_probed(self) -> None:
+        sheet = fact_sheet.render(_manifest(installs=[
+            InstallResult("plugin", "pulumi plugin install", "pass", blocking=True),
+            InstallResult("nodejs", "npm install x", "pass"),
+            InstallResult("java", "a:b:1 on Maven Central", "fail"),
+            InstallResult("dotnet", "(no package id in the schema to check)", "absent"),
+        ]))
+        self.assertIn("it probed nodejs and java", sheet)
+        self.assertIn("carries no coordinate", sheet)


### PR DESCRIPTION
A contributor asked on [#12279](https://github.com/pulumi/registry/pull/12279#issuecomment-5480101118) whether the .NET and Java SDKs are tested. They are not, and the fact-sheet does not say so, so silence reads as a pass.

Java is now probed. The schema names the coordinate in `java.basePackage`, the same as `nodejs.packageName`, `python.packageName` and `go.importBasePath`, so the check reads `basePackage:name:version` from Maven Central over plain HTTP. Nothing is executed. The row is advisory, like every SDK row except `plugin install`.

.NET is not probed, and the sheet now says why. The schema carries no NuGet id. `matthiashamacher/pulumi-ohdear` publishes `Matthiashamacher.Ohdear` while its schema holds only `{"respectSchemaVersion": true}`, and `checkly` publishes `Pulumi.Checkly` while `pulumiverse/pulumi-time` publishes `Pulumiverse.Time`. No rule derives all three, so any guess would fail a correctly published package. When the schema declares `csharp`, the sheet shows a `➖` row that says there is no id to check. When it does not, there is no row.

Of the 101 community packages, 24 declare `java` with a `basePackage`. Four resolve on Maven Central and twenty do not, which is the point of the check: those twenty advertise a Java SDK they do not publish at that version. `com.ovhcloud.pulumi:ovh` published `0.48.7` once and the provider is now at `v2.19.1`. `com.pulumiverse` has no artifacts at all, and `pulumiverse/pulumi-time` has Java commented out of its release matrix. The fix for a contributor is to publish the SDK or to drop the `java` block from the schema, and the failure message says both.

This changes nothing for packages already in the registry. `check-publish` runs no install probes, so only a new submission or a `/check` re-run sees these rows.

## Test plan

- 99 unit tests and `mypy --strict` in `scripts/ci/community-package/`
- `_maven_artifact_exists` against the live Maven Central: `com.pulumi:aws:6.66.2` resolves, `com.pulumiverse:time:0.1.1` and `com.ovhcloud.pulumi:ovh:2.19.1` do not
- The full sweep of the package list reported above, run against the live API and Maven Central
- A rendered fact-sheet for `ohdear` shows the `➖` dotnet row and the line naming what was probed