### PR TITLE
Suggest OpenTofu providers when registry search finds nothing

### DIFF
--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -110,10 +110,23 @@ describe("www.pulumi.com/registry", () => {
         };
 
         // Types into the filter and waits for the empty state to actually be reached,
-        // so assertions don't race the search component's 300ms debounce.
+        // so assertions don't race the search component's 300ms debounce. The
+        // zero-visible-packages assertion is retried, and it can't pass until
+        // filterByTextAndTags -> updateAllCount -> syncEmptyState has run, which is
+        // what makes the "did we fetch?" assertions below deterministic.
         const filterToEmpty = (query) => {
             cy.get(".registry-filter-input").clear().type(query);
             cy.get(".all-packages .package:not(.hidden)").should("have.length", 0);
+        };
+
+        // Ticks a tag filter. The option checkboxes live in shadow DOM behind an
+        // opacity-transitioned menu, so this drives pulumi-filter-select's own
+        // select() @Method() instead. The should() retries until Stencil has
+        // upgraded the element and put the method on it.
+        const selectFilter = (value) => {
+            cy.get("pulumi-filter-select")
+                .should(($el) => expect($el[0].select).to.be.a("function"))
+                .then(($el) => $el[0].select({ value }));
         };
 
         beforeEach(() => {
@@ -153,6 +166,46 @@ describe("www.pulumi.com/registry", () => {
                     "have.text",
                     "$ pulumi package add terraform-provider carlpett/sops 1.4.1",
                 );
+        });
+
+        it("collapses repeated rows for the same provider", () => {
+            // The endpoint looks like one row per documentation page, so a provider
+            // could plausibly return several type:"provider" rows and eat several of
+            // the five slots. Only the best-ranked row for each addr survives.
+            stubTofu({
+                body: [
+                    { type: "provider", addr: "carlpett/sops", version: "v1.4.1", popularity: 584 },
+                    { type: "provider", addr: "carlpett/sops", version: "v1.3.0", popularity: 584 },
+                    { type: "provider", addr: "nobbs/sops", version: "v0.3.3", popularity: 18 },
+                ],
+            });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-item").should("have.length", 2);
+            cy.get(".tf-suggest .tf-suggest-item")
+                .first()
+                .find("code")
+                .should("contain.text", "carlpett/sops 1.4.1");
+        });
+
+        it("announces the search only once the lookup is visibly slow", () => {
+            // The loading heading is deferred so a lookup that resolves at typing
+            // speed never paints an intermediate state into the aria-live region.
+            // A slow one still says what it is doing.
+            cy.intercept("GET", TOFU_API, { body: twoProviders, delay: 1500 }).as("tofu");
+            filterToEmpty("sops");
+
+            cy.get(".tf-suggest .tf-suggest-message").should(
+                "contain.text",
+                "Searching the OpenTofu registry",
+            );
+
+            cy.wait("@tofu");
+            cy.get(".tf-suggest .tf-suggest-message").should(
+                "contain.text",
+                "2 providers in the OpenTofu registry",
+            );
         });
 
         it("prefers the vendor's own namespace when stars tie", () => {
@@ -267,29 +320,33 @@ describe("www.pulumi.com/registry", () => {
             cy.get(".tf-suggest hr.tf-suggest-divider").should("exist");
         });
 
-        it("shows no rule or OpenTofu message when it never searched", () => {
+        it("does not query OpenTofu for a single-character query", () => {
             cy.intercept("GET", TOFU_API, { body: [] }).as("tofu");
-            cy.get(".registry-filter-input").clear().type("q");
-            cy.wait(500);
+
+            // "~" appears in no package name, title, or keyword, so the empty state
+            // is genuinely reached and MIN_QUERY_LENGTH is what suppresses the
+            // lookup. A letter would not test that: "q" alone matches equinix,
+            // mssql, mysql, postgresql, qdrant-cloud and five more, so the panel
+            // would stay CSS-hidden and syncEmptyState would bail on visibleCount
+            // long before reaching the guard.
+            filterToEmpty("~");
+
             cy.get(".tf-suggest").should("be.empty");
             cy.get("@tofu.all").should("have.length", 0);
         });
 
         it("does not query OpenTofu when only tag filters are applied", () => {
             cy.intercept("GET", TOFU_API, { body: [] }).as("tofu");
-            cy.visit("/registry/");
 
-            // Deprecated + a category that has no deprecated packages yields an empty
-            // list with an empty search box.
-            cy.get(".registry-filter-input").clear();
+            // Deprecated + Version Control: both version-control packages are
+            // current, so the pair yields an empty list while the search box stays
+            // empty -- there is no query to send.
+            selectFilter("deprecated");
+            selectFilter("version control system");
+
+            cy.get(".all-packages .package:not(.hidden)").should("have.length", 0);
+            cy.get(".registry-filter-input").should("have.value", "");
             cy.get(".tf-suggest").should("be.empty");
-            cy.get("@tofu.all").should("have.length", 0);
-        });
-
-        it("does not query OpenTofu for a single-character query", () => {
-            cy.intercept("GET", TOFU_API, { body: [] }).as("tofu");
-            cy.get(".registry-filter-input").clear().type("q");
-            cy.wait(500);
             cy.get("@tofu.all").should("have.length", 0);
         });
 

--- a/cypress/e2e/site.cy.js
+++ b/cypress/e2e/site.cy.js
@@ -89,4 +89,220 @@ describe("www.pulumi.com/registry", () => {
             cy.get(".all-packages .package:not(.hidden)").should("have.length", 0);
         });
     });
+
+    // When the filter comes up empty, we look the query up in the OpenTofu registry
+    // and offer `pulumi package add terraform-provider ...` for what we find, since
+    // Pulumi can run any Terraform/OpenTofu provider. See issue #7299.
+    describe("no-results OpenTofu suggestions", () => {
+        const TOFU_API = "https://api.opentofu.org/registry/docs/search*";
+
+        // Deliberately returned out of rank order, and with a non-provider row, so
+        // the assertions below prove we re-sort and filter rather than echoing the API.
+        const twoProviders = [
+            { type: "provider", addr: "nobbs/sops", version: "v0.3.3", popularity: 18 },
+            { type: "module", addr: "someone/sops/aws", version: "v1.0.0", popularity: 99999 },
+            { type: "provider/resource", addr: "carlpett/sops", version: "v1.4.1", popularity: 99999 },
+            { type: "provider", addr: "carlpett/sops", version: "v1.4.1", popularity: 584 },
+        ];
+
+        const stubTofu = (response) => {
+            cy.intercept("GET", TOFU_API, response).as("tofu");
+        };
+
+        // Types into the filter and waits for the empty state to actually be reached,
+        // so assertions don't race the search component's 300ms debounce.
+        const filterToEmpty = (query) => {
+            cy.get(".registry-filter-input").clear().type(query);
+            cy.get(".all-packages .package:not(.hidden)").should("have.length", 0);
+        };
+
+        beforeEach(() => {
+            cy.visit("/registry/");
+        });
+
+        it("ranks providers by stars, not by API order", () => {
+            stubTofu({ body: twoProviders });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-item").should("have.length", 2);
+            cy.get(".tf-suggest .tf-suggest-item")
+                .first()
+                .should("contain.text", "carlpett/sops");
+        });
+
+        it("drops non-provider result types", () => {
+            stubTofu({ body: twoProviders });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            // The module and the provider/resource rows must not appear.
+            cy.get(".tf-suggest").should("not.contain.text", "someone/sops/aws");
+            cy.get(".tf-suggest .tf-suggest-item").should("have.length", 2);
+        });
+
+        it("pins the version in the command, without the leading v", () => {
+            stubTofu({ body: twoProviders });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-item")
+                .first()
+                .find("code")
+                .should(
+                    "have.text",
+                    "$ pulumi package add terraform-provider carlpett/sops 1.4.1",
+                );
+        });
+
+        it("prefers the vendor's own namespace when stars tie", () => {
+            stubTofu({
+                body: [
+                    { type: "provider", addr: "adamdecaf/namecheap", version: "v2.9.2", popularity: 168 },
+                    { type: "provider", addr: "namecheap/namecheap", version: "v2.9.2", popularity: 168 },
+                ],
+            });
+            filterToEmpty("namecheap");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-item")
+                .first()
+                .should("contain.text", "namecheap/namecheap");
+        });
+
+        it("links each provider to the OpenTofu registry in a new tab", () => {
+            stubTofu({ body: twoProviders });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-item")
+                .first()
+                .find("a")
+                .should(
+                    "have.attr",
+                    "href",
+                    "https://search.opentofu.org/provider/carlpett/sops/v1.4.1",
+                )
+                .and("have.attr", "target", "_blank")
+                .and("have.attr", "rel")
+                .and("include", "noopener");
+        });
+
+        it("falls back to the docs link when OpenTofu returns nothing", () => {
+            stubTofu({ body: [] });
+            filterToEmpty("zzzznope");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-item").should("not.exist");
+            cy.get(".no-results .tf-suggest-fallback a")
+                .should("be.visible")
+                .and(
+                    "have.attr",
+                    "href",
+                    "/docs/iac/concepts/providers/any-terraform-provider/",
+                );
+        });
+
+        it("falls back to the docs link when the API fails", () => {
+            cy.intercept("GET", TOFU_API, { forceNetworkError: true }).as("tofu");
+            filterToEmpty("zzzznope");
+
+            cy.get(".tf-suggest .tf-suggest-item").should("not.exist");
+            cy.get(".no-results .tf-suggest-fallback a").should("be.visible");
+        });
+
+        it("drops entries whose addr is not a plain namespace/name", () => {
+            stubTofu({
+                body: [
+                    { type: "provider", addr: "evil/<img src=x onerror=alert(1)>", version: "v1.0.0", popularity: 99999 },
+                    { type: "provider", addr: "carlpett/sops", version: "v1.4.1", popularity: 1 },
+                ],
+            });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            cy.get(".no-results img").should("not.exist");
+            cy.get(".tf-suggest .tf-suggest-item").should("have.length", 1);
+        });
+
+        it("attributes each message to its own registry, split by a rule", () => {
+            stubTofu({ body: twoProviders });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            // Pulumi's message names Pulumi; OpenTofu's names OpenTofu and counts.
+            cy.get(".no-results .no-results-message")
+                .should("contain.text", "Pulumi Registry")
+                .and("contain.text", "sops");
+            cy.get(".tf-suggest .tf-suggest-message")
+                .should("contain.text", "2 providers in the OpenTofu registry")
+                .and("contain.text", "sops");
+            cy.get(".tf-suggest hr.tf-suggest-divider").should("exist");
+        });
+
+        it("uses the singular message for a single provider", () => {
+            stubTofu({
+                body: [
+                    { type: "provider", addr: "carlpett/sops", version: "v1.4.1", popularity: 584 },
+                ],
+            });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-message").should(
+                "contain.text",
+                "1 provider in the OpenTofu registry matches",
+            );
+        });
+
+        it("says so explicitly when OpenTofu has no match either", () => {
+            stubTofu({ body: [] });
+            filterToEmpty("zzzznope");
+            cy.wait("@tofu");
+
+            cy.get(".tf-suggest .tf-suggest-message").should(
+                "contain.text",
+                "No providers in the OpenTofu registry match",
+            );
+            cy.get(".tf-suggest hr.tf-suggest-divider").should("exist");
+        });
+
+        it("shows no rule or OpenTofu message when it never searched", () => {
+            cy.intercept("GET", TOFU_API, { body: [] }).as("tofu");
+            cy.get(".registry-filter-input").clear().type("q");
+            cy.wait(500);
+            cy.get(".tf-suggest").should("be.empty");
+            cy.get("@tofu.all").should("have.length", 0);
+        });
+
+        it("does not query OpenTofu when only tag filters are applied", () => {
+            cy.intercept("GET", TOFU_API, { body: [] }).as("tofu");
+            cy.visit("/registry/");
+
+            // Deprecated + a category that has no deprecated packages yields an empty
+            // list with an empty search box.
+            cy.get(".registry-filter-input").clear();
+            cy.get(".tf-suggest").should("be.empty");
+            cy.get("@tofu.all").should("have.length", 0);
+        });
+
+        it("does not query OpenTofu for a single-character query", () => {
+            cy.intercept("GET", TOFU_API, { body: [] }).as("tofu");
+            cy.get(".registry-filter-input").clear().type("q");
+            cy.wait(500);
+            cy.get("@tofu.all").should("have.length", 0);
+        });
+
+        it("keeps Clear all filters working once suggestions are rendered", () => {
+            stubTofu({ body: twoProviders });
+            filterToEmpty("sops");
+            cy.wait("@tofu");
+            cy.get(".tf-suggest .tf-suggest-item").should("have.length", 2);
+
+            cy.get(".no-results .reset").click();
+
+            cy.get(".all-packages .package:not(.hidden)").should("have.length.greaterThan", 0);
+            cy.get(".tf-suggest").should("be.empty");
+        });
+    });
 });

--- a/themes/default/layouts/partials/registry/package-list.html
+++ b/themes/default/layouts/partials/registry/package-list.html
@@ -137,12 +137,34 @@ append . }} {{ end }} {{ end }}
             <!-- Capture the current (i.e., Page) context so it can be passed into the partial, allowing the partial to build proper relrefs. -->
             {{ $page := . }} {{ range (sort $allPackages "title") }} {{ partial
             "registry/package" (dict "package" . "page" $page) }} {{ end }}
-            <div class="no-results px-4">
-                <p>
+            <div class="no-results w-full px-4">
+                <p class="no-results-message">
                     Looks like we don't have any packages that match your
                     filters. Adjust or clear the filters and try again.
                 </p>
-                <button class="reset btn btn-lg">Clear all filters</button>
+
+                <!--
+                    Owned by opentofu-suggest.ts. Server-rendered empty so the live
+                    region exists in the DOM before anything is injected into it.
+                -->
+                <div class="tf-suggest" role="status" aria-live="polite"></div>
+
+                <!--
+                    Static fallback. Always present, so a failed (or absent) OpenTofu
+                    lookup still leaves the user with a way forward.
+                -->
+                <p class="tf-suggest-fallback">
+                    Pulumi can use <strong>any</strong> Terraform or OpenTofu
+                    provider, even one with no Pulumi package.
+                    <a
+                        href="/docs/iac/concepts/providers/any-terraform-provider/"
+                        >Learn how to use any Terraform provider</a
+                    >.
+                </p>
+
+                <button class="reset btn btn-secondary btn-lg">
+                    Clear all filters
+                </button>
             </div>
         </div>
     </section>

--- a/themes/default/theme/src/scss/docs/_docs-theme.scss
+++ b/themes/default/theme/src/scss/docs/_docs-theme.scss
@@ -1030,6 +1030,20 @@ html[data-theme="dark"] body.section-registry {
         color: var(--docs-fg-muted);
     }
 
+    // Empty-state Any Terraform Provider suggestions. The command blocks inside
+    // are plain `div.highlight > pre`, already handled above, so only the text and
+    // link colors need naming here.
+    .all-packages .no-results {
+        .tf-suggest-meta,
+        .tf-suggest-fallback {
+            color: var(--docs-fg-muted);
+        }
+
+        .tf-suggest a {
+            color: var(--docs-link);
+        }
+    }
+
     // The mobile accordion's own background is written as an inline style by
     // docs-main.ts every time it's toggled, so no rule here can override it. These
     // two properties are what that inline style resolves instead; light mode never

--- a/themes/default/theme/src/scss/docs/_packages.scss
+++ b/themes/default/theme/src/scss/docs/_packages.scss
@@ -46,8 +46,11 @@
             @apply text-sm text-gray-700;
         }
 
+        // Same weight as .tf-suggest-meta above: both are secondary notes beside
+        // the results, and the dark override in _docs-theme.scss already paints
+        // the pair with --docs-fg-muted (which is gray-700's counterpart).
         .tf-suggest-fallback {
-            @apply text-sm mt-6;
+            @apply text-sm text-gray-700 mt-6;
         }
     }
 

--- a/themes/default/theme/src/scss/docs/_packages.scss
+++ b/themes/default/theme/src/scss/docs/_packages.scss
@@ -9,6 +9,48 @@
         }
     }
 
+    // Any Terraform Provider suggestions in the empty state. Light values only —
+    // the dark half lives in _docs-theme.scss, which is unlayered and so beats
+    // anything written here. The injected `div.highlight > pre` command blocks
+    // need no rules at all: _code-light.scss and _docs-theme.scss already paint
+    // them in both modes.
+    .no-results {
+        .tf-suggest:empty {
+            @apply hidden;
+        }
+
+        // Marks the boundary between the Pulumi Registry results above and the
+        // OpenTofu registry results below. Colourless `border-t` picks up the
+        // default border, which the dark base rule already remaps.
+        .tf-suggest-divider {
+            @apply border-0 border-t my-6;
+        }
+
+        .tf-suggest-message {
+            @apply text-base font-semibold mb-3;
+        }
+
+        .tf-suggest-list {
+            @apply list-none p-0 m-0;
+        }
+
+        .tf-suggest-item {
+            @apply mb-4;
+        }
+
+        .tf-suggest-header {
+            @apply flex items-baseline gap-3 mb-1;
+        }
+
+        .tf-suggest-meta {
+            @apply text-sm text-gray-700;
+        }
+
+        .tf-suggest-fallback {
+            @apply text-sm mt-6;
+        }
+    }
+
     .package-tags {
         @apply inline-flex flex-wrap list-none p-0;
         max-width: 430px;

--- a/themes/default/theme/src/ts/copybutton.ts
+++ b/themes/default/theme/src/ts/copybutton.ts
@@ -94,7 +94,7 @@ function normalizeText(lang, text) {
     return text;
 }
 
-function addCopyButton(container: HTMLElement) {
+export function addCopyButton(container: HTMLElement) {
     var tooltipText = "Copy";
     var copyIconSvg =
         '<svg xmlns="http://www.w3.org/2000/svg" class="ph-icon ph-icon--regular copy" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" focusable="false">' +

--- a/themes/default/theme/src/ts/opentofu-suggest.ts
+++ b/themes/default/theme/src/ts/opentofu-suggest.ts
@@ -18,6 +18,13 @@ const PROVIDER_BASE = "https://search.opentofu.org/provider/";
 const MIN_QUERY_LENGTH = 2;
 const MAX_RESULTS = 5;
 const TIMEOUT_MS = 5000;
+// How long a lookup may run before we admit to the user that it is running. Matches
+// the search component's own 300ms debounce (pulumi-registry-list-search.tsx), so a
+// lookup that resolves at typing speed never paints an intermediate state at all.
+const LOADING_DELAY_MS = 300;
+// How much of the user's query we echo back in a heading. One value for every
+// message, so the Pulumi and OpenTofu lines truncate at the same point.
+const QUERY_ECHO_MAX = 60;
 
 const DEFAULT_MESSAGE =
     "Looks like we don't have any packages that match your filters. " +
@@ -49,7 +56,9 @@ let renderedKey: string | null = null; // what is currently painted
 const formatStars = (n: number): string => {
     if (n < 1000) return String(n);
     if (n < 100000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}K`;
-    if (n < 1000000) return `${Math.round(n / 1000)}K`;
+    // 999500 rather than 1000000: that is the exact point where Math.round(n / 1000)
+    // reaches 1000, and "1000K" is not a thing anyone writes.
+    if (n < 999500) return `${Math.round(n / 1000)}K`;
     return `${(n / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
 };
 
@@ -105,6 +114,12 @@ const normalizeResults = (body: any[]): TofuProvider[] =>
                 Number(isVendorNamespace(b)) - Number(isVendorNamespace(a)) ||
                 a.addr.localeCompare(b.addr),
         )
+        // Defensive: the endpoint appears to return one row per documentation page,
+        // so a provider with more than one published version could plausibly yield
+        // several type:"provider" rows for the same addr and eat several of the five
+        // slots. Unconfirmed against the live API, but cheap to make impossible.
+        // Runs after the sort, so the survivor of each addr is its best-ranked row.
+        .filter((p, i, all) => all.findIndex(o => o.addr === p.addr) === i)
         .slice(0, MAX_RESULTS);
 
 const buildCommand = (provider: TofuProvider): HTMLElement => {
@@ -185,7 +200,10 @@ const openSection = (region: HTMLElement, message: string): void => {
 };
 
 const renderLoading = (region: HTMLElement, query: string): void => {
-    openSection(region, `Searching the OpenTofu registry for "${truncate(query, 60)}"…`);
+    openSection(
+        region,
+        `Searching the OpenTofu registry for "${truncate(query, QUERY_ECHO_MAX)}"…`,
+    );
 };
 
 const render = (
@@ -195,7 +213,7 @@ const render = (
     query: string,
 ): void => {
     renderedKey = key;
-    const shown = `"${truncate(query, 60)}"`;
+    const shown = `"${truncate(query, QUERY_ECHO_MAX)}"`;
 
     if (providers.length === 0) {
         // Said explicitly rather than left blank: we told the user we were looking,
@@ -227,8 +245,21 @@ const fetchAndRender = async (
     inFlight = controller;
     const timer = window.setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-    renderLoading(region, query);
+    // Drop the previous query's results right away — the Pulumi message above has
+    // already been rewritten for the new query, so leaving them would put a heading
+    // naming one query above results for another. Removing nodes from a live region
+    // announces nothing, and .tf-suggest:empty collapses the panel.
+    clear(region);
     renderedKey = null;
+
+    // Painting "Searching…" into a role="status" region on every debounced keystroke
+    // makes a screen reader read a run of "Searching… / 5 providers match /
+    // Searching… / 2 providers match". Defer it: a lookup that settles inside
+    // LOADING_DELAY_MS paints and announces nothing but its result. Slow lookups
+    // still get the heading, which is the case where it earns its keep.
+    const loadingTimer = window.setTimeout(() => {
+        if (key === currentKey) renderLoading(region, query);
+    }, LOADING_DELAY_MS);
 
     try {
         const res = await fetch(API + encodeURIComponent(query), {
@@ -246,13 +277,17 @@ const fetchAndRender = async (
     } catch (e) {
         // Aborted, offline, non-200, or malformed. Degrade quietly: the static
         // fallback paragraph below is server-rendered and still on screen. An error
-        // banner in an already-frustrating dead end is worse than nothing. Failures
-        // are deliberately not cached, so the next keystroke retries.
+        // banner in an already-frustrating dead end is worse than nothing.
+        //
+        // renderedKey is set so that the repeated syncEmptyState calls a single query
+        // produces don't re-fire the request. The result itself is never cached, so
+        // once anything else has been rendered, coming back to this query does retry.
         if (key !== currentKey) return;
         clear(region);
         renderedKey = key;
     } finally {
         window.clearTimeout(timer);
+        window.clearTimeout(loadingTimer);
         if (inFlight === controller) inFlight = null;
     }
 };
@@ -292,7 +327,7 @@ export const syncEmptyState = (visibleCount: number, filterText: string): void =
     if (message) {
         message.textContent =
             query.length > 0
-                ? `No packages in the Pulumi Registry match "${truncate(query, 80)}".`
+                ? `No packages in the Pulumi Registry match "${truncate(query, QUERY_ECHO_MAX)}".`
                 : DEFAULT_MESSAGE;
     }
 

--- a/themes/default/theme/src/ts/opentofu-suggest.ts
+++ b/themes/default/theme/src/ts/opentofu-suggest.ts
@@ -1,0 +1,317 @@
+// Suggests Terraform/OpenTofu providers when the registry package filter comes up
+// empty. Pulumi can run any provider in the OpenTofu registry via Any Terraform
+// Provider, so a zero-result filter is the highest-intent moment to say so.
+//
+// The panel itself is shown and hidden entirely by CSS (see _packages.scss: a
+// general sibling combinator reveals .no-results once every .package is hidden).
+// This module never touches that. It owns exactly two things inside the panel:
+// the .no-results-message text and the children of .tf-suggest.
+//
+// It deliberately does NOT rebuild .no-results itself — packages.ts binds the
+// "Clear all filters" listener to that button once at module load, so replacing
+// the panel's innerHTML would silently break it.
+
+import { addCopyButton } from "./copybutton";
+
+const API = "https://api.opentofu.org/registry/docs/search?q=";
+const PROVIDER_BASE = "https://search.opentofu.org/provider/";
+const MIN_QUERY_LENGTH = 2;
+const MAX_RESULTS = 5;
+const TIMEOUT_MS = 5000;
+
+const DEFAULT_MESSAGE =
+    "Looks like we don't have any packages that match your filters. " +
+    "Adjust or clear the filters and try again.";
+
+// `addr` and `version` end up in a URL and in a command we ask people to paste into
+// a shell. Anyone can publish a provider to the OpenTofu registry under any name, so
+// these are allowlists: an entry that doesn't match is dropped, not escaped.
+const ADDR_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z.+-]*$/;
+// The registry keys versions with their leading "v" ("v1.4.1"), which is what the
+// provider page URL needs; `pulumi package add` wants them without it. Keep both.
+const RAW_VERSION_RE = /^v?[0-9][0-9A-Za-z.+-]*$/;
+
+interface TofuProvider {
+    addr: string;
+    version: string; // stripped of its leading "v", for the command; "" when unusable
+    urlVersion: string; // exactly as the registry keys it ("v1.4.1"), or "latest"
+    stars: number;
+}
+
+const cache = new Map<string, TofuProvider[]>();
+let inFlight: AbortController | null = null;
+let currentKey = ""; // the query that owns the panel right now
+let renderedKey: string | null = null; // what is currently painted
+
+// Matches the compact form the site already uses for the pulumi/pulumi star count
+// in docs-top-nav.html (via scripts/fetch-github-stars.js).
+const formatStars = (n: number): string => {
+    if (n < 1000) return String(n);
+    if (n < 100000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}K`;
+    if (n < 1000000) return `${Math.round(n / 1000)}K`;
+    return `${(n / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
+};
+
+const truncate = (s: string, max: number): string =>
+    s.length > max ? `${s.slice(0, max)}…` : s;
+
+const clear = (el: HTMLElement): void => {
+    while (el.firstChild) el.removeChild(el.firstChild);
+};
+
+// True for providers published under a namespace matching their own name, e.g.
+// zerotier/zerotier — the vendor's own publication rather than someone's fork.
+const isVendorNamespace = (p: TofuProvider): boolean => {
+    const parts = p.addr.split("/");
+    return parts[0].toLowerCase() === parts[1].toLowerCase();
+};
+
+const normalizeResults = (body: any[]): TofuProvider[] =>
+    body
+        .filter(
+            r =>
+                r &&
+                r.type === "provider" &&
+                typeof r.addr === "string" &&
+                ADDR_RE.test(r.addr),
+        )
+        .map(r => {
+            const raw = typeof r.version === "string" ? r.version : "";
+            const bare = raw.replace(/^v/, "");
+            const stars = Number(r.popularity);
+            return {
+                addr: r.addr as string,
+                version: VERSION_RE.test(bare) ? bare : "",
+                // Pass the registry's own key through untouched rather than
+                // re-deriving it: "1.4.1" 404s where "v1.4.1" resolves, and not every
+                // provider is guaranteed to carry the prefix.
+                urlVersion: RAW_VERSION_RE.test(raw) ? raw : "latest",
+                stars: isFinite(stars) ? stars : 0,
+            };
+        })
+        // The API's own ranking is not trustworthy — for "random" it puts a 0-star
+        // fork above hashicorp/random. Sort by:
+        //   1. stars, which is what separates a real provider from its forks;
+        //   2. a namespace matching the provider name (zerotier/zerotier,
+        //      namecheap/namecheap), which marks the vendor's own publication. Real
+        //      ties happen — adamdecaf/namecheap and namecheap/namecheap both sit at
+        //      168 stars, and every zerotier provider has 0 — and without this the
+        //      fork wins the top slot on alphabetical order alone;
+        //   3. addr, purely so equal entries don't reshuffle between renders.
+        .sort(
+            (a, b) =>
+                b.stars - a.stars ||
+                Number(isVendorNamespace(b)) - Number(isVendorNamespace(a)) ||
+                a.addr.localeCompare(b.addr),
+        )
+        .slice(0, MAX_RESULTS);
+
+const buildCommand = (provider: TofuProvider): HTMLElement => {
+    const highlight = document.createElement("div");
+    highlight.className = "highlight";
+    const pre = document.createElement("pre");
+    pre.className = "chroma";
+    const code = document.createElement("code");
+    code.className = "language-bash";
+    code.setAttribute("data-lang", "bash");
+    code.setAttribute("data-track", "registry-no-results-tf-provider");
+
+    // textContent, never innerHTML — addr/version are third-party strings. The "$ "
+    // prompt is the site convention; copybutton's normalizeText strips it on copy.
+    const base = `$ pulumi package add terraform-provider ${provider.addr}`;
+    code.textContent = provider.version ? `${base} ${provider.version}` : base;
+
+    pre.appendChild(code);
+    highlight.appendChild(pre);
+    // Reuses the sitewide copy button so this looks and behaves like every other
+    // command on pulumi.com. Its internal insertAdjacentHTML takes a static literal.
+    addCopyButton(highlight);
+    return highlight;
+};
+
+const buildRow = (provider: TofuProvider): HTMLElement => {
+    const li = document.createElement("li");
+    li.className = "tf-suggest-item";
+
+    const header = document.createElement("div");
+    header.className = "tf-suggest-header";
+
+    const [namespace, name] = provider.addr.split("/");
+    const link = document.createElement("a");
+    // Origin is a hardcoded literal and both segments already passed ADDR_RE, so a
+    // javascript: href is structurally impossible; encode anyway.
+    link.href =
+        PROVIDER_BASE +
+        `${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/` +
+        encodeURIComponent(provider.urlVersion);
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = provider.addr;
+    link.setAttribute(
+        "aria-label",
+        `${provider.addr} on the OpenTofu registry (opens in a new tab)`,
+    );
+    header.appendChild(link);
+
+    const meta = document.createElement("span");
+    meta.className = "tf-suggest-meta";
+    meta.textContent = `★ ${formatStars(provider.stars)}`;
+    meta.setAttribute(
+        "aria-label",
+        `${provider.stars} GitHub ${provider.stars === 1 ? "star" : "stars"}`,
+    );
+    header.appendChild(meta);
+
+    li.appendChild(header);
+    li.appendChild(buildCommand(provider));
+    return li;
+};
+
+// Everything the OpenTofu lookup renders sits below a rule, so it reads as coming
+// from a different registry than the (empty) Pulumi results above it.
+const openSection = (region: HTMLElement, message: string): void => {
+    clear(region);
+
+    const divider = document.createElement("hr");
+    divider.className = "tf-suggest-divider";
+    region.appendChild(divider);
+
+    const heading = document.createElement("h3");
+    heading.className = "tf-suggest-message";
+    heading.id = "tf-suggest-heading";
+    heading.textContent = message;
+    region.appendChild(heading);
+};
+
+const renderLoading = (region: HTMLElement, query: string): void => {
+    openSection(region, `Searching the OpenTofu registry for "${truncate(query, 60)}"…`);
+};
+
+const render = (
+    region: HTMLElement,
+    providers: TofuProvider[],
+    key: string,
+    query: string,
+): void => {
+    renderedKey = key;
+    const shown = `"${truncate(query, 60)}"`;
+
+    if (providers.length === 0) {
+        // Said explicitly rather than left blank: we told the user we were looking,
+        // so report the result. The fallback paragraph below still offers the docs.
+        openSection(region, `No providers in the OpenTofu registry match ${shown}.`);
+        return;
+    }
+
+    openSection(
+        region,
+        providers.length === 1
+            ? `1 provider in the OpenTofu registry matches ${shown}:`
+            : `${providers.length} providers in the OpenTofu registry match ${shown}:`,
+    );
+
+    const list = document.createElement("ul");
+    list.className = "tf-suggest-list";
+    list.setAttribute("aria-labelledby", "tf-suggest-heading");
+    providers.forEach(p => list.appendChild(buildRow(p)));
+    region.appendChild(list);
+};
+
+const fetchAndRender = async (
+    region: HTMLElement,
+    query: string,
+    key: string,
+): Promise<void> => {
+    const controller = new AbortController();
+    inFlight = controller;
+    const timer = window.setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    renderLoading(region, query);
+    renderedKey = null;
+
+    try {
+        const res = await fetch(API + encodeURIComponent(query), {
+            signal: controller.signal,
+            headers: { Accept: "application/json" },
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        const body = await res.json();
+        if (!Array.isArray(body)) throw new Error("unexpected shape");
+
+        const providers = normalizeResults(body);
+        cache.set(key, providers);
+        if (key !== currentKey) return; // a newer query owns the panel now
+        render(region, providers, key, query);
+    } catch (e) {
+        // Aborted, offline, non-200, or malformed. Degrade quietly: the static
+        // fallback paragraph below is server-rendered and still on screen. An error
+        // banner in an already-frustrating dead end is worse than nothing. Failures
+        // are deliberately not cached, so the next keystroke retries.
+        if (key !== currentKey) return;
+        clear(region);
+        renderedKey = key;
+    } finally {
+        window.clearTimeout(timer);
+        if (inFlight === controller) inFlight = null;
+    }
+};
+
+// Called from updateAllCount() in packages.ts on every filter path. `filterText` is
+// passed in rather than read from the DOM because the Stencil search component
+// re-renders asynchronously — reading .registry-filter-input right after reset()
+// yields the query the user just cleared.
+export const syncEmptyState = (visibleCount: number, filterText: string): void => {
+    const region = document.querySelector<HTMLElement>(
+        ".all-packages .no-results .tf-suggest",
+    );
+    if (!region) return;
+
+    const message = document.querySelector<HTMLElement>(
+        ".all-packages .no-results .no-results-message",
+    );
+
+    const reset = (): void => {
+        if (inFlight) {
+            inFlight.abort();
+            inFlight = null;
+        }
+        currentKey = "";
+        renderedKey = null;
+        clear(region);
+    };
+
+    // Results exist: the panel is CSS-hidden, so there is nothing to look up.
+    if (visibleCount > 0) {
+        reset();
+        return;
+    }
+
+    const query = (filterText || "").trim();
+
+    if (message) {
+        message.textContent =
+            query.length > 0
+                ? `No packages in the Pulumi Registry match "${truncate(query, 80)}".`
+                : DEFAULT_MESSAGE;
+    }
+
+    // Tag-only filters, or a single character: no meaningful query to send.
+    if (query.length < MIN_QUERY_LENGTH) {
+        reset();
+        return;
+    }
+
+    const key = query.toLowerCase();
+    if (key === renderedKey) return; // already painted for this query
+    currentKey = key;
+
+    const cached = cache.get(key);
+    if (cached) {
+        render(region, cached, key, query);
+        return;
+    }
+
+    if (inFlight) inFlight.abort();
+    void fetchAndRender(region, query, key);
+};

--- a/themes/default/theme/src/ts/packages.ts
+++ b/themes/default/theme/src/ts/packages.ts
@@ -1,3 +1,5 @@
+import { syncEmptyState } from "./opentofu-suggest";
+
 const filterByTextAndTags = (filters, filterText) => {
     const AMAZON_STRING: string = "amazon";
     const AWS_STRING: string = "aws";
@@ -84,10 +86,16 @@ const getActiveFilterText = () => {
     return inputElement?.value || "";
 };
 
-// Refreshes the visible-package count badges.
-const updateAllCount = () => {
+// Refreshes the visible-package count badges and the empty-results panel.
+//
+// Callers pass the filter text they already hold rather than letting this read the
+// DOM, because the Stencil search component re-renders asynchronously: right after
+// reset() or onClearFilter(), .registry-filter-input still holds the *old* query.
+// getActiveFilterText() is only the fallback for callers that have nothing better.
+const updateAllCount = (filterText?: string) => {
     const allCount = document.querySelectorAll(".all-packages .package:not(.hidden)").length;
     document.querySelectorAll(".all-count").forEach(el => el.textContent = String(allCount));
+    syncEmptyState(allCount, filterText !== undefined ? filterText : getActiveFilterText());
 };
 
 document.querySelector(".section-registry")?.addEventListener("filterSelect", (event: CustomEvent) => {
@@ -128,23 +136,29 @@ document.querySelector(".section-registry")?.addEventListener("filterSelect", (e
         el.setAttribute("data-selected-categories", selectedCategories);
     });
 
-    updateAllCount();
+    updateAllCount(filterText);
 
     document.querySelectorAll("pulumi-filter-select-option-group").forEach((el: any) => el.close());
 });
 
-document.querySelector(".section-registry .no-results .reset")?.addEventListener("click", event => {
+document.querySelector(".section-registry .no-results .reset")?.addEventListener("click", async event => {
     event.stopPropagation();
 
+    // Both of these are Stencil @Method()s, so they resolve asynchronously — and
+    // pulumi-filter-select.reset() emits filterSelect, whose handler re-filters using
+    // whatever the search input currently reads. Awaiting them lets that emit land
+    // first, so the authoritative "show everything" pass below is what wins. Without
+    // the awaits the emit arrives afterwards, re-filtering against the stale query
+    // text and leaving every package hidden.
     const search = document.querySelector("pulumi-registry-list-search") as any;
-    search?.reset();
+    await search?.reset();
 
     const fs = document.querySelector("pulumi-filter-select") as any;
-    fs?.reset();
+    await fs?.reset();
 
     filterByTextAndTags([], "");
 
-    updateAllCount();
+    updateAllCount("");
 });
 
 document.querySelector(".section-registry")?.addEventListener("packageSearch", (event: CustomEvent) => {
@@ -163,7 +177,7 @@ document.querySelector(".section-registry")?.addEventListener("packageSearch", (
 
     filterByTextAndTags(filters, filterText);
 
-    updateAllCount();
+    updateAllCount(filterText);
 });
 
 // Apply the default filtering on initial load so deprecated packages start hidden,

--- a/themes/default/theme/stencil/src/components.d.ts
+++ b/themes/default/theme/stencil/src/components.d.ts
@@ -121,6 +121,7 @@ export namespace Components {
         "selectClass"?: string;
     }
     interface PulumiRegistryListSearch {
+        "reset": () => Promise<void>;
     }
     interface PulumiResourceLinks {
         "moduleName": string;

--- a/themes/default/theme/stencil/src/components/pulumi-registry-list-search/pulumi-registry-list-search.tsx
+++ b/themes/default/theme/stencil/src/components/pulumi-registry-list-search/pulumi-registry-list-search.tsx
@@ -1,4 +1,4 @@
-import { Component, h, State, EventEmitter, Event } from "@stencil/core";
+import { Component, h, State, EventEmitter, Event, Method } from "@stencil/core";
 import { debounce } from "lodash";
 
 @Component({
@@ -38,7 +38,12 @@ export class PulumiRegistryListSearch {
     // When a user selects the reset button that appears if there are no matched
     // results for any filters/search.  No need to emit the event, because this starts
     // over with all packages.
-    reset() {
+    //
+    // @Method() is what puts this on the host element; without it packages.ts calls
+    // search.reset() on an element that has no such method and throws, which silently
+    // broke the whole "Clear all filters" handler. Stencil requires these to be async.
+    @Method()
+    async reset() {
       this.filterContent = "";
     }
 


### PR DESCRIPTION
Closes #7299.

Filtering the registry for a provider Pulumi doesn't publish was a dead end — even though Pulumi can run any Terraform or OpenTofu provider. The empty state now looks the query up in the OpenTofu registry and offers each match with a version-pinned `pulumi package add` command.

```
No packages in the Pulumi Registry match "sops".
────────────────────────────────────────────────
5 providers in the OpenTofu registry match "sops":

  carlpett/sops  ★ 584
  $ pulumi package add terraform-provider carlpett/sops 1.4.1
  …

Pulumi can use any Terraform or OpenTofu provider… Learn how →
```

The issue scoped this as good/better/best. **Better turned out not to be buildable** — `search.opentofu.org` keeps its query in React local state and has no `/search` route, so no URL can pre-fill it. **Best turned out cheap**, because the API is CORS-open and its `popularity` field is GitHub stars — the signal needed to tell a real provider from its forks.

## Ranking

The API's own order is not trustworthy: for `random` it returns `brenthc/random` (★0) above `hashicorp/random` (★233). Results are re-sorted by stars, then by a namespace matching the provider name so the vendor's own publication wins a tie (`namecheap/namecheap` over `adamdecaf/namecheap`, both ★168), then alphabetically for stable ordering.

## Safety

`addr` and `version` are publisher-controlled, so both are allowlist-validated before reaching a URL or a command — failures are dropped, not escaped — and every node is built with `textContent`. Verified against payloads carrying HTML injection, path traversal, `javascript:`, and shell metacharacters.

Every failure path (offline, non-200, malformed, timeout, no match) degrades to the static Any Terraform Provider docs link, which is server-rendered and needs no JavaScript.

## Also fixes: "Clear all filters" has never worked

`pulumi-registry-list-search.reset()` lacked a `@Method()` decorator, so Stencil never exposed it on the host element and the handler threw a `TypeError` on its first line — the button did nothing at all. Exposing it revealed a second bug: `pulumi-filter-select.reset()` is async, so its `filterSelect` emit landed *after* the handler's own re-filter and re-hid everything using stale input text. Both resets are now awaited.

Pre-existing and outside the issue's scope, but the button sits inside the panel this PR rebuilds. Happy to split it out.

## Testing

12 new Cypress tests (23 passing total), stubbing the API so they never hit the network: star ranking, vendor tie-break, non-provider filtering, per-`addr` de-duplication, version pinning, link format, deferred loading heading, empty/failure fallbacks, XSS rejection, the two no-fetch guards, and a regression test for the reset button. `make lint` passes.

The no-fetch guards are verified by mutation rather than by inspection: setting `MIN_QUERY_LENGTH` to 1 fails the single-character test. An earlier draft of that test used `"q"`, which matches ten visible packages, so it passed whether the guard worked or not.

Note `cypress/e2e/site.cy.js` isn't wired into any CI workflow, so these are local-verification only — tracked in #12450.

## Follow-ups

- #12450 — nothing in this PR runs in CI, and the feature depends on an external API contract (`type`, `addr`, `version`, `popularity`) nobody here controls.
- The zero-result query is sent to `api.opentofu.org` with no consent gate. No identifier is attached and it only fires once the empty state is reached, but it's the first client-side request to a non-Pulumi origin driven by user input in this bundle, so it's worth an explicit call from whoever owns pulumi.com privacy. (There's no CSP to worry about — `infrastructure/index.ts:218` is the AWS managed `SecurityHeadersPolicy`, which sets no `Content-Security-Policy`.)

## Known limitation

OpenTofu's search substring-matches the namespace, so `plex` returns `simplexiengage/postgresql`. Left as-is rather than filtering unasked — worth a follow-up on whether to require the query to match the provider name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk8u8qqdtjHxAfgcgQehad
