### PR TITLE
Match registry search against package name and keywords

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,6 +81,12 @@ jobs:
           sheets=("${RUNNER_TEMP}"/factsheets/*.factsheet.md)
           [ ${#sheets[@]} -eq 0 ] && exit 0
           cat "${sheets[@]}" > "${RUNNER_TEMP}/comment.md"
+          # GitHub rejects a comment body over 65536 characters.
+          if [ "$(wc -c < "${RUNNER_TEMP}/comment.md")" -gt 60000 ]; then
+            head -c 60000 "${RUNNER_TEMP}/comment.md" > "${RUNNER_TEMP}/truncated.md"
+            printf '\n\n_Truncated: this PR publishes %d packages. The full fact-sheets are in the "Check published packages" job log._\n' "${#sheets[@]}" >> "${RUNNER_TEMP}/truncated.md"
+            mv "${RUNNER_TEMP}/truncated.md" "${RUNNER_TEMP}/comment.md"
+          fi
           gh pr comment "$PR" --edit-last --create-if-none --body-file "${RUNNER_TEMP}/comment.md"
 
   resourcedocsgen:

--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -42,4 +42,51 @@ describe("www.pulumi.com/registry", () => {
             cy.get(".docs-main-nav").should("have.attr", "style").and("match", /height:\s*\d+px/);
         });
     });
+
+    describe("package list filter", () => {
+        beforeEach(() => {
+            cy.visit("/registry/");
+        });
+
+        const filterBy = (query) => {
+            cy.get(".registry-filter-input").clear().type(query);
+            // The search component debounces its event. The random package matches
+            // none of the queries below, so wait until it is hidden before asserting
+            // on the result.
+            cy.get(".all-packages .package.hidden [data-name='random']").should("exist");
+        };
+
+        const expectShown = (name) => {
+            cy.get(`.all-packages .package:not(.hidden) [data-name='${name}']`).should("exist");
+        };
+
+        it("matches the package name", () => {
+            filterBy("scm");
+            expectShown("scm");
+        });
+
+        it("matches every token against the package keywords", () => {
+            filterBy("palo alto");
+            expectShown("scm");
+            filterBy("alto palo");
+            expectShown("scm");
+        });
+
+        it("matches the title after the native hack strips the word", () => {
+            filterBy("native aws");
+            expectShown("aws-native");
+            expectShown("aws");
+        });
+
+        it("treats amazon as a synonym for aws", () => {
+            filterBy("amazon");
+            expectShown("aws");
+            expectShown("eks");
+        });
+
+        it("hides every package when nothing matches", () => {
+            filterBy("no-such-package");
+            cy.get(".all-packages .package:not(.hidden)").should("have.length", 0);
+        });
+    });
 });

--- a/docs/adding-a-new-package.md
+++ b/docs/adding-a-new-package.md
@@ -64,3 +64,9 @@ When a community member requests adding a provider to the registry, a Pulumi sta
 In pulumi/docs, a [scheduled task](https://github.com/pulumi/docs/actions/workflows/update-theme.yml) runs hourly and will pick up any changes in this repo, generate files from the provider schema and `data/registry/${PROVIDER}.yaml`, and publish to pulumi.com.
 
   This scheduled task currently lacks adequate monitoring, and **should be watched to ensure that it runs correctly to completion**. (If it fails, it will block all updates to pulumi.com, including marketing and manually maintained docs pages.)
+
+## Search keywords
+
+The filter box on the registry index page matches a package by its title, its name, and its keywords. The keywords come from the `keywords` field of the provider schema. `resourcedocsgen` copies them into `themes/default/data/registry/packages/<name>.yaml`, without the `pulumi` keyword and without tags such as `category/network` or `kind/native`.
+
+To make a package findable by a new term, add the term to the `keywords` field in the provider schema and release a new version. The next metadata publish picks it up. Do not edit the package YAML file by hand.

--- a/themes/default/data/registry/packages/acme.yaml
+++ b/themes/default/data/registry/packages/acme.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing ACME cloud resources.
 featured: false
+keywords:
+- acme
 logo_url: ""
 name: acme
 native: false

--- a/themes/default/data/registry/packages/aiven.yaml
+++ b/themes/default/data/registry/packages/aiven.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Aiven cloud resources.
 featured: false
+keywords:
+- aiven
 logo_url: ""
 name: aiven
 native: false

--- a/themes/default/data/registry/packages/akamai.yaml
+++ b/themes/default/data/registry/packages/akamai.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing akamai cloud resources.
 featured: false
+keywords:
+- akamai
 logo_url: ""
 name: akamai
 native: false

--- a/themes/default/data/registry/packages/alicloud.yaml
+++ b/themes/default/data/registry/packages/alicloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing AliCloud resources.
 featured: false
+keywords:
+- alicloud
 logo_url: ""
 name: alicloud
 native: false

--- a/themes/default/data/registry/packages/argocd.yaml
+++ b/themes/default/data/registry/packages/argocd.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Argo CD resources.
 featured: false
+keywords:
+- argocd
 logo_url: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 name: argocd
 native: false

--- a/themes/default/data/registry/packages/artifactory.yaml
+++ b/themes/default/data/registry/packages/artifactory.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing artifactory cloud resources.
 featured: false
+keywords:
+- artifactory
 logo_url: ""
 name: artifactory
 native: false

--- a/themes/default/data/registry/packages/auth0.yaml
+++ b/themes/default/data/registry/packages/auth0.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing auth0 cloud resources.
 featured: false
+keywords:
+- auth0
 logo_url: ""
 name: auth0
 native: false

--- a/themes/default/data/registry/packages/aws-apigateway.yaml
+++ b/themes/default/data/registry/packages/aws-apigateway.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: true
 description: Pulumi Amazon Web Services (AWS) API Gateway Components.
 featured: false
+keywords:
+- aws
+- apigateway
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png
 name: aws-apigateway
 native: false

--- a/themes/default/data/registry/packages/aws-native.yaml
+++ b/themes/default/data/registry/packages/aws-native.yaml
@@ -5,6 +5,11 @@ component: false
 description: A native Pulumi package for creating and managing Amazon Web Services
   (AWS) resources.
 featured: false
+keywords:
+- aws
+- aws-native
+- cloud control
+- ccapi
 logo_url: ""
 name: aws-native
 native: true

--- a/themes/default/data/registry/packages/aws.yaml
+++ b/themes/default/data/registry/packages/aws.yaml
@@ -5,6 +5,8 @@ component: false
 description: A Pulumi package for creating and managing Amazon Web Services (AWS)
   cloud resources.
 featured: true
+keywords:
+- aws
 logo_url: ""
 name: aws
 native: false

--- a/themes/default/data/registry/packages/awsx.yaml
+++ b/themes/default/data/registry/packages/awsx.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: true
 description: Pulumi Amazon Web Services (AWS) AWSX Components.
 featured: false
+keywords:
+- aws
+- awsx
 logo_url: ""
 name: awsx
 native: false

--- a/themes/default/data/registry/packages/azapi.yaml
+++ b/themes/default/data/registry/packages/azapi.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Azapi resources
 featured: false
+keywords:
+- azapi
 logo_url: ""
 name: azapi
 native: false

--- a/themes/default/data/registry/packages/azure-justrun.yaml
+++ b/themes/default/data/registry/packages/azure-justrun.yaml
@@ -4,6 +4,11 @@ category: Cloud
 component: true
 description: Provides some simple components to run azure apps
 featured: false
+keywords:
+- azure
+- containerapps
+- appservice
+- web
 logo_url: ""
 name: azure-justrun
 native: false

--- a/themes/default/data/registry/packages/azure-native.yaml
+++ b/themes/default/data/registry/packages/azure-native.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A native Pulumi package for creating and managing Azure resources.
 featured: true
+keywords:
+- azure
+- azure-native
 logo_url: ""
 name: azure-native
 native: true

--- a/themes/default/data/registry/packages/azure.yaml
+++ b/themes/default/data/registry/packages/azure.yaml
@@ -7,6 +7,8 @@ description: A Pulumi package for creating and managing Microsoft Azure cloud re
   to provision Azure infrastructure. Azure Native provides complete coverage of Azure
   resources and same-day access to new resources and resource updates.
 featured: false
+keywords:
+- azure
 logo_url: ""
 name: azure
 native: false

--- a/themes/default/data/registry/packages/azuread.yaml
+++ b/themes/default/data/registry/packages/azuread.yaml
@@ -5,6 +5,8 @@ component: false
 description: A Pulumi package for creating and managing Azure Active Directory (Azure
   AD) cloud resources.
 featured: false
+keywords:
+- azuread
 logo_url: ""
 name: azuread
 native: false

--- a/themes/default/data/registry/packages/azuredevops.yaml
+++ b/themes/default/data/registry/packages/azuredevops.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Azure DevOps.
 featured: false
+keywords:
+- azuredevops
 logo_url: ""
 name: azuredevops
 native: false

--- a/themes/default/data/registry/packages/biznetgio.yaml
+++ b/themes/default/data/registry/packages/biznetgio.yaml
@@ -5,6 +5,11 @@ component: false
 description: Unofficial Pulumi provider for Biznet GIO cloud by Shirasaka Ren - NEO
   Metal, NEO Lite/Lite Pro, NEO GPU, and Object Storage.
 featured: false
+keywords:
+- biznetgio
+- cloud
+- indonesia
+- neo
 logo_url: https://raw.githubusercontent.com/shirasakaren/pulumi-biznetgio/main/assets/logo.png
 name: biznetgio
 native: true

--- a/themes/default/data/registry/packages/buildkite.yaml
+++ b/themes/default/data/registry/packages/buildkite.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Buildkite resources.
 featured: false
+keywords:
+- buildkite
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-buildkite/main/assets/buildkite-logo.png
 name: buildkite
 native: false

--- a/themes/default/data/registry/packages/bytepluscc.yaml
+++ b/themes/default/data/registry/packages/bytepluscc.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package to safely use byteplus Resource in Pulumi programs.
 featured: false
+keywords:
+- byteplus
+- bytepluscc
 logo_url: https://avatars.githubusercontent.com/u/67365215
 name: bytepluscc
 native: false

--- a/themes/default/data/registry/packages/castai.yaml
+++ b/themes/default/data/registry/packages/castai.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing CAST AI cloud resources.
 featured: false
+keywords:
+- castai
+- kubernetes
 logo_url: https://raw.githubusercontent.com/castai/pulumi-castai/main/docs/images/castai-logo.png
 name: castai
 native: false

--- a/themes/default/data/registry/packages/checkly.yaml
+++ b/themes/default/data/registry/packages/checkly.yaml
@@ -4,6 +4,8 @@ category: Monitoring
 component: false
 description: A Pulumi package for creating and managing Checkly monitoring resources.
 featured: false
+keywords:
+- checkly
 logo_url: https://raw.githubusercontent.com/checkly/pulumi-checkly/main/assets/checkly.png
 name: checkly
 native: false

--- a/themes/default/data/registry/packages/chronosphere.yaml
+++ b/themes/default/data/registry/packages/chronosphere.yaml
@@ -4,6 +4,10 @@ category: Cloud
 component: false
 description: Chronosphere Pulumi Provider
 featured: false
+keywords:
+- chronosphere
+- observability
+- prometheus
 logo_url: ""
 name: chronosphere
 native: false

--- a/themes/default/data/registry/packages/cilium.yaml
+++ b/themes/default/data/registry/packages/cilium.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing Cilium resources
 featured: false
+keywords:
+- cilium
 logo_url: https://raw.githubusercontent.com/littlejo/pulumi-cilium/main/docs/cilium.png
 name: cilium
 native: false

--- a/themes/default/data/registry/packages/clickhouse.yaml
+++ b/themes/default/data/registry/packages/clickhouse.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Clickhouse Cloud resources
 featured: false
+keywords:
+- clickhouse
 logo_url: https://avatars3.githubusercontent.com/ClickHouse
 name: clickhouse
 native: false

--- a/themes/default/data/registry/packages/cloudamqp.yaml
+++ b/themes/default/data/registry/packages/cloudamqp.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing CloudAMQP resources.
 featured: false
+keywords:
+- cloudamqp
 logo_url: ""
 name: cloudamqp
 native: false

--- a/themes/default/data/registry/packages/cloudflare.yaml
+++ b/themes/default/data/registry/packages/cloudflare.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing Cloudflare cloud resources.
 featured: false
+keywords:
+- cloudflare
 logo_url: ""
 name: cloudflare
 native: false

--- a/themes/default/data/registry/packages/cloudinit.yaml
+++ b/themes/default/data/registry/packages/cloudinit.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for creating and managing cloudinit cloud resources.
 featured: false
+keywords:
+- cloudinit
 logo_url: ""
 name: cloudinit
 native: false

--- a/themes/default/data/registry/packages/cloudngfwaws.yaml
+++ b/themes/default/data/registry/packages/cloudngfwaws.yaml
@@ -4,6 +4,10 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing Cloud NGFW for AWS resources.
 featured: false
+keywords:
+- cloudngfwaws
+- Palo Alto Networks
+- ngfw
 logo_url: https://avatars.githubusercontent.com/u/4855743?s=200&v=4
 name: cloudngfwaws
 native: false

--- a/themes/default/data/registry/packages/cockroach.yaml
+++ b/themes/default/data/registry/packages/cockroach.yaml
@@ -5,6 +5,9 @@ component: false
 description: A Pulumi package to create and managed Cockroach DB resources in Pulumi
   programs.
 featured: false
+keywords:
+- cockroach
+- pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-cockroach/main/assets/logo.png
 name: cockroach
 native: false

--- a/themes/default/data/registry/packages/command.yaml
+++ b/themes/default/data/registry/packages/command.yaml
@@ -5,6 +5,8 @@ component: false
 description: The Pulumi Command Provider enables you to execute commands and scripts
   either locally or remotely as part of the Pulumi resource model.
 featured: false
+keywords:
+- command
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-command/master/assets/logo.svg
 name: command
 native: true

--- a/themes/default/data/registry/packages/confluentcloud.yaml
+++ b/themes/default/data/registry/packages/confluentcloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Confluent cloud resources.
 featured: false
+keywords:
+- confluentcloud
 logo_url: ""
 name: confluentcloud
 native: false

--- a/themes/default/data/registry/packages/consul.yaml
+++ b/themes/default/data/registry/packages/consul.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing consul resources.
 featured: false
+keywords:
+- consul
 logo_url: ""
 name: consul
 native: false

--- a/themes/default/data/registry/packages/coreweave.yaml
+++ b/themes/default/data/registry/packages/coreweave.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing CoreWeave cloud resources.
 featured: false
+keywords:
+- coreweave
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-coreweave/main/docs/logo.png
 name: coreweave
 native: false

--- a/themes/default/data/registry/packages/cpln.yaml
+++ b/themes/default/data/registry/packages/cpln.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Control Plane (cpln) resources.
 featured: false
+keywords:
+- cpln
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-cpln/main/docs/logo.png
 name: cpln
 native: false

--- a/themes/default/data/registry/packages/cratedb.yaml
+++ b/themes/default/data/registry/packages/cratedb.yaml
@@ -4,6 +4,8 @@ category: Database
 component: false
 description: A Pulumi package for creating and managing CrateDB resources.
 featured: false
+keywords:
+- cratedb
 logo_url: https://avatars.githubusercontent.com/u/4048232?s=48&v=4
 name: cratedb
 native: false

--- a/themes/default/data/registry/packages/crowdstrike.yaml
+++ b/themes/default/data/registry/packages/crowdstrike.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing CrowdStrike resources
 featured: false
+keywords:
+- crowdstrike
 logo_url: https://raw.githubusercontent.com/crowdstrike/pulumi-crowdstrike/main/docs/crowdstrike.png
 name: crowdstrike
 native: false

--- a/themes/default/data/registry/packages/ctfd.yaml
+++ b/themes/default/data/registry/packages/ctfd.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: The CTFd provider for Pulumi, to manage its resources as code.
 featured: false
+keywords:
+- ctfd
 logo_url: https://raw.githubusercontent.com/ctfer-io/pulumi-ctfd/main/res/ctfd.png
 name: ctfd
 native: false

--- a/themes/default/data/registry/packages/danubedata.yaml
+++ b/themes/default/data/registry/packages/danubedata.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi provider for managing DanubeData cloud infrastructure resources.
 featured: false
+keywords:
+- danubedata
 logo_url: ""
 name: danubedata
 native: true

--- a/themes/default/data/registry/packages/databricks.yaml
+++ b/themes/default/data/registry/packages/databricks.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing databricks cloud resources.
 featured: false
+keywords:
+- databricks
 logo_url: ""
 name: databricks
 native: false

--- a/themes/default/data/registry/packages/datadog.yaml
+++ b/themes/default/data/registry/packages/datadog.yaml
@@ -4,6 +4,8 @@ category: Monitoring
 component: false
 description: A Pulumi package for creating and managing Datadog resources.
 featured: false
+keywords:
+- datadog
 logo_url: ""
 name: datadog
 native: false

--- a/themes/default/data/registry/packages/datarobot.yaml
+++ b/themes/default/data/registry/packages/datarobot.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing DataRobot resources.
 featured: false
+keywords:
+- datarobot
+- ai
 logo_url: https://raw.githubusercontent.com/datarobot-community/pulumi-datarobot/main/assets/datarobot-logo.png
 name: datarobot
 native: false

--- a/themes/default/data/registry/packages/dbtcloud.yaml
+++ b/themes/default/data/registry/packages/dbtcloud.yaml
@@ -4,6 +4,10 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing dbt Cloud resources.
 featured: false
+keywords:
+- dbtcloud
+- dbt
+- cloud
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-dbtcloud/main/res/dbt-bit_tm.png
 name: dbtcloud
 native: false

--- a/themes/default/data/registry/packages/defang-aws.yaml
+++ b/themes/default/data/registry/packages/defang-aws.yaml
@@ -5,6 +5,13 @@ component: false
 description: Deploy Compose projects to AWS with Pulumi. Part of the Defang multi-cloud
   provider family — also available for GCP (defang-gcp) and Azure (defang-azure).
 featured: false
+keywords:
+- defang
+- docker
+- cloud
+- aws
+- ecs
+- fargate
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
 name: defang-aws
 native: true

--- a/themes/default/data/registry/packages/defang-azure.yaml
+++ b/themes/default/data/registry/packages/defang-azure.yaml
@@ -5,6 +5,12 @@ component: false
 description: Deploy Compose projects to Azure with Pulumi. Part of the Defang multi-cloud
   provider family — also available for AWS (defang-aws) and GCP (defang-gcp).
 featured: false
+keywords:
+- defang
+- docker
+- cloud
+- azure
+- containerapp
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
 name: defang-azure
 native: true

--- a/themes/default/data/registry/packages/defang-gcp.yaml
+++ b/themes/default/data/registry/packages/defang-gcp.yaml
@@ -5,6 +5,12 @@ component: false
 description: Deploy Compose projects to GCP with Pulumi. Part of the Defang multi-cloud
   provider family — also available for AWS (defang-aws) and Azure (defang-azure).
 featured: false
+keywords:
+- defang
+- docker
+- cloud
+- gcp
+- cloudrun
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
 name: defang-gcp
 native: true

--- a/themes/default/data/registry/packages/defang.yaml
+++ b/themes/default/data/registry/packages/defang.yaml
@@ -9,6 +9,16 @@ description: |-
   - [`defang-gcp`](/registry/packages/defang-gcp/): Deploy containerized services to GCP.
   - [`defang-azure`](/registry/packages/defang-azure/): Deploy containerized services to Azure.
 featured: false
+keywords:
+- categoryinfrastructure
+- defang
+- docker
+- docker compose
+- cloud
+- aws
+- azure
+- gcp
+- digital ocean
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.svg
 name: defang
 native: true

--- a/themes/default/data/registry/packages/descope.yaml
+++ b/themes/default/data/registry/packages/descope.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing descope cloud resources.
 featured: false
+keywords:
+- descope
 logo_url: https://avatars3.githubusercontent.com/descope
 name: descope
 native: false

--- a/themes/default/data/registry/packages/digitalocean.yaml
+++ b/themes/default/data/registry/packages/digitalocean.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing DigitalOcean cloud resources.
 featured: false
+keywords:
+- digitalocean
 logo_url: ""
 name: digitalocean
 native: false

--- a/themes/default/data/registry/packages/dnsimple.yaml
+++ b/themes/default/data/registry/packages/dnsimple.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing dnsimple cloud resources.
 featured: false
+keywords:
+- dnsimple
 logo_url: ""
 name: dnsimple
 native: false

--- a/themes/default/data/registry/packages/docker-build.yaml
+++ b/themes/default/data/registry/packages/docker-build.yaml
@@ -4,6 +4,10 @@ category: Cloud
 component: false
 description: A Pulumi provider for building modern Docker images with buildx and BuildKit.
 featured: false
+keywords:
+- docker
+- buildkit
+- buildx
 logo_url: ""
 name: docker-build
 native: true

--- a/themes/default/data/registry/packages/docker.yaml
+++ b/themes/default/data/registry/packages/docker.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for interacting with Docker in Pulumi programs
 featured: false
+keywords:
+- docker
 logo_url: ""
 name: docker
 native: false

--- a/themes/default/data/registry/packages/dynatrace.yaml
+++ b/themes/default/data/registry/packages/dynatrace.yaml
@@ -4,6 +4,9 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Dynatrace cloud resources.
 featured: false
+keywords:
+- dynatrace
+- pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-dynatrace/master/assets/logo.png
 name: dynatrace
 native: false

--- a/themes/default/data/registry/packages/ec.yaml
+++ b/themes/default/data/registry/packages/ec.yaml
@@ -4,6 +4,12 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing ElasticCloud resources.
 featured: false
+keywords:
+- ec
+- elasticsearch
+- es
+- elastic
+- elasticcloud
 logo_url: ""
 name: ec
 native: false

--- a/themes/default/data/registry/packages/eks.yaml
+++ b/themes/default/data/registry/packages/eks.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: true
 description: Pulumi Amazon Web Services (AWS) EKS Components.
 featured: false
+keywords:
+- aws
+- eks
 logo_url: ""
 name: eks
 native: false

--- a/themes/default/data/registry/packages/equinix.yaml
+++ b/themes/default/data/registry/packages/equinix.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing equinix cloud resources.
 featured: false
+keywords:
+- equinix
 logo_url: https://raw.githubusercontent.com/equinix/pulumi-equinix/main/assets/logo.png
 name: equinix
 native: false

--- a/themes/default/data/registry/packages/eventstorecloud.yaml
+++ b/themes/default/data/registry/packages/eventstorecloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Event Store Cloud resources.
 featured: false
+keywords:
+- eventstorecloud
 logo_url: ""
 name: eventstorecloud
 native: false

--- a/themes/default/data/registry/packages/exoscale.yaml
+++ b/themes/default/data/registry/packages/exoscale.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing exoscale cloud resources.
 featured: false
+keywords:
+- exoscale
 logo_url: ""
 name: exoscale
 native: false

--- a/themes/default/data/registry/packages/f5bigip.yaml
+++ b/themes/default/data/registry/packages/f5bigip.yaml
@@ -4,6 +4,9 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing F5 BigIP resources.
 featured: false
+keywords:
+- f5
+- bigip
 logo_url: ""
 name: f5bigip
 native: false

--- a/themes/default/data/registry/packages/fastly.yaml
+++ b/themes/default/data/registry/packages/fastly.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing fastly cloud resources.
 featured: false
+keywords:
+- fastly
 logo_url: ""
 name: fastly
 native: false

--- a/themes/default/data/registry/packages/formal.yaml
+++ b/themes/default/data/registry/packages/formal.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Formal resources.
 featured: false
+keywords:
+- formal
 logo_url: https://avatars3.githubusercontent.com/formalco
 name: formal
 native: false

--- a/themes/default/data/registry/packages/fortios.yaml
+++ b/themes/default/data/registry/packages/fortios.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Fortios resources
 featured: false
+keywords:
+- fortios
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-fortios/main/docs/fortios.png
 name: fortios
 native: false

--- a/themes/default/data/registry/packages/fusionauth.yaml
+++ b/themes/default/data/registry/packages/fusionauth.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for managing FusionAuth instances.
 featured: false
+keywords:
+- fusionauth
 logo_url: https://avatars.githubusercontent.com/u/41974756?s=200&v=4
 name: fusionauth
 native: false

--- a/themes/default/data/registry/packages/gandi.yaml
+++ b/themes/default/data/registry/packages/gandi.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing gandi cloud resources.
 featured: false
+keywords:
+- gandi
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-gandi/main/logo.svg
 name: gandi
 native: false

--- a/themes/default/data/registry/packages/gcp.yaml
+++ b/themes/default/data/registry/packages/gcp.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Google Cloud Platform resources.
 featured: true
+keywords:
+- gcp
 logo_url: ""
 name: gcp
 native: false

--- a/themes/default/data/registry/packages/genesiscloud.yaml
+++ b/themes/default/data/registry/packages/genesiscloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing genesiscloud cloud resources.
 featured: false
+keywords:
+- genesiscloud
 logo_url: https://avatars.githubusercontent.com/u/38134186?s=200&v=4
 name: genesiscloud
 native: false

--- a/themes/default/data/registry/packages/github.yaml
+++ b/themes/default/data/registry/packages/github.yaml
@@ -4,6 +4,8 @@ category: Version Control System
 component: false
 description: A Pulumi package for creating and managing github cloud resources.
 featured: false
+keywords:
+- github
 logo_url: ""
 name: github
 native: false

--- a/themes/default/data/registry/packages/gitlab.yaml
+++ b/themes/default/data/registry/packages/gitlab.yaml
@@ -4,6 +4,8 @@ category: Version Control System
 component: false
 description: A Pulumi package for creating and managing GitLab resources.
 featured: false
+keywords:
+- gitlab
 logo_url: ""
 name: gitlab
 native: false

--- a/themes/default/data/registry/packages/grafana.yaml
+++ b/themes/default/data/registry/packages/grafana.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing grafana.
 featured: false
+keywords:
+- grafana
+- pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-grafana/main/assets/grafana.png
 name: grafana
 native: false

--- a/themes/default/data/registry/packages/harbor.yaml
+++ b/themes/default/data/registry/packages/harbor.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for creating and managing Harbor resources.
 featured: false
+keywords:
+- harbor
 logo_url: ""
 name: harbor
 native: false

--- a/themes/default/data/registry/packages/harness.yaml
+++ b/themes/default/data/registry/packages/harness.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Harness  resources.
 featured: false
+keywords:
+- harness
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-harness/main/assets/logo.png
 name: harness
 native: false

--- a/themes/default/data/registry/packages/hcloud.yaml
+++ b/themes/default/data/registry/packages/hcloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing hcloud cloud resources.
 featured: false
+keywords:
+- hcloud
 logo_url: ""
 name: hcloud
 native: false

--- a/themes/default/data/registry/packages/heroku.yaml
+++ b/themes/default/data/registry/packages/heroku.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing heroku cloud resources.
 featured: false
+keywords:
+- heroku
 logo_url: ""
 name: heroku
 native: false

--- a/themes/default/data/registry/packages/impart.yaml
+++ b/themes/default/data/registry/packages/impart.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Impart resources.
 featured: false
+keywords:
+- impart
 logo_url: https://console.impartsecurity.net/logomark-brand-background.png
 name: impart
 native: false

--- a/themes/default/data/registry/packages/influxdb.yaml
+++ b/themes/default/data/registry/packages/influxdb.yaml
@@ -4,6 +4,8 @@ category: Database
 component: false
 description: A Pulumi package for creating and managing InfluxDB resources.
 featured: false
+keywords:
+- influxdb
 logo_url: https://avatars.githubusercontent.com/u/5713248?s=200&v=4
 name: influxdb
 native: false

--- a/themes/default/data/registry/packages/influxdb3.yaml
+++ b/themes/default/data/registry/packages/influxdb3.yaml
@@ -4,6 +4,8 @@ category: Database
 component: false
 description: A Pulumi package for creating and managing InfluxDB V3 resources.
 featured: false
+keywords:
+- influxdb3
 logo_url: https://avatars.githubusercontent.com/u/5713248?s=200&v=4
 name: influxdb3
 native: false

--- a/themes/default/data/registry/packages/ionoscloud.yaml
+++ b/themes/default/data/registry/packages/ionoscloud.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing ionoscloud cloud resources.
 featured: false
+keywords:
+- ionos-cloud
+- ionoscloud
 logo_url: https://raw.githubusercontent.com/ionos-cloud/pulumi-ionoscloud/refs/heads/main/.github/LOGO_IONOS_Blue_RGB.png
 name: ionoscloud
 native: false

--- a/themes/default/data/registry/packages/ise.yaml
+++ b/themes/default/data/registry/packages/ise.yaml
@@ -5,6 +5,8 @@ component: false
 description: A Pulumi package for managing resources on a Cisco ISE (Identity Service
   Engine) instance.
 featured: false
+keywords:
+- ise
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-ise/main/docs/ise.png
 name: ise
 native: false

--- a/themes/default/data/registry/packages/junipermist.yaml
+++ b/themes/default/data/registry/packages/junipermist.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Juniper Mist resources.
 featured: false
+keywords:
+- juniper
+- mist
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-junipermist/main/res/juniper.png
 name: junipermist
 native: false

--- a/themes/default/data/registry/packages/kafka-connect.yaml
+++ b/themes/default/data/registry/packages/kafka-connect.yaml
@@ -4,6 +4,9 @@ category: Utility
 component: false
 description: A Pulumi native provider for Kafka Connect
 featured: false
+keywords:
+- kafka
+- kafkaconnect
 logo_url: https://raw.githubusercontent.com/azaurus1/pulumi-kafka-connect/refs/heads/main/.github/images/kafka-logo.png
 name: kafka-connect
 native: true

--- a/themes/default/data/registry/packages/kafka.yaml
+++ b/themes/default/data/registry/packages/kafka.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Kafka.
 featured: false
+keywords:
+- kafka
 logo_url: ""
 name: kafka
 native: false

--- a/themes/default/data/registry/packages/keycloak.yaml
+++ b/themes/default/data/registry/packages/keycloak.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing keycloak cloud resources.
 featured: false
+keywords:
+- keycloak
 logo_url: ""
 name: keycloak
 native: false

--- a/themes/default/data/registry/packages/kong.yaml
+++ b/themes/default/data/registry/packages/kong.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Kong resources.
 featured: false
+keywords:
+- kong
 logo_url: ""
 name: kong
 native: false

--- a/themes/default/data/registry/packages/koyeb.yaml
+++ b/themes/default/data/registry/packages/koyeb.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing koyeb cloud resources.
 featured: false
+keywords:
+- koyeb
 logo_url: ""
 name: koyeb
 native: false

--- a/themes/default/data/registry/packages/kubernetes-cert-manager.yaml
+++ b/themes/default/data/registry/packages/kubernetes-cert-manager.yaml
@@ -4,6 +4,9 @@ category: Infrastructure
 component: true
 description: Strongly-typed Cert Manager installation
 featured: false
+keywords:
+- kubernetes
+- cert-manager
 logo_url: ""
 name: kubernetes-cert-manager
 native: false

--- a/themes/default/data/registry/packages/kubernetes-coredns.yaml
+++ b/themes/default/data/registry/packages/kubernetes-coredns.yaml
@@ -4,6 +4,9 @@ category: Infrastructure
 component: true
 description: Strongly-typed CoreDNS installation
 featured: false
+keywords:
+- kubernetes
+- coredns
 logo_url: ""
 name: kubernetes-coredns
 native: false

--- a/themes/default/data/registry/packages/kubernetes-ingress-nginx.yaml
+++ b/themes/default/data/registry/packages/kubernetes-ingress-nginx.yaml
@@ -4,6 +4,9 @@ category: Infrastructure
 component: true
 description: Strongly-typed NGINX Ingress Controller installation
 featured: false
+keywords:
+- kubernetes
+- nginx
 logo_url: ""
 name: kubernetes-ingress-nginx
 native: false

--- a/themes/default/data/registry/packages/kubernetes.yaml
+++ b/themes/default/data/registry/packages/kubernetes.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Kubernetes resources.
 featured: true
+keywords:
+- kubernetes
 logo_url: ""
 name: kubernetes
 native: true

--- a/themes/default/data/registry/packages/lbrlabs-eks.yaml
+++ b/themes/default/data/registry/packages/lbrlabs-eks.yaml
@@ -4,6 +4,11 @@ category: Cloud
 component: true
 description: A batteries included EKS cluster following best practices.
 featured: false
+keywords:
+- eks
+- kubernetes
+- aws
+- lbrlabs
 logo_url: https://raw.githubusercontent.com/lbrlabs/pulumi-lbrlabs-eks/main/assets/amazon-eks.png
 name: lbrlabs-eks
 native: false

--- a/themes/default/data/registry/packages/linode.yaml
+++ b/themes/default/data/registry/packages/linode.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing linode cloud resources.
 featured: false
+keywords:
+- linode
 logo_url: ""
 name: linode
 native: false

--- a/themes/default/data/registry/packages/logfire.yaml
+++ b/themes/default/data/registry/packages/logfire.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing logfire cloud resources.
 featured: false
+keywords:
+- logfire
 logo_url: https://avatars.githubusercontent.com/u/110818415?s=200&v=4
 name: logfire
 native: false

--- a/themes/default/data/registry/packages/mailgun.yaml
+++ b/themes/default/data/registry/packages/mailgun.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Mailgun resources.
 featured: false
+keywords:
+- mailgun
 logo_url: ""
 name: mailgun
 native: false

--- a/themes/default/data/registry/packages/matchbox.yaml
+++ b/themes/default/data/registry/packages/matchbox.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing the Matchbox iPXE server.
 featured: false
+keywords:
+- matchbox
 logo_url: ""
 name: matchbox
 native: false

--- a/themes/default/data/registry/packages/meraki.yaml
+++ b/themes/default/data/registry/packages/meraki.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing Cisco Meraki resources
 featured: false
+keywords:
+- meraki
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-meraki/assets/assets/meraki.png
 name: meraki
 native: false

--- a/themes/default/data/registry/packages/minio.yaml
+++ b/themes/default/data/registry/packages/minio.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing minio cloud resources.
 featured: false
+keywords:
+- minio
 logo_url: ""
 name: minio
 native: false

--- a/themes/default/data/registry/packages/mongodbatlas.yaml
+++ b/themes/default/data/registry/packages/mongodbatlas.yaml
@@ -4,6 +4,8 @@ category: Database
 component: false
 description: A Pulumi package for creating and managing mongodbatlas cloud resources.
 featured: false
+keywords:
+- mongodbatlas
 logo_url: ""
 name: mongodbatlas
 native: false

--- a/themes/default/data/registry/packages/mysql.yaml
+++ b/themes/default/data/registry/packages/mysql.yaml
@@ -4,6 +4,8 @@ category: Database
 component: false
 description: A Pulumi package for creating and managing mysql cloud resources.
 featured: false
+keywords:
+- mysql
 logo_url: ""
 name: mysql
 native: false

--- a/themes/default/data/registry/packages/netskope-publisher.yaml
+++ b/themes/default/data/registry/packages/netskope-publisher.yaml
@@ -8,6 +8,35 @@ description: Pulumi components for provisioning Netskope Private Access Publishe
   Equinix Metal, Outscale, OpenTelekomCloud, TencentCloud, Yandex, and experimental
   Hyper-V.
 featured: false
+keywords:
+- netskope
+- npa
+- publisher
+- aws
+- azure
+- gcp
+- kubernetes
+- vsphere
+- esxi
+- hcloud
+- nutanix
+- openstack
+- ovh
+- scaleway
+- oci
+- alicloud
+- proxmoxve
+- proxmox
+- digitalocean
+- vultr
+- exoscale
+- upcloud
+- stackit
+- equinix
+- outscale
+- opentelekomcloud
+- tencentcloud
+- yandex
 logo_url: https://raw.githubusercontent.com/johnneerdael/pulumi-netskope-publisher/main/site/source/images/netskope-logo.png
 name: netskope-publisher
 native: false

--- a/themes/default/data/registry/packages/newrelic.yaml
+++ b/themes/default/data/registry/packages/newrelic.yaml
@@ -4,6 +4,8 @@ category: Monitoring
 component: false
 description: A Pulumi package for creating and managing New Relic resources.
 featured: false
+keywords:
+- new relic
 logo_url: ""
 name: newrelic
 native: false

--- a/themes/default/data/registry/packages/nomad.yaml
+++ b/themes/default/data/registry/packages/nomad.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing nomad cloud resources.
 featured: false
+keywords:
+- nomad
 logo_url: ""
 name: nomad
 native: false

--- a/themes/default/data/registry/packages/ns1.yaml
+++ b/themes/default/data/registry/packages/ns1.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing ns1 cloud resources.
 featured: false
+keywords:
+- ns1
 logo_url: ""
 name: ns1
 native: false

--- a/themes/default/data/registry/packages/nutanix.yaml
+++ b/themes/default/data/registry/packages/nutanix.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Nutanix cloud resources.
 featured: false
+keywords:
+- nutanix
 logo_url: https://raw.githubusercontent.com/pierskarsenbarg/pulumi-nutanix/main/docs/nutanix-logo.png
 name: nutanix
 native: false

--- a/themes/default/data/registry/packages/nvidia-aicr.yaml
+++ b/themes/default/data/registry/packages/nvidia-aicr.yaml
@@ -5,6 +5,11 @@ component: false
 description: Deploy validated NVIDIA AI Cluster Runtime (AICR) recipes for GPU-accelerated
   Kubernetes clusters.
 featured: false
+keywords:
+- nvidia
+- aicr
+- gpu
+- kubernetes
 logo_url: https://raw.githubusercontent.com/pulumi-labs/pulumi-nvidia-aicr/main/sdk/dotnet/logo.png
 name: nvidia-aicr
 native: true

--- a/themes/default/data/registry/packages/oci.yaml
+++ b/themes/default/data/registry/packages/oci.yaml
@@ -5,6 +5,9 @@ component: false
 description: A Pulumi package for creating and managing Oracle Cloud Infrastructure
   resources.
 featured: false
+keywords:
+- oci
+- oracle
 logo_url: ""
 name: oci
 native: false

--- a/themes/default/data/registry/packages/ohdear.yaml
+++ b/themes/default/data/registry/packages/ohdear.yaml
@@ -5,6 +5,11 @@ component: false
 description: 'A Pulumi provider for Oh Dear: manage monitors, status pages, tags,
   and notification destinations.'
 featured: false
+keywords:
+- ohdear
+- monitoring
+- uptime
+- status-page
 logo_url: https://raw.githubusercontent.com/matthiashamacher/pulumi-ohdear/main/assets/logo.png
 name: ohdear
 native: true

--- a/themes/default/data/registry/packages/okta.yaml
+++ b/themes/default/data/registry/packages/okta.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing okta resources.
 featured: false
+keywords:
+- okta
 logo_url: ""
 name: okta
 native: false

--- a/themes/default/data/registry/packages/openstack.yaml
+++ b/themes/default/data/registry/packages/openstack.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing OpenStack cloud resources.
 featured: false
+keywords:
+- openstack
 logo_url: ""
 name: openstack
 native: false

--- a/themes/default/data/registry/packages/opsgenie.yaml
+++ b/themes/default/data/registry/packages/opsgenie.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing opsgenie cloud resources.
 featured: false
+keywords:
+- opsgenie
 logo_url: ""
 name: opsgenie
 native: false

--- a/themes/default/data/registry/packages/ovh.yaml
+++ b/themes/default/data/registry/packages/ovh.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing OVH resources.
 featured: false
+keywords:
+- ovh
 logo_url: ""
 name: ovh
 native: false

--- a/themes/default/data/registry/packages/pagerduty.yaml
+++ b/themes/default/data/registry/packages/pagerduty.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing pagerduty cloud resources.
 featured: false
+keywords:
+- pagerduty
 logo_url: ""
 name: pagerduty
 native: false

--- a/themes/default/data/registry/packages/pgedge.yaml
+++ b/themes/default/data/registry/packages/pgedge.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing pgedge cloud resources.
 featured: false
+keywords:
+- pgedge
 logo_url: https://raw.githubusercontent.com/pgEdge/pulumi-pgedge/main/.github/images/logo.png
 name: pgedge
 native: false

--- a/themes/default/data/registry/packages/pinecone.yaml
+++ b/themes/default/data/registry/packages/pinecone.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for creating and managing Pinecone resources.
 featured: false
+keywords:
+- pinecone
 logo_url: ""
 name: pinecone
 native: true

--- a/themes/default/data/registry/packages/port.yaml
+++ b/themes/default/data/registry/packages/port.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for creating and managing Port resources.
 featured: false
+keywords:
+- port
 logo_url: ""
 name: port
 native: false

--- a/themes/default/data/registry/packages/postgresql.yaml
+++ b/themes/default/data/registry/packages/postgresql.yaml
@@ -4,6 +4,8 @@ category: Database
 component: false
 description: A Pulumi package for creating and managing postgresql cloud resources.
 featured: false
+keywords:
+- postgresql
 logo_url: ""
 name: postgresql
 native: false

--- a/themes/default/data/registry/packages/proxmoxve.yaml
+++ b/themes/default/data/registry/packages/proxmoxve.yaml
@@ -5,6 +5,9 @@ component: false
 description: A Pulumi package for creating and managing Proxmox Virtual Environment
   cloud resources.
 featured: false
+keywords:
+- proxmox
+- proxmoxve
 logo_url: https://raw.githubusercontent.com/muhlba91/pulumi-proxmoxve/main/assets/proxmox-logo.png
 name: proxmoxve
 native: false

--- a/themes/default/data/registry/packages/purrl.yaml
+++ b/themes/default/data/registry/packages/purrl.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi native provider for making API calls
 featured: false
+keywords:
+- command
 logo_url: ""
 name: purrl
 native: true

--- a/themes/default/data/registry/packages/rabbitmq.yaml
+++ b/themes/default/data/registry/packages/rabbitmq.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing RabbitMQ resources.
 featured: false
+keywords:
+- rabbitmq
 logo_url: ""
 name: rabbitmq
 native: false

--- a/themes/default/data/registry/packages/rancher2.yaml
+++ b/themes/default/data/registry/packages/rancher2.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing rancher2 resources.
 featured: false
+keywords:
+- rancher2
 logo_url: ""
 name: rancher2
 native: false

--- a/themes/default/data/registry/packages/random.yaml
+++ b/themes/default/data/registry/packages/random.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package to safely use randomness in Pulumi programs.
 featured: false
+keywords:
+- random
 logo_url: ""
 name: random
 native: false

--- a/themes/default/data/registry/packages/rediscloud.yaml
+++ b/themes/default/data/registry/packages/rediscloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing rediscloud cloud resources.
 featured: false
+keywords:
+- rediscloud
 logo_url: https://avatars.githubusercontent.com/u/1991868?s=200&v=4
 name: rediscloud
 native: false

--- a/themes/default/data/registry/packages/rootly.yaml
+++ b/themes/default/data/registry/packages/rootly.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing rootly cloud resources.
 featured: false
+keywords:
+- rootly
 logo_url: https://raw.githubusercontent.com/rootlyhq/pulumi-rootly/master/logos/rootly.svg
 name: rootly
 native: false

--- a/themes/default/data/registry/packages/runpod.yaml
+++ b/themes/default/data/registry/packages/runpod.yaml
@@ -5,6 +5,11 @@ component: false
 description: The Runpod Pulumi provider provides resources to interact with Runpod's
   native APIs.
 featured: false
+keywords:
+- runpod
+- gpus
+- ml
+- ai
 logo_url: https://avatars.githubusercontent.com/u/95939477?s=200&v=4
 name: runpod
 native: true

--- a/themes/default/data/registry/packages/scaleway.yaml
+++ b/themes/default/data/registry/packages/scaleway.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Scaleway cloud resources.
 featured: false
+keywords:
+- scaleway
+- pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-scaleway/master/assets/scaleway.png
 name: scaleway
 native: false

--- a/themes/default/data/registry/packages/scm.yaml
+++ b/themes/default/data/registry/packages/scm.yaml
@@ -4,6 +4,9 @@ category: Network
 component: false
 description: A Pulumi package for managing resources on Strata Cloud Manager.
 featured: false
+keywords:
+- scm
+- paloaltonetworks
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-scm/main/docs/logo.png
 name: scm
 native: false

--- a/themes/default/data/registry/packages/sdm.yaml
+++ b/themes/default/data/registry/packages/sdm.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing StrongDM cloud resources.
 featured: false
+keywords:
+- sdm
 logo_url: https://raw.githubusercontent.com/pierskarsenbarg/pulumi-sdm/main/docs/strongdm-logo.png
 name: sdm
 native: false

--- a/themes/default/data/registry/packages/sdwan.yaml
+++ b/themes/default/data/registry/packages/sdwan.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for managing resources on Cisco Catalyst SD-WAN.
 featured: false
+keywords:
+- sdwan
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-sdwan/main/docs/logo.png
 name: sdwan
 native: false

--- a/themes/default/data/registry/packages/sentry.yaml
+++ b/themes/default/data/registry/packages/sentry.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Sentry resources.
 featured: false
+keywords:
+- sentry
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-sentry/main/sentry.svg
 name: sentry
 native: false

--- a/themes/default/data/registry/packages/signalfx.yaml
+++ b/themes/default/data/registry/packages/signalfx.yaml
@@ -4,6 +4,8 @@ category: Monitoring
 component: false
 description: A Pulumi package for creating and managing SignalFx resources.
 featured: false
+keywords:
+- signalfx
 logo_url: ""
 name: signalfx
 native: false

--- a/themes/default/data/registry/packages/slack.yaml
+++ b/themes/default/data/registry/packages/slack.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for managing Slack workspaces.
 featured: false
+keywords:
+- slack
 logo_url: ""
 name: slack
 native: false

--- a/themes/default/data/registry/packages/snowflake.yaml
+++ b/themes/default/data/registry/packages/snowflake.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing snowflake cloud resources.
 featured: false
+keywords:
+- snowflake
 logo_url: ""
 name: snowflake
 native: false

--- a/themes/default/data/registry/packages/splight.yaml
+++ b/themes/default/data/registry/packages/splight.yaml
@@ -4,6 +4,10 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Splight resources.
 featured: false
+keywords:
+- splightplatform
+- splight
+- infrastructure
 logo_url: https://raw.githubusercontent.com/splightplatform/pulumi-splight/main/docs/logo.png
 name: splight
 native: false

--- a/themes/default/data/registry/packages/splunk.yaml
+++ b/themes/default/data/registry/packages/splunk.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing splunk cloud resources.
 featured: false
+keywords:
+- splunk
 logo_url: ""
 name: splunk
 native: false

--- a/themes/default/data/registry/packages/spotinst.yaml
+++ b/themes/default/data/registry/packages/spotinst.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing spotinst cloud resources.
 featured: false
+keywords:
+- spotinst
 logo_url: ""
 name: spotinst
 native: false

--- a/themes/default/data/registry/packages/stackit.yaml
+++ b/themes/default/data/registry/packages/stackit.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing stackit resources.
 featured: false
+keywords:
+- stackit
 logo_url: https://raw.githubusercontent.com/stackitcloud/pulumi-stackit/main/.github/images/stackit-logo.svg
 name: stackit
 native: false

--- a/themes/default/data/registry/packages/statsig.yaml
+++ b/themes/default/data/registry/packages/statsig.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Statsig resources.
 featured: false
+keywords:
+- statsig
 logo_url: https://statsig-aws-marketplace-asset.s3.us-west-1.amazonaws.com/statsig-logo.png
 name: statsig
 native: false

--- a/themes/default/data/registry/packages/statuscake.yaml
+++ b/themes/default/data/registry/packages/statuscake.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Statuscake resources.
 featured: false
+keywords:
+- statuscake
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-statuscake/main/statuscake.svg
 name: statuscake
 native: false

--- a/themes/default/data/registry/packages/synced-folder.yaml
+++ b/themes/default/data/registry/packages/synced-folder.yaml
@@ -5,6 +5,10 @@ component: true
 description: A Pulumi component that synchronizes a local folder to Amazon S3, Azure
   Blob Storage, or Google Cloud Storage.
 featured: false
+keywords:
+- aws
+- azure
+- gcp
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-synced-folder/main/assets/synced-folder.png
 name: synced-folder
 native: false

--- a/themes/default/data/registry/packages/tailscale.yaml
+++ b/themes/default/data/registry/packages/tailscale.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Tailscale cloud resources.
 featured: false
+keywords:
+- tailscale
 logo_url: ""
 name: tailscale
 native: false

--- a/themes/default/data/registry/packages/talos.yaml
+++ b/themes/default/data/registry/packages/talos.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Talos Linux machines and clusters.
 featured: false
+keywords:
+- talos
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-talos/refs/heads/main/assets/talos-logo.png
 name: talos
 native: false

--- a/themes/default/data/registry/packages/terraform-provider.yaml
+++ b/themes/default/data/registry/packages/terraform-provider.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: Use any Terraform provider with Pulumi
 featured: false
+keywords:
+- catagory/utility
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png
 name: terraform-provider
 native: true

--- a/themes/default/data/registry/packages/terraform.yaml
+++ b/themes/default/data/registry/packages/terraform.yaml
@@ -5,6 +5,8 @@ component: false
 description: The Terraform provider for Pulumi lets you consume the outputs contained
   in Terraform state from your Pulumi programs.
 featured: false
+keywords:
+- terraform
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png
 name: terraform
 native: true

--- a/themes/default/data/registry/packages/thoth.yaml
+++ b/themes/default/data/registry/packages/thoth.yaml
@@ -4,6 +4,11 @@ category: Utility
 component: false
 description: Pulumi provider for Aten Security Thoth AI governance control plane.
 featured: false
+keywords:
+- thoth
+- atensecurity
+- governance
+- ai
 logo_url: https://raw.githubusercontent.com/atensecurity/pulumi-thoth/main/docs/logo.png
 name: thoth
 native: false

--- a/themes/default/data/registry/packages/threefold.yaml
+++ b/themes/default/data/registry/packages/threefold.yaml
@@ -4,6 +4,9 @@ category: Infrastructure
 component: false
 description: The Pulumi Resource Provider for the Threefold Grid.
 featured: false
+keywords:
+- grid
+- threefold
 logo_url: https://www.threefold.io/images/black_threefold.png
 name: threefold
 native: true

--- a/themes/default/data/registry/packages/time.yaml
+++ b/themes/default/data/registry/packages/time.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for creating and managing Time resources
 featured: false
+keywords:
+- time
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-time/main/docs/clock-svgrepo-com.png
 name: time
 native: false

--- a/themes/default/data/registry/packages/tls.yaml
+++ b/themes/default/data/registry/packages/tls.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package to create TLS resources in Pulumi programs.
 featured: false
+keywords:
+- tls
 logo_url: ""
 name: tls
 native: false

--- a/themes/default/data/registry/packages/twingate.yaml
+++ b/themes/default/data/registry/packages/twingate.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing Twingate cloud resources.
 featured: false
+keywords:
+- twingate
 logo_url: https://raw.githubusercontent.com/Twingate/pulumi-twingate/main/docs/logo.png
 name: twingate
 native: false

--- a/themes/default/data/registry/packages/unifi.yaml
+++ b/themes/default/data/registry/packages/unifi.yaml
@@ -4,6 +4,8 @@ category: Network
 component: false
 description: A Pulumi package for creating and managing Unifi network resources.
 featured: false
+keywords:
+- unifi
 logo_url: ""
 name: unifi
 native: false

--- a/themes/default/data/registry/packages/upcloud.yaml
+++ b/themes/default/data/registry/packages/upcloud.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing UpCloud resources.
 featured: false
+keywords:
+- upcloud
 logo_url: https://raw.githubusercontent.com/UpCloudLtd/.github/refs/heads/main/profile/logo.png
 name: upcloud
 native: false

--- a/themes/default/data/registry/packages/upstash.yaml
+++ b/themes/default/data/registry/packages/upstash.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing upstash cloud resources.
 featured: false
+keywords:
+- upstash
 logo_url: https://upstash.com/static/logo/logo-light.svg
 name: upstash
 native: false

--- a/themes/default/data/registry/packages/vault.yaml
+++ b/themes/default/data/registry/packages/vault.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing HashiCorp Vault cloud resources.
 featured: false
+keywords:
+- vault
 logo_url: ""
 name: vault
 native: false

--- a/themes/default/data/registry/packages/venafi.yaml
+++ b/themes/default/data/registry/packages/venafi.yaml
@@ -4,6 +4,8 @@ category: Infrastructure
 component: false
 description: A Pulumi package for creating and managing venafi cloud resources.
 featured: false
+keywords:
+- venafi
 logo_url: ""
 name: venafi
 native: false

--- a/themes/default/data/registry/packages/vercel.yaml
+++ b/themes/default/data/registry/packages/vercel.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: ""
 featured: false
+keywords:
+- vercel
 logo_url: ""
 name: vercel
 native: false

--- a/themes/default/data/registry/packages/volcengine.yaml
+++ b/themes/default/data/registry/packages/volcengine.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing volcengine cloud resources.
 featured: false
+keywords:
+- volcengine
 logo_url: https://avatars.githubusercontent.com/u/67365215
 name: volcengine
 native: false

--- a/themes/default/data/registry/packages/volcenginecc.yaml
+++ b/themes/default/data/registry/packages/volcenginecc.yaml
@@ -4,6 +4,9 @@ category: Cloud
 component: false
 description: A Pulumi package to safely use volcengine resource in Pulumi programs.
 featured: false
+keywords:
+- volcengine
+- volcenginecc
 logo_url: https://avatars.githubusercontent.com/u/67365215
 name: volcenginecc
 native: false

--- a/themes/default/data/registry/packages/vsphere.yaml
+++ b/themes/default/data/registry/packages/vsphere.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating vsphere resources
 featured: false
+keywords:
+- vsphere
 logo_url: ""
 name: vsphere
 native: false

--- a/themes/default/data/registry/packages/vultr.yaml
+++ b/themes/default/data/registry/packages/vultr.yaml
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package for creating and managing Vultr cloud resources.
 featured: false
+keywords:
+- vultr
 logo_url: ""
 name: vultr
 native: false

--- a/themes/default/data/registry/packages/xenorchestra.yaml
+++ b/themes/default/data/registry/packages/xenorchestra.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing Xen Orchestra cloud resources.
 featured: false
+keywords:
+- xenorchestra
 logo_url: https://raw.githubusercontent.com/vatesfr/pulumi-xenorchestra/8c71624229d953d4fb7d4843d5483e53e21b9459/logo_xo.png
 name: xenorchestra
 native: false

--- a/themes/default/data/registry/packages/zitadel.yaml
+++ b/themes/default/data/registry/packages/zitadel.yaml
@@ -4,6 +4,8 @@ category: Cloud
 component: false
 description: A Pulumi package for creating and managing zitadel cloud resources.
 featured: false
+keywords:
+- zitadel
 logo_url: ""
 name: zitadel
 native: false

--- a/themes/default/data/registry/packages/zpa.yaml
+++ b/themes/default/data/registry/packages/zpa.yaml
@@ -5,6 +5,9 @@ component: false
 description: A Pulumi package for creating and managing Zscaler Private Access (ZPA)
   cloud resources.
 featured: false
+keywords:
+- zpa
+- zscaler
 logo_url: https://raw.githubusercontent.com/zscaler/pulumi-zpa/master/assets/zscaler.png
 name: zpa
 native: false

--- a/themes/default/layouts/partials/registry/package.html
+++ b/themes/default/layouts/partials/registry/package.html
@@ -15,6 +15,8 @@ $packageType := "provider" }} {{ $packageTypeName := "Provider" }} {{ if
                 data-type="{{ $packageType }}"
                 data-category="{{ $packageCategory }}"
                 data-title="{{ .package.title }}"
+                data-name="{{ $packageName }}"
+                data-keywords="{{ with .package.keywords }}{{ delimit . " " }}{{ end }}"
                 data-deprecated="{{ $isDeprecated }}"
             >
                 <div class="flex flex-wrap">

--- a/themes/default/theme/src/ts/packages.ts
+++ b/themes/default/theme/src/ts/packages.ts
@@ -33,11 +33,14 @@ const filterByTextAndTags = (filters, filterText) => {
                 packageIsDeprecated || !!filters.find(f => f.group === "type" && f.value === packageType) || (filters.find(f => f.group === "type" && f.value === "provider") && packageIsNative);
             const packageHasSelectedCategory = !!filters.find(f => f.group === "category" && f.value === packageCategory);
 
-            const packageTitle = el.getAttribute("data-title");
-            const downcasedPackageTitle = packageTitle.toLowerCase();
+            // Free text matches when every whitespace-separated token appears in the
+            // package title, name, or keywords.
+            const haystack = [
+                el.getAttribute("data-title"),
+                el.getAttribute("data-name"),
+                el.getAttribute("data-keywords"),
+            ].join(" ").toLowerCase();
             let downcasedFilterText = filterText?.trim().toLowerCase();
-
-            let packageIsAMatch;
 
             // hack to include anything marked as native as responsive to a filter text including the word "native"
             // see https://github.com/pulumi/registry/issues/5715 for reasoning
@@ -46,12 +49,13 @@ const filterByTextAndTags = (filters, filterText) => {
                 packageIsNative = true;
             }
 
+            let packageIsAMatch;
             if (downcasedFilterText === AMAZON_STRING || downcasedFilterText === AWS_STRING){
-                packageIsAMatch = downcasedPackageTitle.includes(AMAZON_STRING) || downcasedPackageTitle.includes(AWS_STRING);
+                packageIsAMatch = haystack.includes(AMAZON_STRING) || haystack.includes(AWS_STRING);
             } else if (downcasedFilterText === GOOGLE_CLOUD_STRING || downcasedFilterText === GCP_STRING || downcasedFilterText === GOOGLE_STRING){
-                packageIsAMatch = downcasedPackageTitle.includes(GOOGLE_CLOUD_STRING) || downcasedPackageTitle.includes(GCP_STRING) || downcasedPackageTitle.includes(GOOGLE_STRING);
+                packageIsAMatch = haystack.includes(GOOGLE_CLOUD_STRING) || haystack.includes(GCP_STRING) || haystack.includes(GOOGLE_STRING);
             } else {
-                packageIsAMatch = downcasedPackageTitle.includes(downcasedFilterText);
+                packageIsAMatch = downcasedFilterText.split(/\s+/).filter(Boolean).every(token => haystack.includes(token));
             }
 
             if ((packageHasSelectedType || noSelectedType) && (packageHasSelectedCategory || noSelectedCategory) && (!filterText || packageIsAMatch)) {

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -371,8 +371,24 @@ func writePackageMetadata(
 		Category:  category,
 		Component: component,
 		Featured:  isFeaturedPackage(spec.Name),
+		Keywords:  searchKeywords(spec.Keywords),
 		Native:    native,
 	}, metadataDir)
+}
+
+// searchKeywords returns the schema keywords that are search terms. The "pulumi"
+// keyword and tags such as "category/network" or "kind/native" are not.
+func searchKeywords(keywords []string) []string {
+	var result []string
+	for _, k := range keywords {
+		if strings.EqualFold(k, "pulumi") ||
+			strings.HasPrefix(k, "category/") ||
+			strings.HasPrefix(k, "kind/") {
+			continue
+		}
+		result = append(result, k)
+	}
+	return result
 }
 
 // legacyNameRuleException prevents the registry from rejecting previously acceptable

--- a/tools/resourcedocsgen/cmd/testdata/TestMetadataBridgedProvider/metadata/random.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMetadataBridgedProvider/metadata/random.yaml.golden
@@ -4,6 +4,8 @@ category: Utility
 component: false
 description: A Pulumi package to safely use randomness in Pulumi programs.
 featured: false
+keywords:
+- random
 logo_url: ""
 name: random
 native: false

--- a/tools/resourcedocsgen/cmd/testdata/TestMetadataComponentProvider/metadata/aws-apigateway.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMetadataComponentProvider/metadata/aws-apigateway.yaml.golden
@@ -4,6 +4,9 @@ category: Cloud
 component: true
 description: Pulumi Amazon Web Services (AWS) API Gateway Components.
 featured: false
+keywords:
+- aws
+- apigateway
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png
 name: aws-apigateway
 native: false

--- a/tools/resourcedocsgen/cmd/testdata/TestMetadataNativeProvider/metadata/command.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMetadataNativeProvider/metadata/command.yaml.golden
@@ -5,6 +5,8 @@ component: false
 description: The Pulumi Command Provider enables you to execute commands and scripts
   either locally or remotely as part of the Pulumi resource model.
 featured: false
+keywords:
+- command
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-command/master/assets/logo.svg
 name: command
 native: true

--- a/tools/resourcedocsgen/pkg/metadata.go
+++ b/tools/resourcedocsgen/pkg/metadata.go
@@ -68,6 +68,10 @@ type PackageMeta struct {
 	// a provider.
 	Component bool `json:"component"`
 
+	// Keywords are the search terms for the package. They come from the schema
+	// keywords, minus the "pulumi" keyword and the "category/" and "kind/" tags.
+	Keywords []string `json:"keywords,omitempty"`
+
 	// SchemaFilePath is the path to the package's schema file (json or yaml)
 	// relative to the root of that package's repo.
 	//


### PR DESCRIPTION
The filter box on the registry index page matched only the package title. Strata Cloud Manager was not found by `scm` or `palo alto`, although the schema declares those keywords.

Two commits:

1. **Match registry search against package name and keywords.**
   - `resourcedocsgen` copies the schema keywords into the package YAML as `keywords`, without `pulumi` and without `category/` and `kind/` tags.
   - The package card exposes `data-name` and `data-keywords`.
   - The filter splits the query on whitespace and requires every token to appear in the title, the name, or the keywords. `palo alto` matches `paloaltonetworks`.
   - `docs/adding-a-new-package.md` explains how to add search terms.
2. **Backfill package keywords from each schema.** Every package YAML with a `schema_file_url` gets the keywords the tool would emit, so the preview shows the new search across the whole registry. The output was checked byte for byte against `resourcedocsgen` for six packages.

The `prisma` term arrives with pulumi/pulumi-scm#606. The hard-coded AWS and GCP synonyms stay for now; #12346 tracks their removal.

Fixes #4902.
