### PR TITLE
Update CODEOWNERS for renamed GitHub teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 CODEOWNERS @komalali @mjeffryes @iwahbe
 
 # Community packages.
-/community-packages/ @pulumi/iac-cloud
+/community-packages/ @pulumi/pulumi-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 CODEOWNERS @komalali @mjeffryes @iwahbe
 
 # Community packages.
-/community-packages/ @pulumi/pulumi-platform
+/community-packages/ @pulumi/cloud-platform


### PR DESCRIPTION
The GitHub team `@pulumi/iac-cloud` no longer exists. The GitHub teams API returns 404 for that slug, so GitHub requests no reviews from it. This change maps `@pulumi/iac-cloud` to `@pulumi/pulumi-platform`. The source of truth is `teams.yaml` in `pulumi/team-management`, at commit 525c7378, "Realign teams to the Aug 17 reorg".
