### PR TITLE
Generate Overview page Installation and Configuration sections from the schema

### DIFF
--- a/docs/overview-page.md
+++ b/docs/overview-page.md
@@ -52,7 +52,7 @@ Keep it to a short paragraph. The detail goes in the sections below.
 
 Give the installation command for **each language the package supports**. A command is more useful than a link, because a reader can copy it and run it.
 
-Wrap them in the site's language chooser so a reader sees only the language they use. The chooser is a pair of Hugo shortcodes — `chooser` with angle-bracket delimiters, `choosable` with percent delimiters — and the language keys are `typescript`, `python`, `go`, `csharp`, `java`, `yaml` and `hcl`. List in the `chooser` tag only the languages your package actually supports:
+Wrap them in the site's language chooser so a reader sees only the language they use. The chooser is a pair of Hugo shortcodes — `chooser` with angle-bracket delimiters, `choosable` with percent delimiters — and the language keys are `typescript`, `python`, `go`, `csharp`, `java`, `yaml` and `hcl`. List all seven — a language you publish no SDK for still gets a tab, carrying `pulumi package add` (see the notes below):
 
 ````markdown
 ## Installation
@@ -114,28 +114,106 @@ pulumi package add your-package
 {{% /choosable %}}
 {{% choosable language hcl %}}
 
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    your-package = {
+      source  = "pulumi/your-package"
+      version = "1.2.3"
+    }
+  }
+}
+```
+
 ```bash
-pulumi package add your-package
+pulumi install
 ```
 
 {{% /choosable %}}
 {{< /chooser >}}
 ````
 
+`resourcedocsgen gen-install --schemaFile <your schema.json>` (experimental) generates this whole block from your schema. It cannot tell which SDKs you actually publish — that is not in the schema — so pass `--languages` to correct it, or `--languages none` if you publish none. Languages you leave out still get a tab showing `pulumi package add`.
+
 Notes:
 
 - **Mind the delimiters.** `{{< chooser >}}` and `{{< /chooser >}}` use angle brackets; `{{% choosable %}}` and `{{% /choosable %}}` use percent signs. Mixing them silently breaks the rendered page, and CI checks for it (`make lint-markdown` runs a malformed-delimiter check over published content).
-- **YAML and HCL use `pulumi package add`.** They consume the package directly rather than through a per-language SDK.
-- **If you publish no SDKs at all**, `pulumi package add` *is* your installation section — one command, and no chooser needed. Many bridged providers currently title this section "Generate Provider"; `## Installation` is the preferred heading.
+- **Give every language a tab, not only the ones you publish an SDK for.** A reader who picks C# and finds an empty panel has been told nothing. For a language with no published SDK, `pulumi package add <name>` generates one locally: it takes the SDK language from the `runtime` in the reader's `Pulumi.yaml`, records the package there, and prints the import line — so the command reads the same for every language. Run outside a project it needs `--language nodejs|python|go|dotnet|java`. (`pulumi package gen-sdk` is the lower-level form, writing an SDK to `./sdk` without recording it; show `add` unless you mean the difference.)
+- **YAML uses `pulumi package add`** for the same reason: it consumes the package directly rather than through a per-language SDK.
+- **HCL does not use `pulumi package add` at all.** An HCL program names the provider in its own `required_providers` block and `pulumi install` fetches it. A source prefixed with `pulumi/` resolves to the native Pulumi provider and must be pinned to an **exact** semver version, not a constraint; any other source is bridged from its Terraform provider, so a package that wraps one (`pulumi package add terraform-provider <ns>/<name>` elsewhere) uses that same upstream address here. See the [Pulumi HCL reference](https://www.pulumi.com/docs/iac/languages-sdks/hcl/hcl-language-reference/).
+- **If you publish no SDKs at all**, every tab still earns its place: the SDK languages and YAML share one `pulumi package add` command, and HCL differs. Many bridged providers currently title this section "Generate Provider"; `## Installation` is the preferred heading.
+- **Local SDK generation needs a `version` in your schema.** Without one, `pulumi package add` fails outright with `version must be provided when package supports packing`.
 - **Java has no one-line install command**, so give the Maven and Gradle dependency coordinates, as above.
 - **Links to package feeds** (npm, PyPI, NuGet, pkg.go.dev, Maven Central) are accepted, and many existing packages use them instead. Prefer commands; add links alongside them if you like.
-- **If your provider ships a plugin binary** users must install separately, give the `pulumi plugin install resource <name> <version> --server <url>` command here too.
+- **You almost certainly do not need a `pulumi plugin install` command.** If your schema sets `pluginDownloadURL`, that value is compiled into every SDK you publish and the engine downloads the plugin binary on first use. Give the `pulumi plugin install resource <name> <version> --server <url>` command only if you know a reader must run it by hand.
 
 ### `## Example Usage`
 
 Provide a **complete, minimal Pulumi program** — one that declares a single resource from your provider — **in every language you support**. It needs the imports and enough surrounding code to actually run. A bare resource declaration on its own is not enough.
 
-Alongside the program, give the **full configuration** needed to run it, as `pulumi config set` commands:
+Wrap the programs in the same language chooser the Installation section uses, so a reader sees only their own language rather than scrolling past five copies of the same program. Use the same language keys, and list only the languages you support:
+
+````markdown
+## Example Usage
+
+{{< chooser language "typescript,python,go" >}}
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as yourpackage from "@your-org/your-package";
+
+const example = new yourpackage.Widget("example", {size: "small"});
+
+export const widgetId = example.id;
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```python
+import pulumi
+import your_org_your_package as yourpackage
+
+example = yourpackage.Widget("example", size="small")
+
+pulumi.export("widgetId", example.id)
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"github.com/your-org/pulumi-your-package/sdk/go/yourpackage"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		example, err := yourpackage.NewWidget(ctx, "example", &yourpackage.WidgetArgs{
+			Size: pulumi.String("small"),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("widgetId", example.ID())
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
+````
+
+The delimiter rule from the Installation section applies here too: `{{< chooser >}}` takes angle brackets, `{{% choosable %}}` takes percent signs.
+
+Alongside the programs, give the **full configuration** needed to run them, as `pulumi config set` commands:
 
 ```bash
 pulumi config set --secret your-package:apiToken <your-token>
@@ -156,6 +234,24 @@ Document every configuration parameter the provider accepts. For each one give:
 - **Required?** — whether the provider works without it
 - **Secret?** — whether it should be set with `pulumi config set --secret`
 - **Description** — what it does and what a valid value looks like
+
+A bullet list is the preferred shape. It is what most existing packages use, and it keeps long descriptions readable where a table column squeezes them:
+
+```markdown
+- `apiToken` (Required, Secret) — The API token used to authenticate. May also be set with the `YOURPACKAGE_API_TOKEN` environment variable.
+- `region` (Optional) — The region to operate in, e.g. `us-east-1`. Defaults to `us-east-1`.
+```
+
+A table carrying the same four fields is equally acceptable, and gives requiredness and secrecy their own columns to scan:
+
+```markdown
+| Name | Required | Secret | Description |
+|---|---|---|---|
+| `apiToken` | Yes | Yes | The API token used to authenticate. May also be set with the `YOURPACKAGE_API_TOKEN` environment variable. |
+| `region` | No | No | The region to operate in, e.g. `us-east-1`. Defaults to `us-east-1`. |
+```
+
+`resourcedocsgen gen-config --schemaFile <your schema.json>` (experimental) generates either form from your schema's `config` block, as a starting point to edit. It emits the list by default; `--style table` selects the second.
 
 Two things routinely get missed here, because they are not derivable from your schema. Put them in the parameter descriptions:
 

--- a/tools/resourcedocsgen/README.md
+++ b/tools/resourcedocsgen/README.md
@@ -21,10 +21,11 @@ go build -o "${GOPATH}/bin/resourcedocsgen" .
 
 Then you can run any of the available commands using `resourcedocsgen <command> <flags>`. Run `resourcedocsgen --help` to see the available commands.
 
-As of this writing, the tool supports two main purposes:
+As of this writing, the tool supports three main purposes:
 
 * Generate the registry metadata
 * Generate API docs and the package nav tree
+* Generate Overview page snippets a package author pastes into their own `docs/_index.md`
 
 ### Generating package metadata
 
@@ -45,6 +46,29 @@ for a certain package (or all packages) within the registry repo for development
 
 For both of the above commands, the default location for generating the API docs is `content/registry/packages/<package name>/api-docs`
 and for the nav tree it is `static/registry/packages/navs/<package name>.json`.
+
+### Generating Overview page sections
+
+**These commands are experimental.** They are new, no CI depends on them, and their output shape and flags may change as we learn what package authors actually need. Nothing in the build calls them.
+
+Two sections of a package's Overview page — `## Installation` and the configuration parameters reference under `## Configuration`, both specified in [`docs/overview-page.md`](../../docs/overview-page.md) — are derivable from the package's schema. `gen-install` and `gen-config` derive them and print markdown to stdout.
+
+These commands are **advisory**. The Overview page is authored in the provider's own repository and fetched from its release tag by `metadata from-github`, so these generate a snippet to paste and edit, not a page. Point them at a local schema, or at the `schema_file_url` from a package's YAML in `themes/default/data/registry/packages/`:
+
+```bash
+resourcedocsgen gen-install --schemaFile provider/cmd/pulumi-resource-example/schema.json --version v1.2.3
+resourcedocsgen gen-config  --schemaFile provider/cmd/pulumi-resource-example/schema.json --style table
+```
+
+A schema cannot say which SDKs a package actually publishes: the `language` blob is written by the code generator, not by the release pipeline. `pulumi-vault` declares no `java` block yet publishes `com.pulumi/vault`, and the roughly hundred bridged providers that publish no SDKs at all still declare four or five language blocks. So `gen-install` guesses from the schema and takes `--languages` as the correction, including `--languages none` for a package whose installation section is a single `pulumi package add` command.
+
+Every one of the seven chooser languages gets a tab either way. A language with a published SDK gets its package-manager command; one without gets `pulumi package add <name>`, which generates an SDK locally, taking its language from the `runtime` in the reader's `Pulumi.yaml`. That is why the command reads identically for C#, Java and YAML on a package that publishes only TypeScript, Python and Go SDKs.
+
+HCL is the exception and never uses `pulumi package add`: its tab emits a `required_providers` block plus `pulumi install`. A native Pulumi provider is sourced as `pulumi/<name>` and pinned to an exact semver version; a package parameterized over a Terraform provider reuses that provider's upstream source and version instead. Because HCL always differs, the chooser is emitted even for a package with no SDKs at all.
+
+A parameterized provider is the one case the schema answers on its own — it is consumed as a local package, so the other tabs default to `pulumi package add terraform-provider <namespace>/<name>`.
+
+`gen-config` reads the schema's provider `config` block and emits a bullet list by default, matching what most existing Overview pages use; `--style table` emits a GFM table instead. Two things the standard requires cannot come from a schema — environment-variable fallbacks (usually read by the vendor SDK a layer beneath it) and mutually exclusive options — so its output ends with a reminder to add them by hand. Requiredness and secrecy come straight from the schema and are only as accurate as the schema is: `pulumi-vault` marks neither its required parameters nor its `token` as secret.
 
 ### Updating the API docs templates
 

--- a/tools/resourcedocsgen/cmd/gen.go
+++ b/tools/resourcedocsgen/cmd/gen.go
@@ -1,0 +1,80 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	stderrors "errors"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/spf13/cobra"
+)
+
+// schemaSource is the shared input of the gen-* commands: a package schema,
+// read either from disk (the author's own provider repo, which is the usual
+// case) or from a URL (how we check a package already in the registry -- its
+// schema_file_url is in themes/default/data/registry/packages/<name>.yaml).
+type schemaSource struct {
+	file string
+	url  string
+}
+
+func (s *schemaSource) addFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&s.file, "schemaFile", "s", "",
+		"The path to the package's schema.json (or schema.yaml)")
+	cmd.Flags().StringVar(&s.url, "schemaFileURL", "",
+		"The URL from which the package's schema can be retrieved, instead of --schemaFile")
+}
+
+func (s *schemaSource) validate() error {
+	switch {
+	case s.file == "" && s.url == "":
+		return stderrors.New("one of --schemaFile or --schemaFileURL is required")
+	case s.file != "" && s.url != "":
+		return stderrors.New("--schemaFile and --schemaFileURL are mutually exclusive")
+	}
+	return nil
+}
+
+func (s *schemaSource) read(client HTTPDoer) (*schema.PackageSpec, error) {
+	if s.url != "" {
+		return readRemoteSchemaFile(client, s.url, "")
+	}
+	return readLocalSchemaFile(s.file)
+}
+
+func readLocalSchemaFile(path string) (*schema.PackageSpec, error) {
+	schemaBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading schema file %q", path)
+	}
+
+	if strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml") {
+		schemaBytes, err = yaml.YAMLToJSON(schemaBytes)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading YAML schema")
+		}
+	}
+
+	spec := &schema.PackageSpec{}
+	if err := json.Unmarshal(schemaBytes, spec); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling schema into a PackageSpec")
+	}
+	return spec, nil
+}

--- a/tools/resourcedocsgen/cmd/gen_config.go
+++ b/tools/resourcedocsgen/cmd/gen_config.go
@@ -1,0 +1,82 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/registry/tools/resourcedocsgen/pkg/overview"
+)
+
+// GenConfigCmd generates the configuration parameters reference of a package's
+// Overview page. Like gen-install it writes a snippet to stdout: the schema
+// carries the name, requiredness, secrecy and description of every parameter,
+// but not the environment-variable fallbacks or mutual-exclusivity rules the
+// standard also asks for, so the output is a starting point the author edits.
+func GenConfigCmd(client HTTPDoer) *cobra.Command {
+	var (
+		source schemaSource
+		style  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "gen-config",
+		Short: "[EXPERIMENTAL] Generate the ## Configuration section of a package's Overview page",
+		Long: "EXPERIMENTAL: output shape and flags may change.\n\n" +
+			"Generate the configuration parameters reference of a package's Overview page " +
+			"(docs/_index.md) from its schema's config block, as specified by docs/overview-page.md. " +
+			"Writes markdown to stdout for you to paste into your provider repo's docs/_index.md.\n\n" +
+			"Two things the standard requires cannot come from a schema -- environment-variable " +
+			"fallbacks and mutually exclusive options -- so the output ends with a reminder to add " +
+			"them by hand.",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := source.validate(); err != nil {
+				return err
+			}
+			if style != string(overview.ConfigStyleTable) && style != string(overview.ConfigStyleList) {
+				return fmt.Errorf("unknown --style %q: expected %q or %q",
+					style, overview.ConfigStyleTable, overview.ConfigStyleList)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spec, err := source.read(client)
+			if err != nil {
+				return err
+			}
+
+			cfg := overview.ReadSchemaConfig(spec)
+			if len(cfg.Vars) == 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"%s declares no provider configuration; nothing to generate\n", spec.Name)
+				return nil
+			}
+
+			_, err = fmt.Fprint(cmd.OutOrStdout(),
+				overview.RenderConfiguration(cfg, overview.ConfigStyle(style)))
+			return err
+		},
+	}
+
+	source.addFlags(cmd)
+	cmd.Flags().StringVar(&style, "style", string(overview.ConfigStyleList),
+		fmt.Sprintf("The shape of the generated reference: %q or %q",
+			overview.ConfigStyleList, overview.ConfigStyleTable))
+
+	return cmd
+}

--- a/tools/resourcedocsgen/cmd/gen_install.go
+++ b/tools/resourcedocsgen/cmd/gen_install.go
@@ -1,0 +1,123 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/registry/tools/resourcedocsgen/pkg/overview"
+)
+
+// noSDKLanguages is the --languages value for a package that publishes no
+// per-language SDKs. About a hundred registry packages are in that category.
+const noSDKLanguages = "none"
+
+// GenInstallCmd generates the `## Installation` section of a package's Overview
+// page. It writes a snippet to stdout for the author to paste into their own
+// repo's docs/_index.md rather than generating the page: that page is authored
+// in the provider repo and fetched from the release tag by `metadata
+// from-github`, so this tool is advisory by design.
+func GenInstallCmd(client HTTPDoer) *cobra.Command {
+	var (
+		source    schemaSource
+		version   string
+		languages string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "gen-install",
+		Short: "[EXPERIMENTAL] Generate the ## Installation section of a package's Overview page",
+		Long: "EXPERIMENTAL: output shape and flags may change.\n\n" +
+			"Generate the ## Installation section of a package's Overview page (docs/_index.md) " +
+			"from its schema, as specified by docs/overview-page.md. Writes markdown to stdout for " +
+			"you to paste into your provider repo's docs/_index.md.\n\n" +
+			"A schema cannot say which SDKs a package actually publishes -- the language blob is " +
+			"written by the code generator, not by the release pipeline -- so use --languages when " +
+			"the guess is wrong, and --languages none for a package that publishes no SDKs at all.",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return source.validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spec, err := source.read(client)
+			if err != nil {
+				return err
+			}
+
+			langs, err := resolveLanguages(languages, spec)
+			if err != nil {
+				return err
+			}
+
+			if version == "" {
+				version = spec.Version
+			}
+
+			plan := overview.DeriveInstalls(spec, version, langs)
+			for _, warning := range plan.Warnings {
+				fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+warning)
+			}
+
+			_, err = fmt.Fprint(cmd.OutOrStdout(), overview.RenderInstallation(plan))
+			return err
+		},
+	}
+
+	source.addFlags(cmd)
+	cmd.Flags().StringVar(&version, "version", "",
+		"The package version, used for the Maven and Gradle coordinates when the schema omits one")
+	cmd.Flags().StringVar(&languages, "languages", "",
+		"Comma-separated languages this package publishes SDKs for ("+
+			strings.Join(overview.SDKLanguages, ", ")+"), or \""+noSDKLanguages+
+			"\" for a package that publishes none. Defaults to the languages the schema declares.")
+
+	return cmd
+}
+
+// resolveLanguages turns the --languages flag into the set of SDK languages to
+// render, defaulting to what the schema declares when the flag is absent.
+func resolveLanguages(flag string, spec *schema.PackageSpec) ([]string, error) {
+	if strings.TrimSpace(flag) == "" {
+		return overview.DefaultLanguages(spec), nil
+	}
+	if strings.EqualFold(strings.TrimSpace(flag), noSDKLanguages) {
+		return nil, nil
+	}
+
+	valid := map[string]bool{}
+	for _, lang := range overview.SDKLanguages {
+		valid[lang] = true
+	}
+
+	var langs []string
+	for _, lang := range strings.Split(flag, ",") {
+		lang = strings.ToLower(strings.TrimSpace(lang))
+		if lang == "" {
+			continue
+		}
+		// yaml and hcl always appear -- they install with `pulumi package add`
+		// rather than an SDK -- so accepting them here would be misleading.
+		if !valid[lang] {
+			return nil, fmt.Errorf("unknown language %q: expected one of %s, or %q",
+				lang, strings.Join(overview.SDKLanguages, ", "), noSDKLanguages)
+		}
+		langs = append(langs, lang)
+	}
+	return langs, nil
+}

--- a/tools/resourcedocsgen/cmd/gen_test.go
+++ b/tools/resourcedocsgen/cmd/gen_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/registry/tools/resourcedocsgen/pkg"
+)
+
+func schemaFixture(name string) string {
+	return filepath.Join("testdata", "gen", name+".json")
+}
+
+// runGen executes one of the gen-* commands against a fixture schema and
+// returns its stdout and stderr. Every case reads a local file, so no test
+// here touches the network.
+func runGen(t *testing.T, cmd *cobra.Command, args ...string) (string, string) {
+	t.Helper()
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+
+	return out.String(), errOut.String()
+}
+
+func TestGenInstall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			// Five languages on pure defaults: @pulumi/ise, pulumi-ise,
+			// Pulumi.Ise, com.pulumi:ise, and a Go path with no /vN element.
+			name: "defaults",
+			args: []string{"--schemaFile", schemaFixture("ise")},
+		},
+		{
+			// ise's schema carries no version, so Maven and Gradle need one.
+			name: "version-flag",
+			args: []string{"--schemaFile", schemaFixture("ise"), "--version", "v0.5.0"},
+		},
+		{
+			// The ~100 bridged providers that publish nothing: one command,
+			// no chooser.
+			name: "no-sdks",
+			args: []string{"--schemaFile", schemaFixture("ise"), "--languages", "none"},
+		},
+		{
+			// vault declares no java block but does publish com.pulumi/vault,
+			// so the author names the languages. Its Go import path already
+			// carries /sdk/v7 and must not be rewritten.
+			name: "explicit-languages",
+			args: []string{
+				"--schemaFile", schemaFixture("vault"),
+				"--languages", "typescript,python,go,csharp,java",
+				"--version", "v7.12.0",
+			},
+		},
+		{
+			// A parameterized bridged provider: the `pulumi package add
+			// terraform-provider <ns>/<name>` form, recovered from the
+			// base64 parameterization parameter.
+			name: "parameterized",
+			args: []string{"--schemaFile", schemaFixture("cosign")},
+		},
+		{
+			// A community package with a scoped npm name and only three SDKs.
+			name: "community",
+			args: []string{"--schemaFile", schemaFixture("logfire"), "--version", "v0.1.19"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, _ := runGen(t, GenInstallCmd(pkg.NewHTTPClient()), tt.args...)
+			autogold.ExpectFile(t, autogold.Raw(out))
+		})
+	}
+}
+
+func TestGenInstallWarnsWithoutVersion(t *testing.T) {
+	t.Parallel()
+
+	out, errOut := runGen(t, GenInstallCmd(pkg.NewHTTPClient()), "--schemaFile", schemaFixture("ise"))
+
+	assert.Contains(t, out, "com.pulumi:ise:VERSION")
+	assert.Contains(t, errOut, "Maven and Gradle coordinates require a version")
+}
+
+func TestGenInstallRejectsUnknownLanguage(t *testing.T) {
+	t.Parallel()
+
+	cmd := GenInstallCmd(pkg.NewHTTPClient())
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	// yaml is a chooser key but not an SDK language: it is always rendered
+	// from `pulumi package add`, so naming it here is a mistake worth catching.
+	cmd.SetArgs([]string{"--schemaFile", schemaFixture("ise"), "--languages", "yaml"})
+
+	assert.ErrorContains(t, cmd.Execute(), `unknown language "yaml"`)
+}
+
+func TestGenConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "table",
+			args: []string{"--schemaFile", schemaFixture("logfire"), "--style", "table"},
+		},
+		{
+			// The default style. Most existing pages use a bullet list, and it
+			// keeps long descriptions readable where a table column squeezes them.
+			name: "list",
+			args: []string{"--schemaFile", schemaFixture("logfire")},
+		},
+		{
+			// vault is the honest worst case: no defaults list, so nothing
+			// reads as required; `token` is not marked secret; authLogin is a
+			// $ref to a complex type; two parameters carry environment-variable
+			// fallbacks that get folded into their descriptions.
+			name: "poor-fidelity",
+			args: []string{"--schemaFile", schemaFixture("vault")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, _ := runGen(t, GenConfigCmd(pkg.NewHTTPClient()), tt.args...)
+			autogold.ExpectFile(t, autogold.Raw(out))
+		})
+	}
+}
+
+func TestGenConfigEmptySchemaConfig(t *testing.T) {
+	t.Parallel()
+
+	out, errOut := runGen(t, GenConfigCmd(pkg.NewHTTPClient()), "--schemaFile", schemaFixture("empty-config"))
+
+	assert.Empty(t, out)
+	assert.Contains(t, errOut, "declares no provider configuration")
+}
+
+func TestGenConfigRejectsUnknownStyle(t *testing.T) {
+	t.Parallel()
+
+	cmd := GenConfigCmd(pkg.NewHTTPClient())
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"--schemaFile", schemaFixture("logfire"), "--style", "prose"})
+
+	assert.ErrorContains(t, cmd.Execute(), `unknown --style "prose"`)
+}
+
+func TestGenSchemaSourceValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "neither",
+			// An explicitly empty slice, not nil: cobra falls back to
+			// os.Args[1:] when SetArgs is given nil, which would let `go test
+			// -update` leak into the command under test.
+			args: []string{},
+			err:  "one of --schemaFile or --schemaFileURL is required",
+		},
+		{
+			name: "both",
+			args: []string{"--schemaFile", schemaFixture("ise"), "--schemaFileURL", "https://example.com/schema.json"},
+			err:  "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := GenInstallCmd(pkg.NewHTTPClient())
+			cmd.SetOut(new(bytes.Buffer))
+			cmd.SetErr(new(bytes.Buffer))
+			cmd.SetArgs(tt.args)
+
+			assert.ErrorContains(t, cmd.Execute(), tt.err)
+		})
+	}
+}

--- a/tools/resourcedocsgen/cmd/root.go
+++ b/tools/resourcedocsgen/cmd/root.go
@@ -48,6 +48,8 @@ func RootCmd(client HTTPDoer) *cobra.Command {
 	rootCmd.AddCommand(PackageMetadataCmd(client))
 	rootCmd.AddCommand(CheckVersion(client))
 	rootCmd.AddCommand(SanitizeDocsCmd())
+	rootCmd.AddCommand(GenInstallCmd(client))
+	rootCmd.AddCommand(GenConfigCmd(client))
 
 	return rootCmd
 }

--- a/tools/resourcedocsgen/cmd/testdata/TestGenConfig/list.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenConfig/list.golden
@@ -1,0 +1,8 @@
+## Configuration
+
+- `apiKey` (Optional, Secret) — Bearer token. If omitted, the LOGFIRE_API_KEY environment variable is used.
+- `baseUrl` (Optional) — Base URL for the Logfire API. If omitted, the provider uses LOGFIRE_BASE_URL or infers the SaaS endpoint from the api_key region. Self-hosted customers should set this explicitly.
+- `customHeaders` (Optional, Secret) — Additional HTTP headers to include on every Logfire API request. Intended for proxy, gateway, or edge authentication. Provider-managed headers cannot be overridden.
+
+<!-- TODO: Environment-variable fallbacks. A parameter's environment-variable fallback is often read by the vendor SDK a layer beneath the schema, so it cannot be generated. Where a parameter can be supplied by an environment variable, name the variable in its description. -->
+<!-- TODO: Mutually exclusive options. If setting one parameter forbids or overrides another, or if a group of parameters must be supplied together, say so in the description of every parameter involved. Nothing else in the docs will surface that constraint. -->

--- a/tools/resourcedocsgen/cmd/testdata/TestGenConfig/poor-fidelity.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenConfig/poor-fidelity.golden
@@ -1,0 +1,11 @@
+## Configuration
+
+- `address` (Optional) — URL of the root of the target Vault server.
+- `authLogin` (Optional) — Login to vault with an existing auth method using auth/<mount>/login
+- `maxLeaseTtlSeconds` (Optional) — Maximum TTL for secret leases requested by this provider. May also be set with the `TERRAFORM_VAULT_MAX_TTL` environment variable.
+- `namespace` (Optional) — The namespace to use. Available only for Vault Enterprise.
+- `skipTlsVerify` (Optional) — Set this to true only if the target Vault server is an insecure development instance. May also be set with the `VAULT_SKIP_VERIFY` environment variable.
+- `token` (Optional) — Token to use to authenticate to Vault.
+
+<!-- TODO: Environment-variable fallbacks. A parameter's environment-variable fallback is often read by the vendor SDK a layer beneath the schema, so it cannot be generated. Where a parameter can be supplied by an environment variable, name the variable in its description. -->
+<!-- TODO: Mutually exclusive options. If setting one parameter forbids or overrides another, or if a group of parameters must be supplied together, say so in the description of every parameter involved. Nothing else in the docs will surface that constraint. -->

--- a/tools/resourcedocsgen/cmd/testdata/TestGenConfig/table.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenConfig/table.golden
@@ -1,0 +1,10 @@
+## Configuration
+
+| Name | Required | Secret | Description |
+|---|---|---|---|
+| `apiKey` | No | Yes | Bearer token. If omitted, the LOGFIRE_API_KEY environment variable is used. |
+| `baseUrl` | No | No | Base URL for the Logfire API. If omitted, the provider uses LOGFIRE_BASE_URL or infers the SaaS endpoint from the api_key region. Self-hosted customers should set this explicitly. |
+| `customHeaders` | No | Yes | Additional HTTP headers to include on every Logfire API request. Intended for proxy, gateway, or edge authentication. Provider-managed headers cannot be overridden. |
+
+<!-- TODO: Environment-variable fallbacks. A parameter's environment-variable fallback is often read by the vendor SDK a layer beneath the schema, so it cannot be generated. Where a parameter can be supplied by an environment variable, name the variable in its description. -->
+<!-- TODO: Mutually exclusive options. If setting one parameter forbids or overrides another, or if a group of parameters must be supplied together, say so in the description of every parameter involved. Nothing else in the docs will surface that constraint. -->

--- a/tools/resourcedocsgen/cmd/testdata/TestGenInstall/community.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenInstall/community.golden
@@ -1,0 +1,70 @@
+## Installation
+
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
+{{% choosable language typescript %}}
+
+```bash
+npm install @pydantic/pulumi-logfire
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```bash
+pip install pulumi-logfire
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```bash
+go get github.com/pydantic/pulumi-logfire/sdk/go/logfire
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add logfire
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add logfire
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```bash
+pulumi package add logfire
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    logfire = {
+      source  = "pulumi/logfire"
+      version = "0.1.19"
+    }
+  }
+}
+```
+
+```bash
+pulumi install
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/tools/resourcedocsgen/cmd/testdata/TestGenInstall/defaults.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenInstall/defaults.golden
@@ -1,0 +1,78 @@
+## Installation
+
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
+{{% choosable language typescript %}}
+
+```bash
+npm install @pulumi/ise
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```bash
+pip install pulumi-ise
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```bash
+go get github.com/pulumi/pulumi-ise/sdk/go/ise
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```bash
+dotnet add package Pulumi.Ise
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.pulumi</groupId>
+    <artifactId>ise</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.pulumi:ise:VERSION'
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    ise = {
+      source  = "pulumi/ise"
+      version = "VERSION"
+    }
+  }
+}
+```
+
+```bash
+pulumi install
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/tools/resourcedocsgen/cmd/testdata/TestGenInstall/explicit-languages.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenInstall/explicit-languages.golden
@@ -1,0 +1,78 @@
+## Installation
+
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
+{{% choosable language typescript %}}
+
+```bash
+npm install @pulumi/vault
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```bash
+pip install pulumi-vault
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```bash
+go get github.com/pulumi/pulumi-vault/sdk/v7/go/vault
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```bash
+dotnet add package Pulumi.Vault
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.pulumi</groupId>
+    <artifactId>vault</artifactId>
+    <version>7.12.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.pulumi:vault:7.12.0'
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```bash
+pulumi package add vault
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    vault = {
+      source  = "pulumi/vault"
+      version = "7.12.0"
+    }
+  }
+}
+```
+
+```bash
+pulumi install
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/tools/resourcedocsgen/cmd/testdata/TestGenInstall/no-sdks.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenInstall/no-sdks.golden
@@ -1,0 +1,76 @@
+## Installation
+
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
+{{% choosable language typescript %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    ise = {
+      source  = "pulumi/ise"
+      version = "VERSION"
+    }
+  }
+}
+```
+
+```bash
+pulumi install
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/tools/resourcedocsgen/cmd/testdata/TestGenInstall/parameterized.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenInstall/parameterized.golden
@@ -1,0 +1,76 @@
+## Installation
+
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
+{{% choosable language typescript %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add terraform-provider chainguard-dev/cosign
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add terraform-provider chainguard-dev/cosign
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add terraform-provider chainguard-dev/cosign
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add terraform-provider chainguard-dev/cosign
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+No SDK is published for this language. Run the following command from your Pulumi project to generate one locally and record it in `Pulumi.yaml`:
+
+```bash
+pulumi package add terraform-provider chainguard-dev/cosign
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```bash
+pulumi package add terraform-provider chainguard-dev/cosign
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    cosign = {
+      source  = "chainguard-dev/cosign"
+      version = "0.4.19"
+    }
+  }
+}
+```
+
+```bash
+pulumi install
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/tools/resourcedocsgen/cmd/testdata/TestGenInstall/version-flag.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestGenInstall/version-flag.golden
@@ -1,0 +1,78 @@
+## Installation
+
+{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}
+{{% choosable language typescript %}}
+
+```bash
+npm install @pulumi/ise
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```bash
+pip install pulumi-ise
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```bash
+go get github.com/pulumi/pulumi-ise/sdk/go/ise
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```bash
+dotnet add package Pulumi.Ise
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.pulumi</groupId>
+    <artifactId>ise</artifactId>
+    <version>0.5.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.pulumi:ise:0.5.0'
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+
+```bash
+pulumi package add ise
+```
+
+{{% /choosable %}}
+{{% choosable language hcl %}}
+
+Declare the provider in your program, then run `pulumi install`:
+
+```hcl
+terraform {
+  required_providers {
+    ise = {
+      source  = "pulumi/ise"
+      version = "0.5.0"
+    }
+  }
+}
+```
+
+```bash
+pulumi install
+```
+
+{{% /choosable %}}
+{{< /chooser >}}

--- a/tools/resourcedocsgen/cmd/testdata/gen/cosign.json
+++ b/tools/resourcedocsgen/cmd/testdata/gen/cosign.json
@@ -1,0 +1,60 @@
+{
+  "config": {
+    "variables": {
+      "timeout": {
+        "description": "Timeout for signing and attestation operations, as a Go duration string (e.g. '5m', '10m'). Defaults to '3m'.",
+        "type": "string"
+      },
+      "useRekorV2": {
+        "description": "When true, the bundle signing path targets Rekor v2 by loading the Rekor v2 SigningConfig from TUF instead of the default. Only affects 'bundle' and 'both' signing; ignored for 'legacy'.",
+        "type": "boolean"
+      }
+    }
+  },
+  "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "liftSingleValueMethodReturns": true,
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateExtraInputTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/cosign/cosign",
+      "liftSingleValueMethodReturns": true,
+      "respectSchemaVersion": true,
+      "rootPackageName": "cosign"
+    },
+    "java": {
+      "basePackage": "",
+      "buildFiles": "",
+      "gradleNexusPublishPluginVersion": "",
+      "gradleTest": ""
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true,
+      "liftSingleValueMethodReturns": true,
+      "packageDescription": "A Pulumi provider dynamically bridged from cosign.",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/chainguard-dev/terraform-provider-cosign)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> please consult the source [`terraform-provider-cosign` repo](https://github.com/chainguard-dev/terraform-provider-cosign/issues).",
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "pyproject": {
+        "enabled": true
+      },
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/chainguard-dev/terraform-provider-cosign)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> please consult the source [`terraform-provider-cosign` repo](https://github.com/chainguard-dev/terraform-provider-cosign/issues).",
+      "respectSchemaVersion": true
+    }
+  },
+  "name": "cosign",
+  "parameterization": {
+    "baseProvider": {
+      "name": "terraform-provider",
+      "version": "1.0.1"
+    },
+    "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2NoYWluZ3VhcmQtZGV2L2Nvc2lnbiIsInZlcnNpb24iOiIwLjQuMTkifX0="
+  },
+  "repository": "https://github.com/chainguard-dev/terraform-provider-cosign",
+  "version": "0.4.19"
+}

--- a/tools/resourcedocsgen/cmd/testdata/gen/empty-config.json
+++ b/tools/resourcedocsgen/cmd/testdata/gen/empty-config.json
@@ -1,0 +1,11 @@
+{
+  "config": {},
+  "language": {
+    "nodejs": {
+      "packageName": "@example/greetings"
+    }
+  },
+  "name": "greetings",
+  "repository": "https://github.com/example/pulumi-greetings",
+  "version": "1.2.3"
+}

--- a/tools/resourcedocsgen/cmd/testdata/gen/ise.json
+++ b/tools/resourcedocsgen/cmd/testdata/gen/ise.json
@@ -1,0 +1,76 @@
+{
+  "config": {
+    "variables": {
+      "insecure": {
+        "description": "Allow insecure HTTPS client. This can also be set as the ISE_INSECURE environment variable. Defaults to <span pulumi-lang-nodejs=\"`true`\" pulumi-lang-dotnet=\"`True`\" pulumi-lang-go=\"`true`\" pulumi-lang-python=\"`true`\" pulumi-lang-yaml=\"`true`\" pulumi-lang-java=\"`true`\" pulumi-lang-hcl=\"`true`\">`true`</span>.",
+        "type": "boolean"
+      },
+      "password": {
+        "description": "Password for the ISE instance. This can also be set as the ISE_PASSWORD environment variable.",
+        "secret": true,
+        "type": "string"
+      },
+      "url": {
+        "description": "URL of the Cisco ISE instance. This can also be set as the ISE_URL environment variable.",
+        "type": "string"
+      },
+      "username": {
+        "description": "Username for the ISE instance. This can also be set as the ISE_USERNAME environment variable.",
+        "type": "string"
+      }
+    }
+  },
+  "displayName": "Cisco ISE",
+  "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "namespaces": {
+        "deviceadmin": "DeviceAdmin",
+        "identitymanagement": "IdentityManagement",
+        "network": "Network",
+        "networkaccess": "NetworkAccess",
+        "profiling": "Profiling",
+        "system": "System",
+        "trustsec": "TrustSec"
+      },
+      "packageReferences": {
+        "Pulumi": "3.*"
+      },
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateExtraInputTypes": true,
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-ise/sdk/go/ise",
+      "respectSchemaVersion": true
+    },
+    "java": {
+      "basePackage": "com.pulumi",
+      "buildFiles": "",
+      "gradleNexusPublishPluginVersion": "",
+      "gradleTest": ""
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "devDependencies": {
+        "@types/mime": "^2.0.0",
+        "@types/node": "^10.0.0"
+      },
+      "disableUnionOutputTypes": true,
+      "packageDescription": "A Pulumi package for managing resources on a Cisco ISE (Identity Service Engine) instance.. Based on terraform-provider-ise: version v0.2.1",
+      "packageName": "@pulumi/ise",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/CiscoDevNet/terraform-provider-ise)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-ise` repo](https://github.com/pulumi/pulumi-ise/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-ise` repo](https://github.com/CiscoDevNet/terraform-provider-ise/issues).",
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "pyproject": {
+        "enabled": true
+      },
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/CiscoDevNet/terraform-provider-ise)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-ise` repo](https://github.com/pulumi/pulumi-ise/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-ise` repo](https://github.com/CiscoDevNet/terraform-provider-ise/issues).",
+      "respectSchemaVersion": true
+    }
+  },
+  "name": "ise",
+  "repository": "https://github.com/pulumi/pulumi-ise"
+}

--- a/tools/resourcedocsgen/cmd/testdata/gen/logfire.json
+++ b/tools/resourcedocsgen/cmd/testdata/gen/logfire.json
@@ -1,0 +1,52 @@
+{
+  "config": {
+    "variables": {
+      "apiKey": {
+        "description": "Bearer token. If omitted, the LOGFIRE_API_KEY environment variable is used.",
+        "secret": true,
+        "type": "string"
+      },
+      "baseUrl": {
+        "description": "Base URL for the Logfire API. If omitted, the provider uses LOGFIRE_BASE_URL or infers the SaaS endpoint from the<span pulumi-lang-nodejs=\" apiKey \" pulumi-lang-dotnet=\" ApiKey \" pulumi-lang-go=\" apiKey \" pulumi-lang-python=\" api_key \" pulumi-lang-yaml=\" apiKey \" pulumi-lang-java=\" apiKey \"> api_key </span>region. Self-hosted customers should set this explicitly.",
+        "type": "string"
+      },
+      "customHeaders": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Additional HTTP headers to include on every Logfire API request. Intended for proxy, gateway, or edge authentication. Provider-managed headers cannot be overridden.",
+        "secret": true,
+        "type": "object"
+      }
+    }
+  },
+  "displayName": "Logfire",
+  "language": {
+    "go": {
+      "generateExtraInputTypes": true,
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pydantic/pulumi-logfire/sdk/go/logfire",
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true,
+      "packageDescription": "A Pulumi package for creating and managing logfire cloud resources.",
+      "packageName": "@pydantic/pulumi-logfire",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/pydantic/terraform-provider-logfire)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-logfire` repo](https://github.com/pydantic/pulumi-logfire/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-logfire` repo](https://github.com/pydantic/terraform-provider-logfire/issues).",
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "packageName": "pulumi_logfire",
+      "pyproject": {
+        "enabled": true
+      },
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/pydantic/terraform-provider-logfire)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-logfire` repo](https://github.com/pydantic/pulumi-logfire/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-logfire` repo](https://github.com/pydantic/terraform-provider-logfire/issues).",
+      "respectSchemaVersion": true
+    }
+  },
+  "name": "logfire",
+  "pluginDownloadURL": "github://api.github.com/pydantic/pulumi-logfire",
+  "repository": "https://github.com/pydantic/pulumi-logfire"
+}

--- a/tools/resourcedocsgen/cmd/testdata/gen/vault.json
+++ b/tools/resourcedocsgen/cmd/testdata/gen/vault.json
@@ -1,0 +1,153 @@
+{
+  "config": {
+    "variables": {
+      "address": {
+        "description": "URL of the root of the target Vault server.",
+        "type": "string"
+      },
+      "authLogin": {
+        "$ref": "#/types/vault:config/authLogin:authLogin",
+        "description": "Login to vault with an existing auth method using auth/<mount>/login"
+      },
+      "maxLeaseTtlSeconds": {
+        "default": 1200,
+        "defaultInfo": {
+          "environment": [
+            "TERRAFORM_VAULT_MAX_TTL"
+          ]
+        },
+        "description": "Maximum TTL for secret leases requested by this provider.",
+        "type": "integer"
+      },
+      "namespace": {
+        "description": "The namespace to use. Available only for Vault Enterprise.",
+        "type": "string"
+      },
+      "skipTlsVerify": {
+        "defaultInfo": {
+          "environment": [
+            "VAULT_SKIP_VERIFY"
+          ]
+        },
+        "description": "Set this to true only if the target Vault server is an insecure development instance.",
+        "type": "boolean"
+      },
+      "token": {
+        "description": "Token to use to authenticate to Vault.",
+        "type": "string"
+      }
+    }
+  },
+  "displayName": "HashiCorp Vault",
+  "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "namespaces": {
+        "ad": "AD",
+        "alicloud": "AliCloud",
+        "appRole": "AppRole",
+        "aws": "Aws",
+        "azure": "Azure",
+        "cf": "Cf",
+        "config": "Config",
+        "consul": "Consul",
+        "database": "Database",
+        "gcp": "Gcp",
+        "generic": "Generic",
+        "github": "GitHub",
+        "identity": "Identity",
+        "index": "index",
+        "jwt": "Jwt",
+        "keymgmt": "KeyMgmt",
+        "kmip": "Kmip",
+        "kubernetes": "Kubernetes",
+        "kv": "kv",
+        "ldap": "Ldap",
+        "managed": "Managed",
+        "mongodbatlas": "MongoDBAtlas",
+        "okta": "Okta",
+        "os": "Os",
+        "pkiSecret": "PkiSecret",
+        "pkiexternalca": "PkiExternalCa",
+        "rabbitMq": "RabbitMQ",
+        "radius": "Radius",
+        "saml": "Saml",
+        "secrets": "Secrets",
+        "spiffe": "Spiffe",
+        "ssh": "Ssh",
+        "terraformcloud": "TerraformCloud",
+        "tokenauth": "TokenAuth",
+        "transform": "Transform",
+        "transit": "Transit",
+        "vault": "Vault"
+      },
+      "packageReferences": {
+        "Pulumi": "3.*"
+      },
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateExtraInputTypes": true,
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-vault/sdk/v7/go/vault",
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "devDependencies": {
+        "@types/mime": "^2.0.0",
+        "@types/node": "^10.0.0"
+      },
+      "disableUnionOutputTypes": true,
+      "packageDescription": "A Pulumi package for creating and managing HashiCorp Vault cloud resources.",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-vault)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-vault` repo](https://github.com/pulumi/pulumi-vault/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-vault` repo](https://github.com/hashicorp/terraform-provider-vault/issues).",
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "pyproject": {
+        "enabled": true
+      },
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-vault)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-vault` repo](https://github.com/pulumi/pulumi-vault/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-vault` repo](https://github.com/hashicorp/terraform-provider-vault/issues).",
+      "respectSchemaVersion": true
+    }
+  },
+  "name": "vault",
+  "repository": "https://github.com/pulumi/pulumi-vault",
+  "types": {
+    "vault:config/authLogin:authLogin": {
+      "language": {
+        "nodejs": {
+          "requiredInputs": []
+        }
+      },
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The authentication engine's namespace. Conflicts with use_root_namespace\n",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "secret": true,
+          "type": "object"
+        },
+        "path": {
+          "type": "string"
+        },
+        "useRootNamespace": {
+          "description": "Authenticate to the root Vault namespace. Conflicts with namespace\n",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/tools/resourcedocsgen/pkg/docs/gen.go
+++ b/tools/resourcedocsgen/pkg/docs/gen.go
@@ -1146,7 +1146,7 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType, isProvid
 				typs = append(typs, docNestedType{
 					Name:        wbr(name),
 					AnchorID:    strings.ToLower(name),
-					Description: sanitizeDescription(typ.Comment),
+					Description: SanitizeDescription(typ.Comment),
 					Properties:  props,
 				})
 			case *schema.EnumType:
@@ -1172,8 +1172,8 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType, isProvid
 							DisplayName:        wbr(enumName),
 							Name:               enumName,
 							Value:              fmt.Sprintf("%v", e.Value),
-							Comment:            sanitizeDescription(e.Comment),
-							DeprecationMessage: sanitizeDescription(e.DeprecationMessage),
+							Comment:            SanitizeDescription(e.Comment),
+							DeprecationMessage: SanitizeDescription(e.DeprecationMessage),
 						})
 					}
 					enums[lang] = langEnumValues
@@ -1248,7 +1248,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(
 			propTypes = append(propTypes, mod.typeString(prop.Type, lang, characteristics, true))
 		}
 
-		comment := sanitizeDescription(prop.Comment)
+		comment := SanitizeDescription(prop.Comment)
 		link := "#" + propID
 
 		// Check if type is defined in a package external to the current package. If it is external, update comment to
@@ -1283,7 +1283,7 @@ func (mod *modContext) getPropertiesWithIDPrefixAndExclude(
 			DisplayName:        wbr(propLangName),
 			Name:               propLangName,
 			Comment:            comment,
-			DeprecationMessage: sanitizeDescription(prop.DeprecationMessage),
+			DeprecationMessage: SanitizeDescription(prop.DeprecationMessage),
 			IsRequired:         prop.IsRequired(),
 			IsInput:            input,
 			// We indicate that a property will replace if either
@@ -1860,14 +1860,14 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 	}
 
 	supportedSnippetLanguages := mod.context.getSupportedSnippetLanguages(r.IsOverlay, r.OverlaySupportedLanguages)
-	docInfo := dctx.decomposeDocstring(sanitizeDescription(r.Comment), supportedSnippetLanguages)
+	docInfo := dctx.decomposeDocstring(SanitizeDescription(r.Comment), supportedSnippetLanguages)
 	data := resourceDocArgs{
 		Header: mod.genResourceHeader(r),
 
 		Tool: mod.tool,
 
 		Comment:            docInfo.description,
-		DeprecationMessage: sanitizeDescription(r.DeprecationMessage),
+		DeprecationMessage: SanitizeDescription(r.DeprecationMessage),
 		ExamplesSection: examplesSection{
 			Examples:             docInfo.examples,
 			LangChooserLanguages: supportedSnippetLanguages,

--- a/tools/resourcedocsgen/pkg/docs/gen_function.go
+++ b/tools/resourcedocsgen/pkg/docs/gen_function.go
@@ -506,7 +506,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 	}
 
 	supportedSnippetLanguages := mod.context.getSupportedSnippetLanguages(f.IsOverlay, f.OverlaySupportedLanguages)
-	docInfo := dctx.decomposeDocstring(sanitizeDescription(f.Comment), supportedSnippetLanguages)
+	docInfo := dctx.decomposeDocstring(SanitizeDescription(f.Comment), supportedSnippetLanguages)
 	args := functionDocArgs{
 		Header: mod.genFunctionHeader(f),
 
@@ -518,7 +518,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		FunctionResult: mod.getFunctionResourceInfo(f, false /*outputVersion*/),
 
 		Comment:            docInfo.description,
-		DeprecationMessage: sanitizeDescription(f.DeprecationMessage),
+		DeprecationMessage: SanitizeDescription(f.DeprecationMessage),
 		ExamplesSection: examplesSection{
 			Examples:             docInfo.examples,
 			LangChooserLanguages: supportedSnippetLanguages,

--- a/tools/resourcedocsgen/pkg/docs/sanitize.go
+++ b/tools/resourcedocsgen/pkg/docs/sanitize.go
@@ -19,13 +19,13 @@ import (
 	"strings"
 )
 
-// sanitizeDescription cleans up common markdown issues found in upstream
+// SanitizeDescription cleans up common markdown issues found in upstream
 // provider schema descriptions (typically from Terraform-bridged providers).
 //
 // Some upstream providers use non-standard markdown patterns that render
 // correctly in the Terraform Registry but break under goldmark (CommonMark).
 // This function normalizes those patterns before doc generation.
-func sanitizeDescription(s string) string {
+func SanitizeDescription(s string) string {
 	s = stripLangSpans(s)
 	s = stripTerraformArgSections(s)
 	s = fixHTMLBullets(s)

--- a/tools/resourcedocsgen/pkg/docs/sanitize_test.go
+++ b/tools/resourcedocsgen/pkg/docs/sanitize_test.go
@@ -365,6 +365,6 @@ func TestSanitizeDescription(t *testing.T) {
 
 - And that is all.`
 
-	actual := sanitizeDescription(input)
+	actual := SanitizeDescription(input)
 	assert.Equal(t, expected, actual)
 }

--- a/tools/resourcedocsgen/pkg/overview/config.go
+++ b/tools/resourcedocsgen/pkg/overview/config.go
@@ -1,0 +1,116 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package overview derives the mechanically-generatable sections of a package's
+// Overview page (docs/_index.md) from its schema. See docs/overview-page.md for
+// the standard these snippets are written against.
+package overview
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/registry/tools/resourcedocsgen/pkg/docs"
+)
+
+// ConfigVar is one provider configuration parameter, flattened out of the
+// schema's config block into the four fields docs/overview-page.md asks an
+// author to document, plus the environment-variable fallbacks the schema
+// happens to know about.
+type ConfigVar struct {
+	// Name is the bare option name, e.g. "apiToken". The standard is explicit
+	// that it carries no "<package>:" prefix.
+	Name string
+	// Type is the JSON-schema type, or "object" for a $ref'd config type.
+	Type string
+	// Description has been through docs.SanitizeDescription.
+	Description string
+	// Required reports membership of the schema's config "defaults" list. Note
+	// that many bridged providers omit that list entirely, in which case every
+	// parameter here reads as optional.
+	Required bool
+	// Secret reports the schema's secret flag, which is likewise unreliable:
+	// pulumi-vault does not mark its `token` secret.
+	Secret bool
+	// EnvVars comes from defaultInfo.environment. It is sparse in practice --
+	// most environment-variable fallbacks are read by the vendor SDK a layer
+	// beneath the schema and appear nowhere in it.
+	EnvVars []string
+	// Deprecated is the schema's deprecationMessage, if any.
+	Deprecated string
+}
+
+// SchemaConfig is a package's provider configuration, normalized for rendering.
+type SchemaConfig struct {
+	Package string
+	Vars    []ConfigVar
+}
+
+// ReadSchemaConfig flattens spec's provider config block. Variables are sorted
+// by name so that output is stable across runs; Go map iteration is not.
+func ReadSchemaConfig(spec *schema.PackageSpec) SchemaConfig {
+	required := make(map[string]bool, len(spec.Config.Required))
+	for _, name := range spec.Config.Required {
+		required[name] = true
+	}
+
+	vars := make([]ConfigVar, 0, len(spec.Config.Variables))
+	for name, prop := range spec.Config.Variables {
+		vars = append(vars, ConfigVar{
+			Name:        name,
+			Type:        configVarType(spec, prop),
+			Description: docs.SanitizeDescription(prop.Description),
+			Required:    required[name],
+			Secret:      prop.Secret,
+			EnvVars:     envVars(prop),
+			Deprecated:  docs.SanitizeDescription(prop.DeprecationMessage),
+		})
+	}
+
+	sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
+
+	return SchemaConfig{Package: spec.Name, Vars: vars}
+}
+
+// configVarType names the parameter's type for the reader. A config variable
+// may be a $ref to a complex type declared elsewhere in the same schema --
+// pulumi-vault's authLogin parameters are the common example -- in which case
+// the referenced type's own type is the useful answer, and "object" is the
+// fallback when the reference points outside this document.
+func configVarType(spec *schema.PackageSpec, prop schema.PropertySpec) string {
+	if prop.Ref == "" {
+		if prop.Type == "" {
+			return "object"
+		}
+		return prop.Type
+	}
+
+	token, ok := strings.CutPrefix(prop.Ref, "#/types/")
+	if !ok {
+		return "object"
+	}
+	if typ, ok := spec.Types[token]; ok && typ.Type != "" {
+		return typ.Type
+	}
+	return "object"
+}
+
+func envVars(prop schema.PropertySpec) []string {
+	if prop.DefaultInfo == nil {
+		return nil
+	}
+	return prop.DefaultInfo.Environment
+}

--- a/tools/resourcedocsgen/pkg/overview/install.go
+++ b/tools/resourcedocsgen/pkg/overview/install.go
@@ -1,0 +1,383 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overview
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	dotnet "github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/codegen"
+	"github.com/pulumi/pulumi-java/pkg/codegen/java"
+	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// The chooser language keys, in the order docs/overview-page.md lists them.
+const (
+	LangTypeScript = "typescript"
+	LangPython     = "python"
+	LangGo         = "go"
+	LangCSharp     = "csharp"
+	LangJava       = "java"
+	LangYAML       = "yaml"
+	LangHCL        = "hcl"
+)
+
+// SDKLanguages are the languages that install a per-language SDK. YAML and HCL
+// are excluded: they consume the package directly through `pulumi package add`.
+var SDKLanguages = []string{LangTypeScript, LangPython, LangGo, LangCSharp, LangJava}
+
+// AllLanguages is every key the chooser accepts, in rendering order.
+var AllLanguages = append(append([]string{}, SDKLanguages...), LangYAML, LangHCL)
+
+// schemaLanguageKeys maps a chooser key to the key the schema's language blob
+// uses for it. They agree everywhere except TypeScript, which the schema calls
+// nodejs.
+var schemaLanguageKeys = map[string]string{
+	LangTypeScript: "nodejs",
+	LangPython:     "python",
+	LangGo:         "go",
+	LangCSharp:     "csharp",
+	LangJava:       "java",
+}
+
+// Install is the installation instruction for a single language.
+type Install struct {
+	// Language is a chooser key.
+	Language string
+	// Package is the published artifact's identifier -- the npm name, the PyPI
+	// project, the Go import path, the NuGet id, or the Maven coordinate.
+	Package string
+	// Command is the shell one-liner that installs it. Empty for Java, which
+	// has no one-line install and uses Maven/Gradle instead.
+	Command string
+	// Maven and Gradle are set for Java only.
+	Maven  string
+	Gradle string
+}
+
+// InstallPlan is everything the ## Installation section needs.
+type InstallPlan struct {
+	Package string
+	Version string
+	// Languages is empty when the package publishes no SDKs, in which case
+	// PackageAdd is the whole installation section.
+	Languages []Install
+	// PackageAdd is the `pulumi package add` command. It covers every language
+	// except HCL, which declares providers in the program instead.
+	PackageAdd string
+	// HCLSource is the provider source an HCL program names in its
+	// required_providers block, and HCLVersion the version it pins.
+	HCLSource  string
+	HCLVersion string
+	// Warnings describe what could not be derived and needs the author's hand.
+	Warnings []string
+}
+
+// DefaultLanguages guesses which languages a package publishes SDKs for.
+//
+// The guess is only that. A schema's language blob is populated by the code
+// generator, not by whatever the release pipeline actually pushed, so it is
+// wrong in both directions: pulumi-vault declares no java block yet publishes
+// com.pulumi/vault, and every one of the ~100 bridged providers that ship no
+// SDKs at all still declares four or five language blocks. A parameterized
+// provider is the one case we can call confidently -- it is consumed through
+// `pulumi package add` -- so it reports no SDK languages. Everywhere else the
+// author overrides this with --languages.
+func DefaultLanguages(spec *schema.PackageSpec) []string {
+	if isTerraformParameterized(spec) {
+		return nil
+	}
+
+	var langs []string
+	for _, lang := range SDKLanguages {
+		if _, ok := spec.Language[schemaLanguageKeys[lang]]; ok {
+			langs = append(langs, lang)
+		}
+	}
+	return langs
+}
+
+// DeriveInstalls builds the installation plan for the given SDK languages.
+// Pass a nil or empty languages slice for a package that publishes no SDKs.
+func DeriveInstalls(spec *schema.PackageSpec, version string, languages []string) InstallPlan {
+	plan := InstallPlan{
+		Package:    spec.Name,
+		Version:    strings.TrimPrefix(version, "v"),
+		PackageAdd: packageAddCommand(spec),
+	}
+	plan.HCLSource, plan.HCLVersion = hclProvider(spec, plan.Version)
+	if plan.HCLVersion == "" {
+		plan.HCLVersion = "VERSION"
+		plan.Warnings = append(plan.Warnings,
+			"HCL pins a native Pulumi provider to an exact semver version and the schema carries none; "+
+				"pass --version, or fill in the VERSION placeholder by hand")
+	}
+
+	// Deliberately no `pulumi plugin install` line. A schema's
+	// pluginDownloadURL is baked into every generated SDK, which is what lets
+	// the engine fetch the plugin binary on first use -- so its presence is
+	// evidence the manual step is *not* needed. The rare provider whose plugin
+	// really must be installed by hand has to say so itself.
+	for _, lang := range sortLanguages(languages) {
+		install, warnings := deriveInstall(spec, plan.Version, lang)
+		plan.Warnings = append(plan.Warnings, warnings...)
+		if install != nil {
+			plan.Languages = append(plan.Languages, *install)
+		}
+	}
+
+	return plan
+}
+
+// sortLanguages puts the requested languages into the standard's order and
+// drops duplicates and the non-SDK keys, which are rendered from PackageAdd.
+func sortLanguages(languages []string) []string {
+	order := make(map[string]int, len(SDKLanguages))
+	for i, lang := range SDKLanguages {
+		order[lang] = i
+	}
+
+	seen := map[string]bool{}
+	var out []string
+	for _, lang := range languages {
+		lang = strings.ToLower(strings.TrimSpace(lang))
+		if _, ok := order[lang]; !ok || seen[lang] {
+			continue
+		}
+		seen[lang] = true
+		out = append(out, lang)
+	}
+	sort.Slice(out, func(i, j int) bool { return order[out[i]] < order[out[j]] })
+	return out
+}
+
+func deriveInstall(spec *schema.PackageSpec, version, lang string) (*Install, []string) {
+	switch lang {
+	case LangTypeScript:
+		var info nodejs.NodePackageInfo
+		decodeLanguageInfo(spec, "nodejs", &info)
+		name := info.PackageName
+		if name == "" {
+			name = "@pulumi/" + spec.Name
+		}
+		return &Install{Language: lang, Package: name, Command: "npm install " + name}, nil
+
+	case LangPython:
+		var info python.PackageInfo
+		decodeLanguageInfo(spec, "python", &info)
+		name := info.PackageName
+		if name == "" {
+			name = "pulumi_" + spec.Name
+		}
+		// PyPI treats underscores and hyphens as the same project. Every
+		// published Overview page spells the install with hyphens.
+		name = strings.ReplaceAll(name, "_", "-")
+		return &Install{Language: lang, Package: name, Command: "pip install " + name}, nil
+
+	case LangGo:
+		var info go_gen.GoPackageInfo
+		decodeLanguageInfo(spec, "go", &info)
+		path := info.ImportBasePath
+		if path == "" {
+			var warnings []string
+			path, warnings = fallbackGoImportPath(spec)
+			return &Install{Language: lang, Package: path, Command: "go get " + path}, warnings
+		}
+		// Never synthesize the /vN major-version element: a schema that needs
+		// one already carries it (pulumi-vault's is .../sdk/v7/go/vault), and
+		// guessing produces an import path that does not resolve.
+		return &Install{Language: lang, Package: path, Command: "go get " + path}, nil
+
+	case LangCSharp:
+		var info dotnet.CSharpPackageInfo
+		decodeLanguageInfo(spec, "csharp", &info)
+		id := info.GetRootNamespace() + "." + pascalCase(spec.Name)
+		return &Install{Language: lang, Package: id, Command: "dotnet add package " + id}, nil
+
+	case LangJava:
+		var info java.PackageInfo
+		decodeLanguageInfo(spec, "java", &info)
+		groupID := strings.TrimSuffix(info.BasePackageOrDefault(), ".")
+		artifactID := spec.Name
+		var warnings []string
+		v := version
+		if v == "" {
+			v = "VERSION"
+			warnings = append(warnings,
+				"Maven and Gradle coordinates require a version and the schema carries none; "+
+					"pass --version, or fill in the VERSION placeholder by hand")
+		}
+		return &Install{
+			Language: lang,
+			Package:  groupID + ":" + artifactID,
+			Maven:    mavenBlock(groupID, artifactID, v),
+			Gradle:   fmt.Sprintf("implementation '%s:%s:%s'", groupID, artifactID, v),
+		}, warnings
+	}
+
+	return nil, nil
+}
+
+func mavenBlock(groupID, artifactID, version string) string {
+	return fmt.Sprintf(`<dependency>
+    <groupId>%s</groupId>
+    <artifactId>%s</artifactId>
+    <version>%s</version>
+</dependency>`, groupID, artifactID, version)
+}
+
+// fallbackGoImportPath builds an import path from the schema's repository when
+// the go language blob declares no importBasePath.
+func fallbackGoImportPath(spec *schema.PackageSpec) (string, []string) {
+	repo := spec.Repository
+	repo = strings.TrimSuffix(strings.TrimSuffix(repo, "/"), ".git")
+	repo = strings.TrimPrefix(strings.TrimPrefix(repo, "https://"), "http://")
+	if repo == "" {
+		return "<TODO: Go import path>", []string{
+			"the schema declares neither a go importBasePath nor a repository, " +
+				"so the Go import path could not be derived",
+		}
+	}
+	return fmt.Sprintf("%s/sdk/go/%s", repo, goPackageName(spec.Name)), []string{
+		"the schema declares no go importBasePath; the Go import path was guessed " +
+			"from the repository and may need a /vN major-version element",
+	}
+}
+
+// goPackageName reduces a package name to the identifier a Go SDK's leaf
+// directory uses: aws-native becomes awsnative.
+func goPackageName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(b.String())
+}
+
+// pascalCase renders a package name the way the .NET generator names its
+// assembly: aws-native becomes AwsNative.
+func pascalCase(name string) string {
+	parts := strings.FieldsFunc(name, func(r rune) bool { return r == '-' || r == '_' || r == '.' })
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		b.WriteString(strings.ToLower(part[1:]))
+	}
+	return b.String()
+}
+
+// packageAddCommand builds the `pulumi package add` line YAML and HCL use, and
+// which is the whole installation section for a package with no SDKs.
+func packageAddCommand(spec *schema.PackageSpec) string {
+	if source, ok := terraformProviderSource(spec); ok {
+		return "pulumi package add terraform-provider " + source
+	}
+	return "pulumi package add " + spec.Name
+}
+
+// hclProvider returns the source and version an HCL program uses to reference
+// this package.
+//
+// HCL does not use `pulumi package add`. A program names the provider in its
+// required_providers block and `pulumi install` fetches it. A source prefixed
+// with "pulumi/" resolves to a native Pulumi provider and must be pinned to an
+// exact semver version; any other source is bridged from its Terraform
+// provider, so a parameterized package reuses the upstream address and version
+// it already carries.
+func hclProvider(spec *schema.PackageSpec, version string) (source, pinned string) {
+	if remote, ok := terraformProviderRemote(spec); ok {
+		if remote.Version != "" {
+			return remote.source(), remote.Version
+		}
+		return remote.source(), version
+	}
+	return "pulumi/" + spec.Name, version
+}
+
+func isTerraformParameterized(spec *schema.PackageSpec) bool {
+	_, ok := terraformProviderSource(spec)
+	return ok
+}
+
+// terraformRemote is the upstream provider a parameterized bridged package
+// wraps, as recorded in parameterization.parameter.
+type terraformRemote struct {
+	URL     string `json:"url"`
+	Version string `json:"version"`
+}
+
+// source strips the registry host from the remote URL, leaving the
+// "<namespace>/<name>" address both `pulumi package add terraform-provider`
+// and an HCL required_providers block expect.
+func (r terraformRemote) source() string {
+	parts := strings.Split(strings.Trim(r.URL, "/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.Join(parts[len(parts)-2:], "/")
+}
+
+// terraformProviderRemote decodes the base64 parameter a parameterized bridged
+// package carries -- {"remote":{"url":"<registry host>/<ns>/<name>","version":
+// "..."}} -- which is what the ~100 registry packages whose Overview pages read
+// `pulumi package add terraform-provider chainguard-dev/cosign` are built from.
+func terraformProviderRemote(spec *schema.PackageSpec) (terraformRemote, bool) {
+	if spec.Parameterization == nil || spec.Parameterization.BaseProvider.Name != "terraform-provider" {
+		return terraformRemote{}, false
+	}
+
+	var parameter struct {
+		Remote terraformRemote `json:"remote"`
+	}
+	if err := json.Unmarshal(spec.Parameterization.Parameter, &parameter); err != nil {
+		return terraformRemote{}, false
+	}
+	if parameter.Remote.source() == "" {
+		return terraformRemote{}, false
+	}
+	return parameter.Remote, true
+}
+
+// terraformProviderSource is the "<namespace>/<name>" address of the upstream
+// provider, when this package is a parameterized bridge over one.
+func terraformProviderSource(spec *schema.PackageSpec) (string, bool) {
+	remote, ok := terraformProviderRemote(spec)
+	if !ok {
+		return "", false
+	}
+	return remote.source(), true
+}
+
+func decodeLanguageInfo(spec *schema.PackageSpec, key string, into any) {
+	raw, ok := spec.Language[key]
+	if !ok || len(raw) == 0 {
+		return
+	}
+	// A malformed or unexpected language blob is not worth failing over: the
+	// caller falls back to the generator's own defaults, which is what the
+	// language's code generator would do anyway.
+	_ = json.Unmarshal(raw, into)
+}

--- a/tools/resourcedocsgen/pkg/overview/overview_test.go
+++ b/tools/resourcedocsgen/pkg/overview/overview_test.go
@@ -1,0 +1,340 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overview
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cosignParameter is the base64 parameterization parameter chainguard-dev's
+// cosign package carries, which decodes to
+// {"remote":{"url":"registry.opentofu.org/chainguard-dev/cosign","version":"0.4.19"}}.
+const cosignParameter = "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2NoYWluZ3VhcmQtZGV2" +
+	"L2Nvc2lnbiIsInZlcnNpb24iOiIwLjQuMTkifX0="
+
+func spec(t *testing.T, jsonSpec string) *schema.PackageSpec {
+	t.Helper()
+
+	var out schema.PackageSpec
+	require.NoError(t, json.Unmarshal([]byte(jsonSpec), &out))
+	return &out
+}
+
+func TestPascalCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ in, want string }{
+		{"ise", "Ise"},
+		{"vault", "Vault"},
+		{"aws-native", "AwsNative"},
+		{"azure_native", "AzureNative"},
+		{"docker-build", "DockerBuild"},
+		{"newrelic", "Newrelic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, pascalCase(tt.in))
+		})
+	}
+}
+
+func TestGoPackageName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ise", goPackageName("ise"))
+	assert.Equal(t, "awsnative", goPackageName("aws-native"))
+	assert.Equal(t, "dockerbuild", goPackageName("docker_build"))
+}
+
+func TestTerraformProviderSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		jsonSpec string
+		want     string
+		wantOK   bool
+	}{
+		{
+			name: "terraform provider",
+			// parameter is the base64 of
+			// {"remote":{"url":"registry.opentofu.org/chainguard-dev/cosign","version":"0.4.19"}}
+			jsonSpec: `{"name":"cosign","parameterization":{
+				"baseProvider":{"name":"terraform-provider","version":"1.0.1"},
+				"parameter":"` + cosignParameter + `"}}`,
+			want:   "chainguard-dev/cosign",
+			wantOK: true,
+		},
+		{
+			name:     "not parameterized",
+			jsonSpec: `{"name":"vault"}`,
+			wantOK:   false,
+		},
+		{
+			name: "parameterized on some other base provider",
+			jsonSpec: `{"name":"other","parameterization":{
+				"baseProvider":{"name":"something-else","version":"1.0.0"},"parameter":"e30="}}`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := terraformProviderSource(spec(t, tt.jsonSpec))
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefaultLanguagesSkipsSDKsForParameterizedPackages(t *testing.T) {
+	t.Parallel()
+
+	// cosign declares all five language blocks and publishes none of them. A
+	// parameterized provider is consumed with `pulumi package add`, which is
+	// the one case the schema does let us call.
+	parameterized := spec(t, `{"name":"cosign",
+		"language":{"csharp":{},"go":{},"java":{},"nodejs":{},"python":{}},
+		"parameterization":{"baseProvider":{"name":"terraform-provider","version":"1.0.1"},
+		"parameter":"eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2NoYWluZ3VhcmQtZGV2L2Nvc2lnbiJ9fQ=="}}`)
+	assert.Empty(t, DefaultLanguages(parameterized))
+
+	// vault declares four blocks; the missing java one is why --languages exists.
+	vault := spec(t, `{"name":"vault","language":{"csharp":{},"go":{},"nodejs":{},"python":{}}}`)
+	assert.Equal(t, []string{LangTypeScript, LangPython, LangGo, LangCSharp}, DefaultLanguages(vault))
+}
+
+func TestDeriveInstallsDefaults(t *testing.T) {
+	t.Parallel()
+
+	// No language overrides at all: every identifier comes from a default.
+	plan := DeriveInstalls(
+		spec(t, `{"name":"ise","repository":"https://github.com/pulumi/pulumi-ise",
+			"language":{"csharp":{},"go":{},"java":{},"nodejs":{},"python":{}}}`),
+		"v0.5.0", SDKLanguages)
+
+	byLanguage := map[string]Install{}
+	for _, install := range plan.Languages {
+		byLanguage[install.Language] = install
+	}
+
+	assert.Equal(t, "npm install @pulumi/ise", byLanguage[LangTypeScript].Command)
+	assert.Equal(t, "pip install pulumi-ise", byLanguage[LangPython].Command)
+	assert.Equal(t, "dotnet add package Pulumi.Ise", byLanguage[LangCSharp].Command)
+	assert.Equal(t, "com.pulumi:ise", byLanguage[LangJava].Package)
+	assert.Contains(t, byLanguage[LangJava].Gradle, "com.pulumi:ise:0.5.0")
+
+	// No importBasePath, so the Go path is guessed from the repository and the
+	// caller is told so.
+	assert.Equal(t, "go get github.com/pulumi/pulumi-ise/sdk/go/ise", byLanguage[LangGo].Command)
+	assert.Contains(t, plan.Warnings[0], "no go importBasePath")
+}
+
+func TestDeriveInstallsPrefersSchemaNames(t *testing.T) {
+	t.Parallel()
+
+	plan := DeriveInstalls(
+		spec(t, `{"name":"logfire","language":{
+			"nodejs":{"packageName":"@pydantic/pulumi-logfire"},
+			"python":{"packageName":"pulumi_logfire"},
+			"go":{"importBasePath":"github.com/pydantic/pulumi-logfire/sdk/go/logfire"}}}`),
+		"v0.1.19", []string{LangTypeScript, LangPython, LangGo})
+
+	require.Len(t, plan.Languages, 3)
+	assert.Equal(t, "npm install @pydantic/pulumi-logfire", plan.Languages[0].Command)
+	// PyPI treats the two spellings as one project; published pages use hyphens.
+	assert.Equal(t, "pip install pulumi-logfire", plan.Languages[1].Command)
+	assert.Equal(t, "go get github.com/pydantic/pulumi-logfire/sdk/go/logfire", plan.Languages[2].Command)
+	assert.Empty(t, plan.Warnings)
+}
+
+func TestDeriveInstallsKeepsExistingGoMajorVersion(t *testing.T) {
+	t.Parallel()
+
+	plan := DeriveInstalls(
+		spec(t, `{"name":"vault","language":{
+			"go":{"importBasePath":"github.com/pulumi/pulumi-vault/sdk/v7/go/vault"}}}`),
+		"v7.12.0", []string{LangGo})
+
+	require.Len(t, plan.Languages, 1)
+	assert.Equal(t, "go get github.com/pulumi/pulumi-vault/sdk/v7/go/vault", plan.Languages[0].Command)
+	assert.Empty(t, plan.Warnings)
+}
+
+func TestDeriveInstallsOmitsPluginInstall(t *testing.T) {
+	t.Parallel()
+
+	// A pluginDownloadURL is baked into the generated SDKs, so the engine
+	// downloads the plugin on first use. Emitting `pulumi plugin install`
+	// because the field is set would tell readers to do by hand the very thing
+	// that field automates.
+	plan := DeriveInstalls(
+		spec(t, `{"name":"example","pluginDownloadURL":"github://api.github.com/example/pulumi-example",
+			"language":{"nodejs":{}}}`),
+		"v1.2.3", []string{LangTypeScript})
+
+	assert.NotContains(t, RenderInstallation(plan), "pulumi plugin install")
+}
+
+func TestRenderInstallationCoversEveryLanguage(t *testing.T) {
+	t.Parallel()
+
+	// logfire publishes three SDKs. C# and Java readers must still be given a
+	// working path rather than an empty panel: `pulumi package add` generates
+	// an SDK locally, taking its language from the project's runtime, which is
+	// why the command reads identically for them and for YAML and HCL.
+	plan := DeriveInstalls(
+		spec(t, `{"name":"logfire","language":{
+			"nodejs":{"packageName":"@pydantic/pulumi-logfire"},
+			"python":{"packageName":"pulumi_logfire"},
+			"go":{"importBasePath":"github.com/pydantic/pulumi-logfire/sdk/go/logfire"}}}`),
+		"v0.1.19", []string{LangTypeScript, LangPython, LangGo})
+
+	got := RenderInstallation(plan)
+
+	assert.Contains(t, got, `{{< chooser language "typescript,python,go,csharp,java,yaml,hcl" >}}`)
+	for _, lang := range AllLanguages {
+		assert.Contains(t, got, "{{% choosable language "+lang+" %}}",
+			"every language needs a tab, including those with no published SDK")
+	}
+	assert.Contains(t, got, "No SDK is published for this language.")
+	assert.Equal(t, 3, strings.Count(got, "pulumi package add logfire"),
+		"csharp, java and yaml fall back to `pulumi package add`; hcl does not")
+}
+
+func TestRenderInstallationHCLDeclaresTheProvider(t *testing.T) {
+	t.Parallel()
+
+	// HCL has no `pulumi package add` step. A program names the provider in its
+	// own required_providers block and `pulumi install` fetches it -- which is
+	// also why the chooser is never collapsed to a single command, even for a
+	// package with no SDKs at all: HCL's instructions always differ.
+	native := RenderInstallation(DeriveInstalls(spec(t, `{"name":"logfire"}`), "v0.1.19", nil))
+
+	assert.Contains(t, native, "{{% choosable language hcl %}}")
+	assert.Contains(t, native, `source  = "pulumi/logfire"`)
+	// A native Pulumi provider takes an exact semver version, not a constraint.
+	assert.Contains(t, native, `version = "0.1.19"`)
+	assert.Contains(t, native, "pulumi install")
+
+	// A parameterized package is bridged from its Terraform provider, so it
+	// reuses the upstream source and version rather than the pulumi/ prefix.
+	bridged := RenderInstallation(DeriveInstalls(
+		spec(t, `{"name":"cosign","parameterization":{
+			"baseProvider":{"name":"terraform-provider","version":"1.0.1"},
+			"parameter":"`+cosignParameter+`"}}`), "", nil))
+
+	assert.Contains(t, bridged, `source  = "chainguard-dev/cosign"`)
+	assert.Contains(t, bridged, `version = "0.4.19"`)
+	assert.NotContains(t, bridged, "pulumi/cosign")
+}
+
+func TestRenderInstallationWarnsWhenHCLHasNoVersion(t *testing.T) {
+	t.Parallel()
+
+	plan := DeriveInstalls(spec(t, `{"name":"logfire"}`), "", nil)
+
+	assert.Contains(t, RenderInstallation(plan), `version = "VERSION"`)
+	assert.Contains(t, plan.Warnings[0], "exact semver version")
+}
+
+func TestReadSchemaConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := ReadSchemaConfig(spec(t, `{"name":"example","config":{
+		"defaults":["apiToken"],
+		"variables":{
+			"region":{"type":"string","description":"The region.",
+				"defaultInfo":{"environment":["EXAMPLE_REGION","EXAMPLE_DEFAULT_REGION"]}},
+			"apiToken":{"type":"string","description":"The token.","secret":true},
+			"authLogin":{"$ref":"#/types/example:config/authLogin:authLogin","description":"Login."}}},
+		"types":{"example:config/authLogin:authLogin":{"type":"object","properties":{}}}}`))
+
+	// Sorted by name, so that repeated runs produce identical output.
+	require.Len(t, cfg.Vars, 3)
+	assert.Equal(t, []string{"apiToken", "authLogin", "region"},
+		[]string{cfg.Vars[0].Name, cfg.Vars[1].Name, cfg.Vars[2].Name})
+
+	// Requiredness comes from the config block's "defaults" list -- note the
+	// JSON key does not match the Go field name.
+	assert.True(t, cfg.Vars[0].Required)
+	assert.True(t, cfg.Vars[0].Secret)
+	assert.False(t, cfg.Vars[2].Required)
+
+	// A $ref config variable resolves to the referenced type's own type.
+	assert.Equal(t, "object", cfg.Vars[1].Type)
+
+	assert.Equal(t, []string{"EXAMPLE_REGION", "EXAMPLE_DEFAULT_REGION"}, cfg.Vars[2].EnvVars)
+}
+
+func TestReadSchemaConfigSanitizesDescriptions(t *testing.T) {
+	t.Parallel()
+
+	// Bridged provider descriptions carry language-specific spans that the
+	// registry's own renderer strips; a pasted snippet must not show them.
+	description := `Infers the endpoint from the` +
+		`<span pulumi-lang-nodejs=\" apiKey \" pulumi-lang-python=\" api_key \">` +
+		` api_key </span>region.`
+
+	cfg := ReadSchemaConfig(spec(t, `{"name":"example","config":{"variables":{
+		"baseUrl":{"type":"string","description":"`+description+`"}}}}`))
+
+	require.Len(t, cfg.Vars, 1)
+	assert.NotContains(t, cfg.Vars[0].Description, "pulumi-lang-")
+	assert.Contains(t, cfg.Vars[0].Description, "api_key")
+}
+
+func TestRenderConfigurationFoldsInEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	cfg := SchemaConfig{Package: "example", Vars: []ConfigVar{
+		{Name: "region", Description: "The region.", EnvVars: []string{"EXAMPLE_REGION"}},
+		{Name: "token", Description: "The token.", Required: true, Secret: true},
+		// Already named in the description, so it is not appended twice.
+		{Name: "url", Description: "Read from `EXAMPLE_URL` when unset.", EnvVars: []string{"EXAMPLE_URL"}},
+	}}
+
+	got := RenderConfiguration(cfg, ConfigStyleList)
+
+	assert.Contains(t, got,
+		"- `region` (Optional) — The region. May also be set with the `EXAMPLE_REGION` environment variable.")
+	assert.Contains(t, got, "- `token` (Required, Secret) — The token.")
+	assert.Contains(t, got, "- `url` (Optional) — Read from `EXAMPLE_URL` when unset.\n")
+	assert.Contains(t, got, "TODO: Environment-variable fallbacks")
+	assert.Contains(t, got, "TODO: Mutually exclusive options")
+}
+
+func TestRenderConfigurationEscapesTableCells(t *testing.T) {
+	t.Parallel()
+
+	cfg := SchemaConfig{Package: "example", Vars: []ConfigVar{
+		{Name: "mode", Description: "One of a | b | c.\nSpanning two lines."},
+	}}
+
+	row := RenderConfiguration(cfg, ConfigStyleTable)
+
+	// A raw pipe would end the cell, and a newline would end the row.
+	assert.Contains(t, row, `| `+"`mode`"+` | No | No | One of a \| b \| c. Spanning two lines. |`)
+}

--- a/tools/resourcedocsgen/pkg/overview/render.go
+++ b/tools/resourcedocsgen/pkg/overview/render.go
@@ -1,0 +1,243 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overview
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The two constraints docs/overview-page.md calls out as impossible to derive
+// from a schema. The generator emits them as reminders rather than pretending
+// the generated reference is complete.
+const (
+	envVarPlaceholder = `<!-- TODO: Environment-variable fallbacks. A parameter's environment-variable ` +
+		`fallback is often read by the vendor SDK a layer beneath the schema, so it cannot be generated. ` +
+		`Where a parameter can be supplied by an environment variable, name the variable in its description. -->`
+
+	exclusivityPlaceholder = `<!-- TODO: Mutually exclusive options. If setting one parameter forbids or ` +
+		`overrides another, or if a group of parameters must be supplied together, say so in the description ` +
+		`of every parameter involved. Nothing else in the docs will surface that constraint. -->`
+)
+
+// RenderInstallation renders the ## Installation section.
+//
+// Mind the delimiters: chooser takes angle brackets and choosable takes percent
+// signs. Mixing them silently breaks the rendered page.
+func RenderInstallation(plan InstallPlan) string {
+	var b strings.Builder
+	b.WriteString("## Installation\n\n")
+
+	installs := make(map[string]Install, len(plan.Languages))
+	for _, install := range plan.Languages {
+		installs[install.Language] = install
+	}
+
+	// Every language gets a tab, not only the ones with a published SDK. A
+	// reader who picks C# and finds an empty panel has been told nothing; a
+	// reader told to run `pulumi package add` has a working path.
+	fmt.Fprintf(&b, "{{< chooser language %q >}}\n", strings.Join(AllLanguages, ","))
+
+	for _, lang := range AllLanguages {
+		fmt.Fprintf(&b, "{{%% choosable language %s %%}}\n\n", lang)
+
+		install, published := installs[lang]
+		switch {
+		case lang == LangHCL:
+			// HCL has no `pulumi package add` step at all: a program names the
+			// provider in its own required_providers block and `pulumi install`
+			// fetches it.
+			b.WriteString("Declare the provider in your program, then run `pulumi install`:\n\n")
+			b.WriteString(fence("hcl", requiredProvidersBlock(plan)))
+			b.WriteString("\n")
+			b.WriteString(bashFence("pulumi install"))
+		case published && lang == LangJava:
+			b.WriteString("Maven:\n\n")
+			b.WriteString(fence("xml", install.Maven))
+			b.WriteString("\nGradle:\n\n")
+			b.WriteString(fence("groovy", install.Gradle))
+		case published:
+			b.WriteString(bashFence(install.Command))
+		case lang == LangYAML:
+			// YAML consumes the package directly rather than through an SDK.
+			b.WriteString(bashFence(plan.PackageAdd))
+		default:
+			// No SDK is published for this language, so generate one locally.
+			// `pulumi package add` takes the SDK language from the project's
+			// runtime, which is why the command reads the same here as it does
+			// for YAML.
+			b.WriteString(localSDKNote)
+			b.WriteString(bashFence(plan.PackageAdd))
+		}
+
+		b.WriteString("\n{{% /choosable %}}\n")
+	}
+
+	b.WriteString("{{< /chooser >}}\n")
+
+	return b.String()
+}
+
+// localSDKNote precedes the `pulumi package add` command shown for a language
+// with no published SDK, so a reader understands they are generating one rather
+// than installing a package from a feed.
+const localSDKNote = "No SDK is published for this language. Run the following command from your " +
+	"Pulumi project to generate one locally and record it in `Pulumi.yaml`:\n\n"
+
+// requiredProvidersBlock renders the terraform block an HCL program uses to
+// reference the package. A "pulumi/"-prefixed source resolves to the native
+// Pulumi provider and must carry an exact semver version; any other source is
+// bridged from its Terraform provider.
+func requiredProvidersBlock(plan InstallPlan) string {
+	return fmt.Sprintf(`terraform {
+  required_providers {
+    %s = {
+      source  = %q
+      version = %q
+    }
+  }
+}`, plan.Package, plan.HCLSource, plan.HCLVersion)
+}
+
+// ConfigStyle selects the shape of the generated configuration reference.
+type ConfigStyle string
+
+const (
+	// ConfigStyleTable renders a GFM table, one row per parameter.
+	ConfigStyleTable ConfigStyle = "table"
+	// ConfigStyleList renders a bullet list, which is what most existing
+	// Overview pages use.
+	ConfigStyleList ConfigStyle = "list"
+)
+
+// RenderConfiguration renders the ## Configuration section's parameter
+// reference in the requested style.
+func RenderConfiguration(cfg SchemaConfig, style ConfigStyle) string {
+	var b strings.Builder
+	b.WriteString("## Configuration\n\n")
+
+	if style == ConfigStyleList {
+		for _, v := range cfg.Vars {
+			fmt.Fprintf(&b, "- `%s` (%s) — %s\n", v.Name, listMarkers(v), configDescription(v))
+		}
+	} else {
+		b.WriteString("| Name | Required | Secret | Description |\n")
+		b.WriteString("|---|---|---|---|\n")
+		for _, v := range cfg.Vars {
+			fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n",
+				v.Name, yesNo(v.Required), yesNo(v.Secret), escapeCell(configDescription(v)))
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(envVarPlaceholder)
+	b.WriteString("\n")
+	b.WriteString(exclusivityPlaceholder)
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// listMarkers renders the required/secret pair as the parenthetical the bullet
+// form uses, e.g. "Required, Secret".
+func listMarkers(v ConfigVar) string {
+	markers := []string{"Optional"}
+	if v.Required {
+		markers = []string{"Required"}
+	}
+	if v.Secret {
+		markers = append(markers, "Secret")
+	}
+	return strings.Join(markers, ", ")
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
+// configDescription is the parameter's description as a single line, with the
+// environment-variable fallbacks and deprecation notice the schema does know
+// about folded in.
+func configDescription(v ConfigVar) string {
+	description := flatten(v.Description)
+	if description == "" {
+		description = "<TODO: describe this parameter and what a valid value looks like.>"
+	}
+
+	if len(v.EnvVars) > 0 && !mentionsAny(description, v.EnvVars) {
+		quoted := make([]string, len(v.EnvVars))
+		for i, name := range v.EnvVars {
+			quoted[i] = "`" + name + "`"
+		}
+		description = strings.TrimSuffix(description, ".") + ". May also be set with the " +
+			joinWithOr(quoted) + " environment " + pluralize("variable", len(quoted)) + "."
+	}
+
+	if v.Deprecated != "" {
+		description = strings.TrimSuffix(description, ".") + ". Deprecated: " + flatten(v.Deprecated)
+	}
+
+	return description
+}
+
+func mentionsAny(haystack string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func joinWithOr(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " or " + items[1]
+	}
+	return strings.Join(items[:len(items)-1], ", ") + ", or " + items[len(items)-1]
+}
+
+func pluralize(word string, n int) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
+}
+
+// flatten collapses a description onto one line. Every hand-written list item
+// and table row in this repo is a single line, and a table cell cannot contain
+// a newline at all.
+func flatten(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func escapeCell(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+func fence(language, body string) string {
+	return fmt.Sprintf("```%s\n%s\n```\n", language, body)
+}
+
+func bashFence(command string) string {
+	return fence("bash", command)
+}


### PR DESCRIPTION
Fixes #12352 (partially — the configuration drift linter, item 2a, lands separately).

# Josh Says

This is intended as the beginnings of a standardized structure for the registry pages that should be the same everywhere: code that will give new registry packages a starting point for better-looking docs.

It does 2 things:

- Standardize the installation instructions based off the schema for all languages, with an emphasis on CLI tools rather than a link to the package in e.g. npm
- Template out a starting point for the provider configuration parameters based on the schema (with an option for both bulleted lists, the default, and a MD table). This is just a starting point because the info in the schema may not be exhaustive for _each_ option (sometimes it is, sometimes it's not), but _the schema contains all of the config options that should be documented_.

Evolving the standard provider index pages is a challenging problem given that the source docs live upstream in the provider repos as full Markdown docs, but this at least puts "better" and "standardized" into code. I'm not sure yet how we might roll out the improved structure to all providers in the Registry.

## Sample Screenshots - Install

With a published SDK:

<img width="743" height="220" alt="image" src="https://github.com/user-attachments/assets/0e2b057c-a896-45a0-aa78-3927407a6309" />

Without a published SDK:

<img width="745" height="261" alt="image" src="https://github.com/user-attachments/assets/3d0e77d8-8bde-4f08-98c1-00667dd1d5ba" />

YAML (never uses an SDK):

<img width="748" height="206" alt="image" src="https://github.com/user-attachments/assets/72a8137e-9238-44d6-b2c7-efbf6f6f507f" />

HCL (a special little snowflake):

<img width="759" height="450" alt="image" src="https://github.com/user-attachments/assets/9d23abab-a131-4089-801e-c083e25b400a" />

## Sample Screenshots - Provider Config

Bullet list (more compact):

<img width="717" height="302" alt="image" src="https://github.com/user-attachments/assets/be2c872e-b871-4d92-91d6-8db6280ab232" />

MD tables:

(Note that we can't template these for a nice display because they have to be hand-edited after the fact and there's no way to get a macro to render where in the provider repo, where these need to be sourced.)

<img width="741" height="483" alt="image" src="https://github.com/user-attachments/assets/147b951f-2e22-479e-9d56-82bcd07e377e" />


# Claude Says

## What

Two of the sections [the Overview page standard](https://github.com/pulumi/registry/blob/master/docs/overview-page.md) requires are mechanically derivable from a package's `schema.json`, and today every author writes them by hand — which is why they are so often incomplete or stale.

This adds two **experimental** `resourcedocsgen` commands that print a markdown snippet to stdout:

```bash
resourcedocsgen gen-install --schemaFile provider/cmd/pulumi-resource-example/schema.json --version v1.2.3
resourcedocsgen gen-config  --schemaFile provider/cmd/pulumi-resource-example/schema.json
```

Both are **advisory**. The Overview page is authored in the provider's own repository and fetched from its release tag by `metadata from-github`, so these generate something to paste and edit, not a page. Nothing in CI calls them, and no behavior changes for any existing build.

## What the schema can and cannot answer

**It cannot tell you which SDKs a package publishes.** The `language` blob is written by the code generator, not by the release pipeline. `chainguard-dev/cosign` declares all five languages and publishes none; `pulumi-vault` declares no `java` block yet publishes `com.pulumi/vault`. So `gen-install` guesses and takes `--languages` as the correction, with `--languages none` for the ~100 bridged packages that publish nothing.

**Every one of the seven chooser languages gets a tab regardless.** A reader who picks C# and finds an empty panel has been told nothing; one told to run `pulumi package add` has a working path. Verified empirically that the command reads the same for every language, because it takes the SDK language from the `runtime` in the reader's `Pulumi.yaml`:

| Probe | Result |
|---|---|
| `pulumi package add random` in a `runtime: nodejs` project | generates SDK, installs deps, records `packages:` in Pulumi.yaml, prints `import * as random from "@pulumi/random"` |
| same command in a `runtime: go` project | same, prints the Go import path |
| outside any project | requires `--language nodejs\|python\|go\|dotnet\|java` |

**HCL is the exception and never uses `pulumi package add`.** Its tab emits a `required_providers` block plus `pulumi install`. A native provider is sourced as `pulumi/<name>` and pinned to an exact semver version; a package parameterized over a Terraform provider reuses that provider's upstream source and version, recovered from the base64 `parameterization.parameter` — `cosign` → `chainguard-dev/cosign`, matching its committed page exactly.

**`gen-config`** reads the provider `config` block, resolving one level of `$ref` and folding in `defaultInfo.environment`. Requiredness comes from the config block's `defaults` list (the JSON key does not match the Go field name), and is only as accurate as the schema is — `pulumi-vault` marks nothing required and does not mark its `token` secret. The output says so honestly rather than inventing it, and ends with placeholders for the two things the standard requires that no schema can express: environment-variable fallbacks and mutually exclusive options.

It emits a bullet list by default, matching ~110 of the 149 existing configuration references; `--style table` emits a GFM table instead.

## Docs

`docs/overview-page.md` gains a canonical configuration example in both shapes, plus three corrections the implementation surfaced:

- **Installation** now says to give every language a tab, reversing "list only the languages your package actually supports".
- Its **HCL tab showed `pulumi package add`**, which HCL does not use at all.
- Its **`pulumi plugin install` note** now leads with "you almost certainly do not need this". `pluginDownloadURL` is compiled into every SDK, so its presence is evidence the manual step is *not* needed — the opposite of what the note implied.

`## Example Usage` also gains chooser guidance and a worked three-language example. **Nothing here generates that section**; it is included because it had the same gap — it demanded a program in every language without saying how to present them.

## Risk

The only change to pre-existing code is exporting `docs.SanitizeDescription`, reused to strip the `<span pulumi-lang-*>` markup bridged providers carry in config descriptions. The `cmd/testdata` goldens are byte-identical, which is the check that the rename altered nothing.

## Testing

`go test ./...`, `make lint-resourcedocsgen` and `make lint-markdown` pass. Golden fixtures are trimmed real schemas, each chosen because it breaks a naive implementation: `ise` (five languages on pure defaults), `vault` (`/sdk/v7` Go path, no `java` block despite a published Java SDK, no `defaults` key, a `$ref` config type), `logfire` (scoped npm name, `<span pulumi-lang-*>` in a description), `cosign` (all five language blocks, zero SDKs, parameterized), and an empty-config package. No test touches the network.

Rendered locally against the Logfire page to confirm the chooser, the HCL block and the configuration list all display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXzNvw9yTH4Kcdx6ZhsKKt
