### PR TITLE
Fix the registry package type filters

### DIFF
--- a/.claude/commands/_common/review-criteria.md
+++ b/.claude/commands/_common/review-criteria.md
@@ -50,7 +50,6 @@ Every package YAML file must include:
 | `schema_file_url` | string | URL to the provider's schema JSON |
 | `category` | string | One of the valid categories (see below) |
 | `component` | boolean | Whether this is a component provider |
-| `native` | boolean | Whether this is a native provider |
 | `package_status` | string | `ga` or `public_preview` |
 
 ### Valid Categories
@@ -62,7 +61,7 @@ Every package YAML file must include:
 - `version` must match semver pattern: `v\d+\.\d+\.\d+` (with optional pre-release suffix)
 - `repo_url` must be a valid GitHub URL: `https://github.com/{owner}/{repo}`
 - `schema_file_url` must be a valid URL pointing to a JSON file
-- `component` and `native` must be boolean (`true` or `false`)
+- `component` must be boolean (`true` or `false`)
 - `package_status` must be `ga` or `public_preview`
 
 ## Infrastructure (`infrastructure/`)

--- a/.claude/commands/new-package/SKILL.md
+++ b/.claude/commands/new-package/SKILL.md
@@ -58,9 +58,8 @@ Use `AskUserQuestion` to collect the following (ask in sequence, one at a time):
 
 For community packages, also ask:
 8. **Is this a component provider?** (yes/no)
-9. **Is this a native provider?** (yes/no)
 
-For first-party packages, default `component: false` and `native: false` (can be overridden).
+For first-party packages, default `component: false` (can be overridden).
 
 ---
 

--- a/.claude/commands/new-package/references/yaml-template.md
+++ b/.claude/commands/new-package/references/yaml-template.md
@@ -16,7 +16,6 @@ description: "{description}"
 featured: false
 logo_url: ""
 name: {name}
-native: {native}
 package_status: ga
 publisher: {publisher}
 repo_url: {repo_url}
@@ -36,7 +35,6 @@ version: {version}
 | `featured` | Whether to feature on registry homepage (set to `false` for new packages) | `false` |
 | `logo_url` | URL to provider logo (leave empty if none) | `""` |
 | `name` | Package short name (lowercase, alphanumeric + hyphens) | `example-provider` |
-| `native` | Whether this is a native provider (not bridged from Terraform) | `false` |
 | `package_status` | Release status | `ga` |
 | `publisher` | Organization or individual publishing the provider | `pulumiverse` |
 | `repo_url` | GitHub repository URL | `https://github.com/pulumiverse/pulumi-example` |

--- a/.claude/commands/shipit/references/quality-checks.md
+++ b/.claude/commands/shipit/references/quality-checks.md
@@ -39,7 +39,7 @@ Scan last 10 conversation messages for:
 
 For package YAML files, perform a quick inline check:
 
-1. Verify required fields are present: `name`, `title`, `description`, `publisher`, `repo_url`, `version`, `schema_file_url`, `category`, `component`, `native`, `package_status`
+1. Verify required fields are present: `name`, `title`, `description`, `publisher`, `repo_url`, `version`, `schema_file_url`, `category`, `component`, `package_status`
 2. Verify `category` is one of: `Cloud`, `Database`, `Infrastructure`, `Monitoring`, `Network`, `Utility`, `Version Control System`
 3. Verify `version` matches semver: `v\d+\.\d+\.\d+`
 4. Verify `package_status` is `ga` or `public_preview`

--- a/.claude/commands/validate-package.md
+++ b/.claude/commands/validate-package.md
@@ -51,7 +51,6 @@ Check that all required fields are present:
 | `schema_file_url` | Yes | string |
 | `category` | Yes | string |
 | `component` | Yes | boolean |
-| `native` | Yes | boolean |
 | `package_status` | Yes | string |
 
 Optional fields: `logo_url`, `featured`, `updated_on`
@@ -62,7 +61,7 @@ Optional fields: `logo_url`, `featured`, `updated_on`
 - **`package_status`**: Must be `ga` or `public_preview`
 - **`version`**: Must match semver pattern `v\d+\.\d+\.\d+` (optional pre-release suffix like `-alpha.1`)
 - **`repo_url`**: Must be a valid GitHub URL (`https://github.com/{owner}/{repo}`)
-- **`component`** and **`native`**: Must be boolean (`true` or `false`)
+- **`component`**: Must be boolean (`true` or `false`)
 - **`name`**: Must be lowercase, alphanumeric with hyphens only
 - **`schema_file_url`**: Must be a valid URL
 

--- a/themes/default/layouts/partials/registry/package-list.html
+++ b/themes/default/layouts/partials/registry/package-list.html
@@ -26,20 +26,14 @@ append . }} {{ end }} {{ end }}
                             <div class="toggle" slot="toggle">Type</div>
                             <div class="options">
                                 <pulumi-filter-select-option
-                                    value="native-provider"
-                                    label="Native Provider"
-                                    >Native
-                                    Provider</pulumi-filter-select-option
-                                >
-                                <pulumi-filter-select-option
                                     value="provider"
-                                    label="Provider"
-                                    >Provider</pulumi-filter-select-option
+                                    label="Providers"
+                                    >Providers</pulumi-filter-select-option
                                 >
                                 <pulumi-filter-select-option
                                     value="component"
-                                    label="Component"
-                                    >Component</pulumi-filter-select-option
+                                    label="Components"
+                                    >Components</pulumi-filter-select-option
                                 >
                                 <pulumi-filter-select-option
                                     value="deprecated"
@@ -119,7 +113,7 @@ append . }} {{ end }} {{ end }}
         </div>
         <div class="flex justify-between flex-col md:flex-row gap-4 items-start md:items-center mb-4 px-4">
             <h2 class="flex items-center mt-8 md:mt-0">
-                <span>A&ndash;Z packages</span>
+                <span>Packages</span>
                 <span
                     class="all-count ml-4 py-0.5 px-3 rounded-full bg-gray-100 text-lg"
                 >

--- a/themes/default/layouts/partials/registry/package.html
+++ b/themes/default/layouts/partials/registry/package.html
@@ -1,11 +1,9 @@
 {{ $packageName := .package.name }} {{ $href := relref .page (printf
 "/registry/packages/%s/" $packageName) }} {{ $packageCategory := lower
 .package.category }} {{ $packageCategoryName := .package.category }} {{
-$packageType := "provider" }} {{ $packageTypeName := "Provider" }} {{ if
-.package.native }} {{ $packageType = "native-provider" }} {{ $packageTypeName =
-"Native Provider" }} {{ end }} {{ if .package.component }} {{ $packageType =
-"component" }} {{ $packageTypeName = "Component" }} {{ end }} {{ $isDeprecated
-:= eq .package.publisher "DEPRECATED" }}
+$packageType := "provider" }} {{ if .package.component }} {{ $packageType =
+"component" }} {{ end }} {{ $isDeprecated := eq .package.publisher "DEPRECATED"
+}}
 
 <div class="package my-1.5 w-full md:w-1/2 lg:w-1/3 px-3">
     <a href="{{ $href }}" title="{{ .package.title }}">

--- a/themes/default/layouts/registry/list.html
+++ b/themes/default/layouts/registry/list.html
@@ -25,7 +25,7 @@
                     </div>
                     <div class="az-packages">
                         <h2 class="no-anchor az-packages-heading">
-                            A-Z packages
+                            All packages
                         </h2>
                         <ul>
                             {{ range (sort site.Data.registry.packages "title")

--- a/themes/default/theme/src/scss/docs/_docs-theme.scss
+++ b/themes/default/theme/src/scss/docs/_docs-theme.scss
@@ -956,7 +956,7 @@ html[data-theme="dark"] body.section-registry {
         color: var(--docs-fg-muted);
     }
 
-    // A–Z count pill (bg-gray-100).
+    // Packages count pill (bg-gray-100).
     .all-packages .all-count {
         background-color: var(--docs-surface);
         color: var(--docs-fg);

--- a/themes/default/theme/src/scss/docs/_packages.scss
+++ b/themes/default/theme/src/scss/docs/_packages.scss
@@ -54,14 +54,6 @@
             }
         }
 
-        &[data-filter-value="native-provider"] {
-            @apply border-violet-300;
-
-            [data-selected-types*="native-provider"] & {
-                @apply bg-violet-300;
-            }
-        }
-
         &[data-filter-value="component"] {
             @apply border-violet-300;
 

--- a/themes/default/theme/src/ts/packages.ts
+++ b/themes/default/theme/src/ts/packages.ts
@@ -25,12 +25,11 @@ const filterByTextAndTags = (filters, filterText) => {
 
             const packageType = el.getAttribute("data-type");
             const packageCategory = el.getAttribute("data-category");
-            let packageIsNative = packageType === "native-provider";
 
             // A deprecated package that reaches this point was explicitly requested
             // via the "Deprecated" type option, so treat it as a type match.
             const packageHasSelectedType =
-                packageIsDeprecated || !!filters.find(f => f.group === "type" && f.value === packageType) || (filters.find(f => f.group === "type" && f.value === "provider") && packageIsNative);
+                packageIsDeprecated || !!filters.find(f => f.group === "type" && f.value === packageType);
             const packageHasSelectedCategory = !!filters.find(f => f.group === "category" && f.value === packageCategory);
 
             // Free text matches when every whitespace-separated token appears in the
@@ -42,11 +41,12 @@ const filterByTextAndTags = (filters, filterText) => {
             ].join(" ").toLowerCase();
             let downcasedFilterText = filterText?.trim().toLowerCase();
 
-            // hack to include anything marked as native as responsive to a filter text including the word "native"
-            // see https://github.com/pulumi/registry/issues/5715 for reasoning
+            // Searching for "native aws" should still turn up both aws and aws-native.
+            // The "kind/native" schema tag is stripped out of data-keywords by
+            // resourcedocsgen, so drop the word from the query rather than fail to
+            // match it. See https://github.com/pulumi/registry/issues/5715.
             if (downcasedFilterText.includes("native")) {
                 downcasedFilterText = downcasedFilterText.replace(/native/g, "");
-                packageIsNative = true;
             }
 
             let packageIsAMatch;

--- a/tools/resourcedocsgen/cmd/docs/registry_test.go
+++ b/tools/resourcedocsgen/cmd/docs/registry_test.go
@@ -31,7 +31,6 @@ description: A Pulumi package to safely use randomness in Pulumi programs.
 featured: false
 logo_url: ""
 name: random
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-random
@@ -123,7 +122,6 @@ description: A Pulumi package to safely use randomness in Pulumi programs.
 featured: false
 logo_url: ""
 name: random
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-random
@@ -137,7 +135,6 @@ description: Pulumi Amazon Web Services (AWS) API Gateway Components.
 featured: false
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png
 name: aws-apigateway
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aws-apigateway

--- a/tools/resourcedocsgen/cmd/metadata.go
+++ b/tools/resourcedocsgen/cmd/metadata.go
@@ -361,7 +361,6 @@ func writePackageMetadata(
 	}
 
 	component := isComponent(spec.Keywords)
-	native := !component && (spec.Attribution == "" || isNative(spec.Keywords))
 	return emitPackageMetadata(pkg.PackageMeta{
 		Name:        spec.Name,
 		Description: spec.Description,
@@ -379,7 +378,6 @@ func writePackageMetadata(
 		Component: component,
 		Featured:  isFeaturedPackage(spec.Name),
 		Keywords:  searchKeywords(spec.Keywords),
-		Native:    native,
 	}, metadataDir)
 }
 
@@ -536,10 +534,6 @@ func isComponent(keywords []string) bool {
 
 func isFeaturedPackage(pkgName string) bool {
 	return slices.Contains(featuredPackages, pkgName)
-}
-
-func isNative(keywords []string) bool {
-	return getTagFromKeywords(keywords, "kind/native") != nil
 }
 
 func getTagWithPrefixFromKeywords(keywords []string, tagPrefix string) *string {

--- a/tools/resourcedocsgen/cmd/testdata/TestMetadataBridgedProvider/metadata/random.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMetadataBridgedProvider/metadata/random.yaml.golden
@@ -8,7 +8,6 @@ keywords:
 - random
 logo_url: ""
 name: random
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-random

--- a/tools/resourcedocsgen/cmd/testdata/TestMetadataComponentProvider/metadata/aws-apigateway.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMetadataComponentProvider/metadata/aws-apigateway.yaml.golden
@@ -9,7 +9,6 @@ keywords:
 - apigateway
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png
 name: aws-apigateway
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aws-apigateway

--- a/tools/resourcedocsgen/cmd/testdata/TestMetadataNativeProvider/metadata/command.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMetadataNativeProvider/metadata/command.yaml.golden
@@ -9,7 +9,6 @@ keywords:
 - command
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-command/master/assets/logo.svg
 name: command
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-command

--- a/tools/resourcedocsgen/cmd/testdata/TestMissingMetadataFile/metadata/test.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestMissingMetadataFile/metadata/test.yaml.golden
@@ -6,7 +6,6 @@ description: ""
 featured: false
 logo_url: ""
 name: test
-native: true
 package_status: ga
 publisher: example
 repo_url: https://github.com/pulumi/pulumi-test

--- a/tools/resourcedocsgen/cmd/testdata/TestRepoURLFromRemoteSchema/metadata/test.yaml.golden
+++ b/tools/resourcedocsgen/cmd/testdata/TestRepoURLFromRemoteSchema/metadata/test.yaml.golden
@@ -6,7 +6,6 @@ description: ""
 featured: false
 logo_url: ""
 name: test
-native: true
 package_status: ga
 publisher: Some Publisher
 repo_url: https://github.com/pulumi/pulumi-test

--- a/tools/resourcedocsgen/pkg/metadata.go
+++ b/tools/resourcedocsgen/pkg/metadata.go
@@ -62,8 +62,6 @@ type PackageMeta struct {
 	// Featured indicates whether or not a package is highlighted as
 	// a featured package.
 	Featured bool `json:"featured"`
-	// Native is true if the package does not use the TF bridge.
-	Native bool `json:"native"`
 	// Component indicates if the package is a component and not
 	// a provider.
 	Component bool `json:"component"`


### PR DESCRIPTION
The "Native Provider" filter was showing bridged Terraform providers (Pinecone, among others) as native. The `native` flag it reads is derived as `!component && (attribution == "" || kind/native)`, so any package whose schema omits `attribution` is flagged native — the data can't be trusted.

Rather than fix the data, this removes the facet. Whether a provider is native isn't something users shop on, and the one case where it mattered (Azure Native vs. Classic) is handled by package alerts and naming.

## Changes

- Drop the Native Provider option; native packages now render as `provider`
- Remove the now-redundant clause that made "Provider" a superset of native
- Relabel the type options "Providers" / "Components"
- Rename the "A-Z packages" headings: "All packages" in the sidebar (it does list everything, deprecated included), "Packages" in the main column (that grid hides deprecated by default)
- Remove `native` from `PackageMeta` and its derivation in `resourcedocsgen`, and drop it from the skill docs that listed it as required

The 312 generated package YAMLs still carry the dead key; #12440 strips them in a separate mechanical diff so this one stays reviewable. Merging this alone is safe — the three sites that unmarshal `PackageMeta` use `ghodss/yaml`, which ignores unknown fields.

Verified with `make lint`, `make build-assets`, `go test ./...` in `tools/resourcedocsgen`, and the Cypress `package list filter` suite (7/7), with the YAMLs left unstripped to exercise that intermediate state.

Fixes #10864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCUrytgvtCgtr4KAP8X7M9