### PR TITLE
Strip the dead native field from the package YAMLs

### DIFF
--- a/themes/default/data/registry/packages/aci.yaml
+++ b/themes/default/data/registry/packages/aci.yaml
@@ -7,7 +7,6 @@ description: The Pulumi ACI provider provides resources to interact with a Cisco
 featured: false
 logo_url: https://raw.githubusercontent.com/netascode/pulumi-aci/master/assets/logo.png
 name: aci
-native: true
 package_status: public_preview
 publisher: Cisco
 repo_url: https://github.com/netascode/pulumi-aci

--- a/themes/default/data/registry/packages/acme.yaml
+++ b/themes/default/data/registry/packages/acme.yaml
@@ -8,7 +8,6 @@ keywords:
 - acme
 logo_url: ""
 name: acme
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-acme

--- a/themes/default/data/registry/packages/aem.yaml
+++ b/themes/default/data/registry/packages/aem.yaml
@@ -7,7 +7,6 @@ description: Easily manage Adobe Experience Manager instances in the cloud witho
 featured: false
 logo_url: https://raw.githubusercontent.com/wttech/pulumi-aem/main/docs/logo.175.png
 name: aem
-native: true
 package_status: public_preview
 publisher: Wttech
 repo_url: https://github.com/wttech/pulumi-aem

--- a/themes/default/data/registry/packages/airbyte.yaml
+++ b/themes/default/data/registry/packages/airbyte.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from airbyte.
 featured: false
 logo_url: https://raw.githubusercontent.com/airbytehq/airbyte/1c4ad4d536c44942b42225bf8af5bbef7e7409a4/docs/platform/assets/airbyte_new_logo.svg
 name: airbyte
-native: false
 package_status: ga
 publisher: airbytehq
 repo_url: https://github.com/airbytehq/terraform-provider-airbyte

--- a/themes/default/data/registry/packages/aiven.yaml
+++ b/themes/default/data/registry/packages/aiven.yaml
@@ -8,7 +8,6 @@ keywords:
 - aiven
 logo_url: ""
 name: aiven
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aiven

--- a/themes/default/data/registry/packages/akamai.yaml
+++ b/themes/default/data/registry/packages/akamai.yaml
@@ -8,7 +8,6 @@ keywords:
 - akamai
 logo_url: ""
 name: akamai
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-akamai

--- a/themes/default/data/registry/packages/akeyless.yaml
+++ b/themes/default/data/registry/packages/akeyless.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from akeyless.
 featured: false
 logo_url: ""
 name: akeyless
-native: false
 package_status: ga
 publisher: akeyless-community
 repo_url: https://github.com/akeyless-community/terraform-provider-akeyless

--- a/themes/default/data/registry/packages/algolia.yaml
+++ b/themes/default/data/registry/packages/algolia.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from algolia.
 featured: false
 logo_url: ""
 name: algolia
-native: false
 package_status: public_preview
 publisher: k-yomo
 repo_url: https://github.com/k-yomo/terraform-provider-algolia

--- a/themes/default/data/registry/packages/alicloud.yaml
+++ b/themes/default/data/registry/packages/alicloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - alicloud
 logo_url: ""
 name: alicloud
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-alicloud

--- a/themes/default/data/registry/packages/alks.yaml
+++ b/themes/default/data/registry/packages/alks.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from alks.
 featured: false
 logo_url: ""
 name: alks
-native: false
 package_status: ga
 publisher: cox-automotive
 repo_url: https://github.com/cox-automotive/terraform-provider-alks

--- a/themes/default/data/registry/packages/aptible.yaml
+++ b/themes/default/data/registry/packages/aptible.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from aptible.
 featured: false
 logo_url: ""
 name: aptible
-native: false
 package_status: public_preview
 publisher: aptible
 repo_url: https://github.com/aptible/terraform-provider-aptible

--- a/themes/default/data/registry/packages/aquasec.yaml
+++ b/themes/default/data/registry/packages/aquasec.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing Aquasec cloud resources.
 featured: false
 logo_url: ""
 name: aquasec
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumiverse/pulumi-aquasec

--- a/themes/default/data/registry/packages/argocd.yaml
+++ b/themes/default/data/registry/packages/argocd.yaml
@@ -8,7 +8,6 @@ keywords:
 - argocd
 logo_url: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 name: argocd
-native: false
 package_status: ga
 publisher: Three141
 repo_url: https://github.com/three141/pulumi-argocd

--- a/themes/default/data/registry/packages/artifactory.yaml
+++ b/themes/default/data/registry/packages/artifactory.yaml
@@ -8,7 +8,6 @@ keywords:
 - artifactory
 logo_url: ""
 name: artifactory
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-artifactory

--- a/themes/default/data/registry/packages/astra.yaml
+++ b/themes/default/data/registry/packages/astra.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing Astra DB cloud resources
 featured: false
 logo_url: ""
 name: astra
-native: false
 package_status: ga
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-astra

--- a/themes/default/data/registry/packages/athenz.yaml
+++ b/themes/default/data/registry/packages/athenz.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from athenz.
 featured: false
 logo_url: ""
 name: athenz
-native: false
 package_status: ga
 publisher: athenz
 repo_url: https://github.com/athenz/terraform-provider-athenz

--- a/themes/default/data/registry/packages/auth0.yaml
+++ b/themes/default/data/registry/packages/auth0.yaml
@@ -8,7 +8,6 @@ keywords:
 - auth0
 logo_url: ""
 name: auth0
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-auth0

--- a/themes/default/data/registry/packages/authentik.yaml
+++ b/themes/default/data/registry/packages/authentik.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from authentik.
 featured: false
 logo_url: ""
 name: authentik
-native: false
 package_status: ga
 publisher: goauthentik
 repo_url: https://github.com/goauthentik/terraform-provider-authentik

--- a/themes/default/data/registry/packages/auto-deploy.yaml
+++ b/themes/default/data/registry/packages/auto-deploy.yaml
@@ -6,7 +6,6 @@ description: ""
 featured: false
 logo_url: ""
 name: auto-deploy
-native: true
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-auto-deploy

--- a/themes/default/data/registry/packages/avi.yaml
+++ b/themes/default/data/registry/packages/avi.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from avi.
 featured: false
 logo_url: ""
 name: avi
-native: false
 package_status: ga
 publisher: vmware
 repo_url: https://github.com/vmware/terraform-provider-avi

--- a/themes/default/data/registry/packages/aviatrix.yaml
+++ b/themes/default/data/registry/packages/aviatrix.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing Aviatrix cloud resources
 featured: false
 logo_url: https://raw.githubusercontent.com/astipkovits/pulumi-aviatrix/main/aviatrix_logo.svg
 name: aviatrix
-native: false
 package_status: public_preview
 publisher: Aviatrix
 repo_url: https://github.com/astipkovits/pulumi-aviatrix

--- a/themes/default/data/registry/packages/aws-apigateway.yaml
+++ b/themes/default/data/registry/packages/aws-apigateway.yaml
@@ -9,7 +9,6 @@ keywords:
 - apigateway
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png
 name: aws-apigateway
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aws-apigateway

--- a/themes/default/data/registry/packages/aws-iam.yaml
+++ b/themes/default/data/registry/packages/aws-iam.yaml
@@ -4,7 +4,6 @@ description: "A Pulumi component to deploy a static website to AWS"
 featured: false
 logo_url: ""
 name: aws-iam
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-aws-iam

--- a/themes/default/data/registry/packages/aws-miniflux.yaml
+++ b/themes/default/data/registry/packages/aws-miniflux.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: aws-miniflux
-native: false
 package_status: public_preview
 publisher: Christian Nunciato
 repo_url: "https://github.com/pulumi/pulumi-aws-miniflux"

--- a/themes/default/data/registry/packages/aws-native.yaml
+++ b/themes/default/data/registry/packages/aws-native.yaml
@@ -12,7 +12,6 @@ keywords:
 - ccapi
 logo_url: ""
 name: aws-native
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aws-native

--- a/themes/default/data/registry/packages/aws-quickstart-aurora-postgres.yaml
+++ b/themes/default/data/registry/packages/aws-quickstart-aurora-postgres.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: aws-quickstart-aurora-postgres
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-quickstart-aurora-postgres"

--- a/themes/default/data/registry/packages/aws-quickstart-redshift.yaml
+++ b/themes/default/data/registry/packages/aws-quickstart-redshift.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: aws-quickstart-redshift
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-quickstart-redshift"

--- a/themes/default/data/registry/packages/aws-quickstart-vpc.yaml
+++ b/themes/default/data/registry/packages/aws-quickstart-vpc.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: aws-quickstart-vpc
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-quickstart-vpc"

--- a/themes/default/data/registry/packages/aws-s3-replicated-bucket.yaml
+++ b/themes/default/data/registry/packages/aws-s3-replicated-bucket.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: aws-s3-replicated-bucket
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-aws-s3-replicated-bucket"

--- a/themes/default/data/registry/packages/aws-static-website.yaml
+++ b/themes/default/data/registry/packages/aws-static-website.yaml
@@ -6,7 +6,6 @@ description: A Pulumi component to deploy a static website to AWS
 featured: false
 logo_url: ""
 name: aws-static-website
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-aws-static-website

--- a/themes/default/data/registry/packages/aws.yaml
+++ b/themes/default/data/registry/packages/aws.yaml
@@ -9,7 +9,6 @@ keywords:
 - aws
 logo_url: ""
 name: aws
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-aws

--- a/themes/default/data/registry/packages/awscontroltower.yaml
+++ b/themes/default/data/registry/packages/awscontroltower.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing control tower accounts.
 featured: false
 logo_url: https://pulumi.com/logos/pkg/aws.svg
 name: awscontroltower
-native: false
 package_status: public_preview
 publisher: lbrlabs
 repo_url: https://github.com/lbrlabs/pulumi-awscontroltower

--- a/themes/default/data/registry/packages/awsx.yaml
+++ b/themes/default/data/registry/packages/awsx.yaml
@@ -9,7 +9,6 @@ keywords:
 - awsx
 logo_url: ""
 name: awsx
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-awsx

--- a/themes/default/data/registry/packages/awx.yaml
+++ b/themes/default/data/registry/packages/awx.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from awx.
 featured: false
 logo_url: ""
 name: awx
-native: false
 package_status: public_preview
 publisher: denouche
 repo_url: https://github.com/denouche/terraform-provider-awx

--- a/themes/default/data/registry/packages/azapi.yaml
+++ b/themes/default/data/registry/packages/azapi.yaml
@@ -8,7 +8,6 @@ keywords:
 - azapi
 logo_url: ""
 name: azapi
-native: false
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/dirien/pulumi-azapi

--- a/themes/default/data/registry/packages/azure-justrun.yaml
+++ b/themes/default/data/registry/packages/azure-justrun.yaml
@@ -11,7 +11,6 @@ keywords:
 - web
 logo_url: ""
 name: azure-justrun
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-azure-justrun

--- a/themes/default/data/registry/packages/azure-native.yaml
+++ b/themes/default/data/registry/packages/azure-native.yaml
@@ -9,7 +9,6 @@ keywords:
 - azure-native
 logo_url: ""
 name: azure-native
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-azure-native

--- a/themes/default/data/registry/packages/azure-quickstart-acr-geo-replication.yaml
+++ b/themes/default/data/registry/packages/azure-quickstart-acr-geo-replication.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: azure-quickstart-acr-geo-replication
-native: false
 package_status: public_preview
 publisher: Ian Wahbe
 repo_url: "https://github.com/pulumi/pulumi-azure-quickstart-acr-geo-replication"

--- a/themes/default/data/registry/packages/azure-static-website.yaml
+++ b/themes/default/data/registry/packages/azure-static-website.yaml
@@ -4,7 +4,6 @@ description: A Pulumi component to deploy a static website to Azure
 featured: false
 logo_url: ""
 name: azure-static-website
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-azure-static-website

--- a/themes/default/data/registry/packages/azure.yaml
+++ b/themes/default/data/registry/packages/azure.yaml
@@ -11,7 +11,6 @@ keywords:
 - azure
 logo_url: ""
 name: azure
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-azure

--- a/themes/default/data/registry/packages/azuread.yaml
+++ b/themes/default/data/registry/packages/azuread.yaml
@@ -9,7 +9,6 @@ keywords:
 - azuread
 logo_url: ""
 name: azuread
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-azuread

--- a/themes/default/data/registry/packages/azuredevops.yaml
+++ b/themes/default/data/registry/packages/azuredevops.yaml
@@ -8,7 +8,6 @@ keywords:
 - azuredevops
 logo_url: ""
 name: azuredevops
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-azuredevops

--- a/themes/default/data/registry/packages/bitbucket.yaml
+++ b/themes/default/data/registry/packages/bitbucket.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from bitbucket.
 featured: false
 logo_url: ""
 name: bitbucket
-native: false
 package_status: ga
 publisher: drfaust92
 repo_url: https://github.com/drfaust92/terraform-provider-bitbucket

--- a/themes/default/data/registry/packages/bitwarden.yaml
+++ b/themes/default/data/registry/packages/bitwarden.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from bitwarden.
 featured: false
 logo_url: ""
 name: bitwarden
-native: false
 package_status: public_preview
 publisher: maxlaverse
 repo_url: https://github.com/maxlaverse/terraform-provider-bitwarden

--- a/themes/default/data/registry/packages/biznetgio.yaml
+++ b/themes/default/data/registry/packages/biznetgio.yaml
@@ -12,7 +12,6 @@ keywords:
 - neo
 logo_url: https://raw.githubusercontent.com/shirasakaren/pulumi-biznetgio/main/assets/logo.png
 name: biznetgio
-native: true
 package_status: public_preview
 publisher: shirasakaren
 repo_url: https://github.com/shirasakaren/pulumi-biznetgio

--- a/themes/default/data/registry/packages/buildkite.yaml
+++ b/themes/default/data/registry/packages/buildkite.yaml
@@ -8,7 +8,6 @@ keywords:
 - buildkite
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-buildkite/main/assets/buildkite-logo.png
 name: buildkite
-native: false
 package_status: ga
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-buildkite

--- a/themes/default/data/registry/packages/bytepluscc.yaml
+++ b/themes/default/data/registry/packages/bytepluscc.yaml
@@ -9,7 +9,6 @@ keywords:
 - bytepluscc
 logo_url: https://avatars.githubusercontent.com/u/67365215
 name: bytepluscc
-native: false
 package_status: public_preview
 publisher: Byteplus
 repo_url: https://github.com/byteplus-sdk/pulumi-bytepluscc

--- a/themes/default/data/registry/packages/castai.yaml
+++ b/themes/default/data/registry/packages/castai.yaml
@@ -9,7 +9,6 @@ keywords:
 - kubernetes
 logo_url: https://raw.githubusercontent.com/castai/pulumi-castai/main/docs/images/castai-logo.png
 name: castai
-native: false
 package_status: ga
 publisher: CAST AI
 repo_url: https://github.com/castai/pulumi-castai

--- a/themes/default/data/registry/packages/checkly.yaml
+++ b/themes/default/data/registry/packages/checkly.yaml
@@ -8,7 +8,6 @@ keywords:
 - checkly
 logo_url: https://raw.githubusercontent.com/checkly/pulumi-checkly/main/assets/checkly.png
 name: checkly
-native: false
 package_status: ga
 publisher: Checkly
 repo_url: https://github.com/checkly/pulumi-checkly

--- a/themes/default/data/registry/packages/checkpoint.yaml
+++ b/themes/default/data/registry/packages/checkpoint.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from checkpoint.
 featured: false
 logo_url: ""
 name: checkpoint
-native: false
 package_status: ga
 publisher: checkpointsw
 repo_url: https://github.com/checkpointsw/terraform-provider-checkpoint

--- a/themes/default/data/registry/packages/chronosphere.yaml
+++ b/themes/default/data/registry/packages/chronosphere.yaml
@@ -10,7 +10,6 @@ keywords:
 - prometheus
 logo_url: ""
 name: chronosphere
-native: false
 package_status: public_preview
 publisher: Chronosphere
 repo_url: https://github.com/chronosphereio/pulumi-chronosphere

--- a/themes/default/data/registry/packages/cilium.yaml
+++ b/themes/default/data/registry/packages/cilium.yaml
@@ -8,7 +8,6 @@ keywords:
 - cilium
 logo_url: https://raw.githubusercontent.com/littlejo/pulumi-cilium/main/docs/cilium.png
 name: cilium
-native: false
 package_status: public_preview
 publisher: littlejo
 repo_url: https://github.com/littlejo/pulumi-cilium

--- a/themes/default/data/registry/packages/circleci.yaml
+++ b/themes/default/data/registry/packages/circleci.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from circleci.
 featured: false
 logo_url: ""
 name: circleci
-native: false
 package_status: public_preview
 publisher: mrolla
 repo_url: https://github.com/mrolla/terraform-provider-circleci

--- a/themes/default/data/registry/packages/civo.yaml
+++ b/themes/default/data/registry/packages/civo.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from civo.
 featured: false
 logo_url: ""
 name: civo
-native: false
 package_status: ga
 publisher: civo
 repo_url: https://github.com/civo/terraform-provider-civo

--- a/themes/default/data/registry/packages/clickhouse.yaml
+++ b/themes/default/data/registry/packages/clickhouse.yaml
@@ -8,7 +8,6 @@ keywords:
 - clickhouse
 logo_url: https://avatars3.githubusercontent.com/ClickHouse
 name: clickhouse
-native: false
 package_status: ga
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-clickhouse

--- a/themes/default/data/registry/packages/cloudamqp.yaml
+++ b/themes/default/data/registry/packages/cloudamqp.yaml
@@ -8,7 +8,6 @@ keywords:
 - cloudamqp
 logo_url: ""
 name: cloudamqp
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-cloudamqp

--- a/themes/default/data/registry/packages/cloudflare.yaml
+++ b/themes/default/data/registry/packages/cloudflare.yaml
@@ -8,7 +8,6 @@ keywords:
 - cloudflare
 logo_url: ""
 name: cloudflare
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-cloudflare

--- a/themes/default/data/registry/packages/cloudfoundry.yaml
+++ b/themes/default/data/registry/packages/cloudfoundry.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from cloudfoundry.
 featured: false
 logo_url: ""
 name: cloudfoundry
-native: false
 package_status: public_preview
 publisher: cloudfoundry-community
 repo_url: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry

--- a/themes/default/data/registry/packages/cloudinit.yaml
+++ b/themes/default/data/registry/packages/cloudinit.yaml
@@ -8,7 +8,6 @@ keywords:
 - cloudinit
 logo_url: ""
 name: cloudinit
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-cloudinit

--- a/themes/default/data/registry/packages/cloudngfwaws.yaml
+++ b/themes/default/data/registry/packages/cloudngfwaws.yaml
@@ -10,7 +10,6 @@ keywords:
 - ngfw
 logo_url: https://avatars.githubusercontent.com/u/4855743?s=200&v=4
 name: cloudngfwaws
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-cloudngfwaws

--- a/themes/default/data/registry/packages/cockroach.yaml
+++ b/themes/default/data/registry/packages/cockroach.yaml
@@ -10,7 +10,6 @@ keywords:
 - pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-cockroach/main/assets/logo.png
 name: cockroach
-native: false
 package_status: public_preview
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-cockroach

--- a/themes/default/data/registry/packages/coder.yaml
+++ b/themes/default/data/registry/packages/coder.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from coder.
 featured: false
 logo_url: ""
 name: coder
-native: false
 package_status: ga
 publisher: coder
 repo_url: https://github.com/coder/terraform-provider-coder

--- a/themes/default/data/registry/packages/command.yaml
+++ b/themes/default/data/registry/packages/command.yaml
@@ -9,7 +9,6 @@ keywords:
 - command
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-command/master/assets/logo.svg
 name: command
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-command

--- a/themes/default/data/registry/packages/commercetools.yaml
+++ b/themes/default/data/registry/packages/commercetools.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from commercetools.
 featured: false
 logo_url: ""
 name: commercetools
-native: false
 package_status: ga
 publisher: labd
 repo_url: https://github.com/labd/terraform-provider-commercetools

--- a/themes/default/data/registry/packages/confluent.yaml
+++ b/themes/default/data/registry/packages/confluent.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing confluent cloud resource
 featured: false
 logo_url: ""
 name: confluent
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-confluent

--- a/themes/default/data/registry/packages/confluentcloud.yaml
+++ b/themes/default/data/registry/packages/confluentcloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - confluentcloud
 logo_url: ""
 name: confluentcloud
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-confluentcloud

--- a/themes/default/data/registry/packages/constellix.yaml
+++ b/themes/default/data/registry/packages/constellix.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from constellix.
 featured: false
 logo_url: ""
 name: constellix
-native: false
 package_status: public_preview
 publisher: constellix
 repo_url: https://github.com/constellix/terraform-provider-constellix

--- a/themes/default/data/registry/packages/consul.yaml
+++ b/themes/default/data/registry/packages/consul.yaml
@@ -8,7 +8,6 @@ keywords:
 - consul
 logo_url: ""
 name: consul
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-consul

--- a/themes/default/data/registry/packages/coralogix.yaml
+++ b/themes/default/data/registry/packages/coralogix.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from coralogix.
 featured: false
 logo_url: ""
 name: coralogix
-native: false
 package_status: ga
 publisher: coralogix
 repo_url: https://github.com/coralogix/terraform-provider-coralogix

--- a/themes/default/data/registry/packages/coreweave.yaml
+++ b/themes/default/data/registry/packages/coreweave.yaml
@@ -8,7 +8,6 @@ keywords:
 - coreweave
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-coreweave/main/docs/logo.png
 name: coreweave
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-coreweave

--- a/themes/default/data/registry/packages/cosign.yaml
+++ b/themes/default/data/registry/packages/cosign.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from cosign.
 featured: false
 logo_url: ""
 name: cosign
-native: false
 package_status: public_preview
 publisher: chainguard-dev
 repo_url: https://github.com/chainguard-dev/terraform-provider-cosign

--- a/themes/default/data/registry/packages/cpln.yaml
+++ b/themes/default/data/registry/packages/cpln.yaml
@@ -8,7 +8,6 @@ keywords:
 - cpln
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-cpln/main/docs/logo.png
 name: cpln
-native: false
 package_status: public_preview
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-cpln

--- a/themes/default/data/registry/packages/cratedb.yaml
+++ b/themes/default/data/registry/packages/cratedb.yaml
@@ -8,7 +8,6 @@ keywords:
 - cratedb
 logo_url: https://avatars.githubusercontent.com/u/4048232?s=48&v=4
 name: cratedb
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/thulasirajkomminar/pulumi-cratedb

--- a/themes/default/data/registry/packages/crowdstrike.yaml
+++ b/themes/default/data/registry/packages/crowdstrike.yaml
@@ -8,7 +8,6 @@ keywords:
 - crowdstrike
 logo_url: https://raw.githubusercontent.com/crowdstrike/pulumi-crowdstrike/main/docs/crowdstrike.png
 name: crowdstrike
-native: false
 package_status: public_preview
 publisher: CrowdStrike
 repo_url: https://github.com/crowdstrike/pulumi-crowdstrike

--- a/themes/default/data/registry/packages/ctfd.yaml
+++ b/themes/default/data/registry/packages/ctfd.yaml
@@ -8,7 +8,6 @@ keywords:
 - ctfd
 logo_url: https://raw.githubusercontent.com/ctfer-io/pulumi-ctfd/main/res/ctfd.png
 name: ctfd
-native: false
 package_status: ga
 publisher: CTFer.io
 repo_url: https://github.com/ctfer-io/pulumi-ctfd

--- a/themes/default/data/registry/packages/cyral.yaml
+++ b/themes/default/data/registry/packages/cyral.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from cyral.
 featured: false
 logo_url: ""
 name: cyral
-native: false
 package_status: ga
 publisher: cyralinc
 repo_url: https://github.com/cyralinc/terraform-provider-cyral

--- a/themes/default/data/registry/packages/danubedata.yaml
+++ b/themes/default/data/registry/packages/danubedata.yaml
@@ -8,7 +8,6 @@ keywords:
 - danubedata
 logo_url: ""
 name: danubedata
-native: true
 package_status: public_preview
 publisher: AdrianSilaghi
 repo_url: https://github.com/AdrianSilaghi/pulumi-danubedata

--- a/themes/default/data/registry/packages/databricks.yaml
+++ b/themes/default/data/registry/packages/databricks.yaml
@@ -8,7 +8,6 @@ keywords:
 - databricks
 logo_url: ""
 name: databricks
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-databricks

--- a/themes/default/data/registry/packages/datadog.yaml
+++ b/themes/default/data/registry/packages/datadog.yaml
@@ -8,7 +8,6 @@ keywords:
 - datadog
 logo_url: ""
 name: datadog
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-datadog

--- a/themes/default/data/registry/packages/datarobot.yaml
+++ b/themes/default/data/registry/packages/datarobot.yaml
@@ -9,7 +9,6 @@ keywords:
 - ai
 logo_url: https://raw.githubusercontent.com/datarobot-community/pulumi-datarobot/main/assets/datarobot-logo.png
 name: datarobot
-native: false
 package_status: public_preview
 publisher: DataRobot, Inc.
 repo_url: https://github.com/datarobot-community/pulumi-datarobot

--- a/themes/default/data/registry/packages/dbtcloud.yaml
+++ b/themes/default/data/registry/packages/dbtcloud.yaml
@@ -10,7 +10,6 @@ keywords:
 - cloud
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-dbtcloud/main/res/dbt-bit_tm.png
 name: dbtcloud
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-dbtcloud

--- a/themes/default/data/registry/packages/defang-aws.yaml
+++ b/themes/default/data/registry/packages/defang-aws.yaml
@@ -14,7 +14,6 @@ keywords:
 - fargate
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
 name: defang-aws
-native: true
 package_status: ga
 publisher: Defang
 repo_url: https://github.com/DefangLabs/pulumi-defang

--- a/themes/default/data/registry/packages/defang-azure.yaml
+++ b/themes/default/data/registry/packages/defang-azure.yaml
@@ -13,7 +13,6 @@ keywords:
 - containerapp
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
 name: defang-azure
-native: true
 package_status: ga
 publisher: Defang
 repo_url: https://github.com/DefangLabs/pulumi-defang

--- a/themes/default/data/registry/packages/defang-gcp.yaml
+++ b/themes/default/data/registry/packages/defang-gcp.yaml
@@ -13,7 +13,6 @@ keywords:
 - cloudrun
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.png
 name: defang-gcp
-native: true
 package_status: ga
 publisher: Defang
 repo_url: https://github.com/DefangLabs/pulumi-defang

--- a/themes/default/data/registry/packages/defang.yaml
+++ b/themes/default/data/registry/packages/defang.yaml
@@ -21,7 +21,6 @@ keywords:
 - digital ocean
 logo_url: https://raw.githubusercontent.com/DefangLabs/pulumi-defang/refs/heads/main/docs/logo.svg
 name: defang
-native: true
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/DefangLabs/pulumi-defang

--- a/themes/default/data/registry/packages/descope.yaml
+++ b/themes/default/data/registry/packages/descope.yaml
@@ -8,7 +8,6 @@ keywords:
 - descope
 logo_url: https://avatars3.githubusercontent.com/descope
 name: descope
-native: false
 package_status: public_preview
 publisher: Descope
 repo_url: https://github.com/descope/pulumi-descope

--- a/themes/default/data/registry/packages/dex.yaml
+++ b/themes/default/data/registry/packages/dex.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider for managing Dex resources via the Dex gRPC Admin
 featured: false
 logo_url: ""
 name: dex
-native: true
 package_status: public_preview
 publisher: Kotaicode GmbH
 repo_url: https://github.com/kotaicode/pulumi-dex

--- a/themes/default/data/registry/packages/digitalocean.yaml
+++ b/themes/default/data/registry/packages/digitalocean.yaml
@@ -8,7 +8,6 @@ keywords:
 - digitalocean
 logo_url: ""
 name: digitalocean
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-digitalocean

--- a/themes/default/data/registry/packages/discord.yaml
+++ b/themes/default/data/registry/packages/discord.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from discord.
 featured: false
 logo_url: ""
 name: discord
-native: false
 package_status: ga
 publisher: lucky3028
 repo_url: https://github.com/lucky3028/terraform-provider-discord

--- a/themes/default/data/registry/packages/dnsimple.yaml
+++ b/themes/default/data/registry/packages/dnsimple.yaml
@@ -8,7 +8,6 @@ keywords:
 - dnsimple
 logo_url: ""
 name: dnsimple
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-dnsimple

--- a/themes/default/data/registry/packages/docker-build.yaml
+++ b/themes/default/data/registry/packages/docker-build.yaml
@@ -10,7 +10,6 @@ keywords:
 - buildx
 logo_url: ""
 name: docker-build
-native: true
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-docker-build

--- a/themes/default/data/registry/packages/docker.yaml
+++ b/themes/default/data/registry/packages/docker.yaml
@@ -8,7 +8,6 @@ keywords:
 - docker
 logo_url: ""
 name: docker
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-docker

--- a/themes/default/data/registry/packages/dome9.yaml
+++ b/themes/default/data/registry/packages/dome9.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from dome9.
 featured: false
 logo_url: ""
 name: dome9
-native: false
 package_status: ga
 publisher: dome9
 repo_url: https://github.com/dome9/terraform-provider-dome9

--- a/themes/default/data/registry/packages/doppler.yaml
+++ b/themes/default/data/registry/packages/doppler.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing doppler cloud resources.
 featured: false
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-doppler/main/docs/logo.png
 name: doppler
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-doppler

--- a/themes/default/data/registry/packages/dynatrace.yaml
+++ b/themes/default/data/registry/packages/dynatrace.yaml
@@ -9,7 +9,6 @@ keywords:
 - pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-dynatrace/master/assets/logo.png
 name: dynatrace
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-dynatrace

--- a/themes/default/data/registry/packages/ec.yaml
+++ b/themes/default/data/registry/packages/ec.yaml
@@ -12,7 +12,6 @@ keywords:
 - elasticcloud
 logo_url: ""
 name: ec
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-ec

--- a/themes/default/data/registry/packages/edgecenter.yaml
+++ b/themes/default/data/registry/packages/edgecenter.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from edgecenter.
 featured: false
 logo_url: ""
 name: edgecenter
-native: false
 package_status: public_preview
 publisher: edge-center
 repo_url: https://github.com/edge-center/terraform-provider-edgecenter

--- a/themes/default/data/registry/packages/eks.yaml
+++ b/themes/default/data/registry/packages/eks.yaml
@@ -9,7 +9,6 @@ keywords:
 - eks
 logo_url: ""
 name: eks
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-eks

--- a/themes/default/data/registry/packages/elasticstack.yaml
+++ b/themes/default/data/registry/packages/elasticstack.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from elasticstack.
 featured: false
 logo_url: ""
 name: elasticstack
-native: false
 package_status: public_preview
 publisher: elastic
 repo_url: https://github.com/elastic/terraform-provider-elasticstack

--- a/themes/default/data/registry/packages/equinix-metal.yaml
+++ b/themes/default/data/registry/packages/equinix-metal.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing equinix-metal cloud reso
 featured: false
 logo_url: ""
 name: equinix-metal
-native: false
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-equinix-metal

--- a/themes/default/data/registry/packages/equinix.yaml
+++ b/themes/default/data/registry/packages/equinix.yaml
@@ -8,7 +8,6 @@ keywords:
 - equinix
 logo_url: https://raw.githubusercontent.com/equinix/pulumi-equinix/main/assets/logo.png
 name: equinix
-native: false
 package_status: public_preview
 publisher: Equinix
 repo_url: https://github.com/equinix/pulumi-equinix

--- a/themes/default/data/registry/packages/esxi-native.yaml
+++ b/themes/default/data/registry/packages/esxi-native.yaml
@@ -7,7 +7,6 @@ description: VMWare ESXi provider to provision VMs directly on an ESXi hyperviso
 featured: false
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-esxi-native/main/docs/esxi-logo.png
 name: esxi-native
-native: true
 package_status: ga
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-esxi-native

--- a/themes/default/data/registry/packages/etcd.yaml
+++ b/themes/default/data/registry/packages/etcd.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from etcd.
 featured: false
 logo_url: ""
 name: etcd
-native: false
 package_status: public_preview
 publisher: ferlab-ste-justine
 repo_url: https://github.com/ferlab-ste-justine/terraform-provider-etcd

--- a/themes/default/data/registry/packages/eventstorecloud.yaml
+++ b/themes/default/data/registry/packages/eventstorecloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - eventstorecloud
 logo_url: ""
 name: eventstorecloud
-native: false
 package_status: public_preview
 publisher: EventStore
 repo_url: https://github.com/EventStore/pulumi-eventstorecloud

--- a/themes/default/data/registry/packages/exoscale.yaml
+++ b/themes/default/data/registry/packages/exoscale.yaml
@@ -8,7 +8,6 @@ keywords:
 - exoscale
 logo_url: ""
 name: exoscale
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-exoscale

--- a/themes/default/data/registry/packages/f5bigip.yaml
+++ b/themes/default/data/registry/packages/f5bigip.yaml
@@ -9,7 +9,6 @@ keywords:
 - bigip
 logo_url: ""
 name: f5bigip
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-f5bigip

--- a/themes/default/data/registry/packages/fastly.yaml
+++ b/themes/default/data/registry/packages/fastly.yaml
@@ -8,7 +8,6 @@ keywords:
 - fastly
 logo_url: ""
 name: fastly
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-fastly

--- a/themes/default/data/registry/packages/filescom.yaml
+++ b/themes/default/data/registry/packages/filescom.yaml
@@ -9,7 +9,6 @@ keywords:
 - files.com
 logo_url: https://raw.githubusercontent.com/jschady/pulumi-filescom/main/docs/logo.svg
 name: filescom
-native: false
 package_status: public_preview
 publisher: jschady
 repo_url: https://github.com/jschady/pulumi-filescom

--- a/themes/default/data/registry/packages/fivetran.yaml
+++ b/themes/default/data/registry/packages/fivetran.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from fivetran.
 featured: false
 logo_url: ""
 name: fivetran
-native: false
 package_status: ga
 publisher: fivetran
 repo_url: https://github.com/fivetran/terraform-provider-fivetran

--- a/themes/default/data/registry/packages/flexibleengine.yaml
+++ b/themes/default/data/registry/packages/flexibleengine.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from flexibleengine.
 featured: false
 logo_url: ""
 name: flexibleengine
-native: false
 package_status: ga
 publisher: flexibleenginecloud
 repo_url: https://github.com/flexibleenginecloud/terraform-provider-flexibleengine

--- a/themes/default/data/registry/packages/flux.yaml
+++ b/themes/default/data/registry/packages/flux.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing Flux cloud resources.
 featured: false
 logo_url: ""
 name: flux
-native: false
 package_status: ga
 publisher: oun
 repo_url: https://github.com/oun/pulumi-flux

--- a/themes/default/data/registry/packages/formal.yaml
+++ b/themes/default/data/registry/packages/formal.yaml
@@ -8,7 +8,6 @@ keywords:
 - formal
 logo_url: https://avatars3.githubusercontent.com/formalco
 name: formal
-native: false
 package_status: ga
 publisher: Formal
 repo_url: https://github.com/formalco/pulumi-formal

--- a/themes/default/data/registry/packages/fortimanager.yaml
+++ b/themes/default/data/registry/packages/fortimanager.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from fortimanager.
 featured: false
 logo_url: ""
 name: fortimanager
-native: false
 package_status: ga
 publisher: fortinetdev
 repo_url: https://github.com/fortinetdev/terraform-provider-fortimanager

--- a/themes/default/data/registry/packages/fortios.yaml
+++ b/themes/default/data/registry/packages/fortios.yaml
@@ -8,7 +8,6 @@ keywords:
 - fortios
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-fortios/main/docs/fortios.png
 name: fortios
-native: false
 package_status: public_preview
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-fortios

--- a/themes/default/data/registry/packages/freebox.yaml
+++ b/themes/default/data/registry/packages/freebox.yaml
@@ -7,7 +7,6 @@ description: A Pulumi provider for Freebox (port forwarding, VMs, VPN, LAN, DHCP
 featured: false
 logo_url: https://raw.githubusercontent.com/OlivierPaquien/pulumi-freebox/main/docs/logo.png
 name: freebox
-native: true
 package_status: public_preview
 publisher: OlivierPaquien
 repo_url: https://github.com/OlivierPaquien/pulumi-freebox

--- a/themes/default/data/registry/packages/fusionauth.yaml
+++ b/themes/default/data/registry/packages/fusionauth.yaml
@@ -8,7 +8,6 @@ keywords:
 - fusionauth
 logo_url: https://avatars.githubusercontent.com/u/41974756?s=200&v=4
 name: fusionauth
-native: false
 package_status: ga
 publisher: Theo Gravity
 repo_url: https://github.com/theogravity/pulumi-fusionauth

--- a/themes/default/data/registry/packages/gandi.yaml
+++ b/themes/default/data/registry/packages/gandi.yaml
@@ -8,7 +8,6 @@ keywords:
 - gandi
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-gandi/main/logo.svg
 name: gandi
-native: false
 package_status: ga
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-gandi

--- a/themes/default/data/registry/packages/gcore.yaml
+++ b/themes/default/data/registry/packages/gcore.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from gcore.
 featured: false
 logo_url: ""
 name: gcore
-native: false
 package_status: public_preview
 publisher: g-core
 repo_url: https://github.com/g-core/terraform-provider-gcore

--- a/themes/default/data/registry/packages/gcorelabs.yaml
+++ b/themes/default/data/registry/packages/gcorelabs.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from gcorelabs.
 featured: false
 logo_url: ""
 name: gcorelabs
-native: false
 package_status: public_preview
 publisher: g-core
 repo_url: https://github.com/g-core/terraform-provider-gcorelabs

--- a/themes/default/data/registry/packages/gcp-global-cloudrun.yaml
+++ b/themes/default/data/registry/packages/gcp-global-cloudrun.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: gcp-global-cloudrun
-native: false
 package_status: public_preview
 publisher: Paul Stack
 repo_url: "https://github.com/pulumi/pulumi-gcp-global-cloudrun"

--- a/themes/default/data/registry/packages/gcp.yaml
+++ b/themes/default/data/registry/packages/gcp.yaml
@@ -8,7 +8,6 @@ keywords:
 - gcp
 logo_url: ""
 name: gcp
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-gcp

--- a/themes/default/data/registry/packages/genesiscloud.yaml
+++ b/themes/default/data/registry/packages/genesiscloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - genesiscloud
 logo_url: https://avatars.githubusercontent.com/u/38134186?s=200&v=4
 name: genesiscloud
-native: false
 package_status: public_preview
 publisher: Genesiscloud
 repo_url: https://github.com/genesiscloud/pulumi-genesiscloud

--- a/themes/default/data/registry/packages/github.yaml
+++ b/themes/default/data/registry/packages/github.yaml
@@ -8,7 +8,6 @@ keywords:
 - github
 logo_url: ""
 name: github
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-github

--- a/themes/default/data/registry/packages/gitlab.yaml
+++ b/themes/default/data/registry/packages/gitlab.yaml
@@ -8,7 +8,6 @@ keywords:
 - gitlab
 logo_url: ""
 name: gitlab
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-gitlab

--- a/themes/default/data/registry/packages/glesys.yaml
+++ b/themes/default/data/registry/packages/glesys.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from glesys.
 featured: false
 logo_url: ""
 name: glesys
-native: false
 package_status: public_preview
 publisher: glesys
 repo_url: https://github.com/glesys/terraform-provider-glesys

--- a/themes/default/data/registry/packages/google-cloud-static-website.yaml
+++ b/themes/default/data/registry/packages/google-cloud-static-website.yaml
@@ -4,7 +4,6 @@ description: A Pulumi component to deploy a static website to Google Cloud
 featured: false
 logo_url: ""
 name: google-cloud-static-website
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-google-cloud-static-website

--- a/themes/default/data/registry/packages/google-native.yaml
+++ b/themes/default/data/registry/packages/google-native.yaml
@@ -4,7 +4,6 @@ description: A native Pulumi package for creating and managing Google Cloud reso
 featured: false
 logo_url: ""
 name: google-native
-native: true
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-google-native

--- a/themes/default/data/registry/packages/googleworkspace.yaml
+++ b/themes/default/data/registry/packages/googleworkspace.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from googleworkspace.
 featured: false
 logo_url: ""
 name: googleworkspace
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/hashicorp/terraform-provider-googleworkspace

--- a/themes/default/data/registry/packages/grafana.yaml
+++ b/themes/default/data/registry/packages/grafana.yaml
@@ -9,7 +9,6 @@ keywords:
 - pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-grafana/main/assets/grafana.png
 name: grafana
-native: false
 package_status: ga
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-grafana

--- a/themes/default/data/registry/packages/harbor.yaml
+++ b/themes/default/data/registry/packages/harbor.yaml
@@ -8,7 +8,6 @@ keywords:
 - harbor
 logo_url: ""
 name: harbor
-native: false
 package_status: ga
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-harbor

--- a/themes/default/data/registry/packages/harness.yaml
+++ b/themes/default/data/registry/packages/harness.yaml
@@ -8,7 +8,6 @@ keywords:
 - harness
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-harness/main/assets/logo.png
 name: harness
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-harness

--- a/themes/default/data/registry/packages/hcl.yaml
+++ b/themes/default/data/registry/packages/hcl.yaml
@@ -6,7 +6,6 @@ description: Instantiate a Terraform/OpenTofu module as a Pulumi component.
 featured: false
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-hcl/master/assets/logo.svg
 name: hcl
-native: true
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-hcl

--- a/themes/default/data/registry/packages/hcloud.yaml
+++ b/themes/default/data/registry/packages/hcloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - hcloud
 logo_url: ""
 name: hcloud
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-hcloud

--- a/themes/default/data/registry/packages/hcp.yaml
+++ b/themes/default/data/registry/packages/hcp.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing HCP cloud resources.
 featured: false
 logo_url: https://raw.githubusercontent.com/grapl-security/pulumi-hcp/main/assets/hcp.svg
 name: hcp
-native: false
 package_status: public_preview
 publisher: Grapl Security
 repo_url: https://github.com/grapl-security/pulumi-hcp

--- a/themes/default/data/registry/packages/heroku.yaml
+++ b/themes/default/data/registry/packages/heroku.yaml
@@ -8,7 +8,6 @@ keywords:
 - heroku
 logo_url: ""
 name: heroku
-native: false
 package_status: ga
 publisher: pulumiverse - Marcel Arns
 repo_url: https://github.com/pulumiverse/pulumi-heroku

--- a/themes/default/data/registry/packages/honeycombio.yaml
+++ b/themes/default/data/registry/packages/honeycombio.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from honeycombio.
 featured: false
 logo_url: ""
 name: honeycombio
-native: false
 package_status: public_preview
 publisher: honeycombio
 repo_url: https://github.com/honeycombio/terraform-provider-honeycombio

--- a/themes/default/data/registry/packages/hpegl.yaml
+++ b/themes/default/data/registry/packages/hpegl.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from hpegl.
 featured: false
 logo_url: ""
 name: hpegl
-native: false
 package_status: public_preview
 publisher: hpe
 repo_url: https://github.com/hpe/terraform-provider-hpegl

--- a/themes/default/data/registry/packages/hsdp.yaml
+++ b/themes/default/data/registry/packages/hsdp.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from hsdp.
 featured: false
 logo_url: ""
 name: hsdp
-native: false
 package_status: ga
 publisher: philips-software
 repo_url: https://github.com/philips-software/terraform-provider-hsdp

--- a/themes/default/data/registry/packages/ibm.yaml
+++ b/themes/default/data/registry/packages/ibm.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from ibm.
 featured: false
 logo_url: ""
 name: ibm
-native: false
 package_status: ga
 publisher: ibm-cloud
 repo_url: https://github.com/ibm-cloud/terraform-provider-ibm

--- a/themes/default/data/registry/packages/impart.yaml
+++ b/themes/default/data/registry/packages/impart.yaml
@@ -8,7 +8,6 @@ keywords:
 - impart
 logo_url: https://console.impartsecurity.net/logomark-brand-background.png
 name: impart
-native: false
 package_status: public_preview
 publisher: Impart Security
 repo_url: https://github.com/impart-security/pulumi-impart

--- a/themes/default/data/registry/packages/improvmx.yaml
+++ b/themes/default/data/registry/packages/improvmx.yaml
@@ -6,7 +6,6 @@ description: Manage ImprovMX email forwarding resources.
 featured: false
 logo_url: https://raw.githubusercontent.com/lokkju/pulumi-improvmx/main/docs/improvmx-logo.png
 name: improvmx
-native: true
 package_status: public_preview
 publisher: lokkju
 repo_url: https://github.com/lokkju/pulumi-improvmx

--- a/themes/default/data/registry/packages/incapsula.yaml
+++ b/themes/default/data/registry/packages/incapsula.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from incapsula.
 featured: false
 logo_url: ""
 name: incapsula
-native: false
 package_status: ga
 publisher: imperva
 repo_url: https://github.com/imperva/terraform-provider-incapsula

--- a/themes/default/data/registry/packages/incident.yaml
+++ b/themes/default/data/registry/packages/incident.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from incident.
 featured: false
 logo_url: ""
 name: incident
-native: false
 package_status: ga
 publisher: incident-io
 repo_url: https://github.com/incident-io/terraform-provider-incident

--- a/themes/default/data/registry/packages/influxdb.yaml
+++ b/themes/default/data/registry/packages/influxdb.yaml
@@ -8,7 +8,6 @@ keywords:
 - influxdb
 logo_url: https://avatars.githubusercontent.com/u/5713248?s=200&v=4
 name: influxdb
-native: false
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/thulasirajkomminar/pulumi-influxdb

--- a/themes/default/data/registry/packages/influxdb3.yaml
+++ b/themes/default/data/registry/packages/influxdb3.yaml
@@ -8,7 +8,6 @@ keywords:
 - influxdb3
 logo_url: https://avatars.githubusercontent.com/u/5713248?s=200&v=4
 name: influxdb3
-native: false
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/thulasirajkomminar/pulumi-influxdb3

--- a/themes/default/data/registry/packages/infoblox.yaml
+++ b/themes/default/data/registry/packages/infoblox.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from infoblox.
 featured: false
 logo_url: ""
 name: infoblox
-native: false
 package_status: ga
 publisher: infobloxopen
 repo_url: https://github.com/infobloxopen/terraform-provider-infoblox

--- a/themes/default/data/registry/packages/intersight.yaml
+++ b/themes/default/data/registry/packages/intersight.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from intersight.
 featured: false
 logo_url: ""
 name: intersight
-native: false
 package_status: ga
 publisher: ciscodevnet
 repo_url: https://github.com/ciscodevnet/terraform-provider-intersight

--- a/themes/default/data/registry/packages/ionoscloud.yaml
+++ b/themes/default/data/registry/packages/ionoscloud.yaml
@@ -9,7 +9,6 @@ keywords:
 - ionoscloud
 logo_url: https://raw.githubusercontent.com/ionos-cloud/pulumi-ionoscloud/refs/heads/main/.github/LOGO_IONOS_Blue_RGB.png
 name: ionoscloud
-native: false
 package_status: public_preview
 publisher: ionos-cloud
 repo_url: https://github.com/ionos-cloud/pulumi-ionoscloud

--- a/themes/default/data/registry/packages/iosxe.yaml
+++ b/themes/default/data/registry/packages/iosxe.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing Cisco IOS XE Devices.
 featured: false
 logo_url: "https://www.pulumi.com/logos/tech/cisco.svg"
 name: iosxe
-native: false
 package_status: public_preview
 publisher: lbrlabs
 repo_url: https://github.com/lbrlabs/pulumi-iosxe

--- a/themes/default/data/registry/packages/ise.yaml
+++ b/themes/default/data/registry/packages/ise.yaml
@@ -9,7 +9,6 @@ keywords:
 - ise
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-ise/main/docs/ise.png
 name: ise
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-ise

--- a/themes/default/data/registry/packages/iterative.yaml
+++ b/themes/default/data/registry/packages/iterative.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from iterative.
 featured: false
 logo_url: ""
 name: iterative
-native: false
 package_status: public_preview
 publisher: iterative
 repo_url: https://github.com/iterative/terraform-provider-iterative

--- a/themes/default/data/registry/packages/jetstream.yaml
+++ b/themes/default/data/registry/packages/jetstream.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from jetstream.
 featured: false
 logo_url: ""
 name: jetstream
-native: false
 package_status: public_preview
 publisher: nats-io
 repo_url: https://github.com/nats-io/terraform-provider-jetstream

--- a/themes/default/data/registry/packages/juju.yaml
+++ b/themes/default/data/registry/packages/juju.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from juju.
 featured: false
 logo_url: ""
 name: juju
-native: false
 package_status: ga
 publisher: juju
 repo_url: https://github.com/juju/terraform-provider-juju

--- a/themes/default/data/registry/packages/junipermist.yaml
+++ b/themes/default/data/registry/packages/junipermist.yaml
@@ -9,7 +9,6 @@ keywords:
 - mist
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-junipermist/main/res/juniper.png
 name: junipermist
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-junipermist

--- a/themes/default/data/registry/packages/kafka-connect.yaml
+++ b/themes/default/data/registry/packages/kafka-connect.yaml
@@ -9,7 +9,6 @@ keywords:
 - kafkaconnect
 logo_url: https://raw.githubusercontent.com/azaurus1/pulumi-kafka-connect/refs/heads/main/.github/images/kafka-logo.png
 name: kafka-connect
-native: true
 package_status: public_preview
 publisher: azaurus1
 repo_url: https://github.com/azaurus1/pulumi-kafka-connect

--- a/themes/default/data/registry/packages/kafka.yaml
+++ b/themes/default/data/registry/packages/kafka.yaml
@@ -8,7 +8,6 @@ keywords:
 - kafka
 logo_url: ""
 name: kafka
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-kafka

--- a/themes/default/data/registry/packages/keycloak.yaml
+++ b/themes/default/data/registry/packages/keycloak.yaml
@@ -8,7 +8,6 @@ keywords:
 - keycloak
 logo_url: ""
 name: keycloak
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-keycloak

--- a/themes/default/data/registry/packages/kong.yaml
+++ b/themes/default/data/registry/packages/kong.yaml
@@ -8,7 +8,6 @@ keywords:
 - kong
 logo_url: ""
 name: kong
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-kong

--- a/themes/default/data/registry/packages/konnect.yaml
+++ b/themes/default/data/registry/packages/konnect.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from konnect.
 featured: false
 logo_url: ""
 name: konnect
-native: false
 package_status: ga
 publisher: kong
 repo_url: https://github.com/kong/terraform-provider-konnect

--- a/themes/default/data/registry/packages/koyeb.yaml
+++ b/themes/default/data/registry/packages/koyeb.yaml
@@ -8,7 +8,6 @@ keywords:
 - koyeb
 logo_url: ""
 name: koyeb
-native: false
 package_status: public_preview
 publisher: Koyeb
 repo_url: https://github.com/koyeb/pulumi-koyeb

--- a/themes/default/data/registry/packages/kubernetes-cert-manager.yaml
+++ b/themes/default/data/registry/packages/kubernetes-cert-manager.yaml
@@ -9,7 +9,6 @@ keywords:
 - cert-manager
 logo_url: ""
 name: kubernetes-cert-manager
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-kubernetes-cert-manager

--- a/themes/default/data/registry/packages/kubernetes-coredns.yaml
+++ b/themes/default/data/registry/packages/kubernetes-coredns.yaml
@@ -9,7 +9,6 @@ keywords:
 - coredns
 logo_url: ""
 name: kubernetes-coredns
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-kubernetes-coredns

--- a/themes/default/data/registry/packages/kubernetes-ingress-nginx.yaml
+++ b/themes/default/data/registry/packages/kubernetes-ingress-nginx.yaml
@@ -9,7 +9,6 @@ keywords:
 - nginx
 logo_url: ""
 name: kubernetes-ingress-nginx
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-kubernetes-ingress-nginx

--- a/themes/default/data/registry/packages/kubernetes.yaml
+++ b/themes/default/data/registry/packages/kubernetes.yaml
@@ -8,7 +8,6 @@ keywords:
 - kubernetes
 logo_url: ""
 name: kubernetes
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-kubernetes

--- a/themes/default/data/registry/packages/lacework.yaml
+++ b/themes/default/data/registry/packages/lacework.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from lacework.
 featured: false
 logo_url: ""
 name: lacework
-native: false
 package_status: ga
 publisher: lacework
 repo_url: https://github.com/lacework/terraform-provider-lacework

--- a/themes/default/data/registry/packages/launchdarkly.yaml
+++ b/themes/default/data/registry/packages/launchdarkly.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing launch darkly cloud reso
 featured: false
 logo_url: https://raw.githubusercontent.com/lbrlabs/pulumi-launchdarkly/master/assets/logo.png
 name: launchdarkly
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/lbrlabs/pulumi-launchdarkly

--- a/themes/default/data/registry/packages/lbrlabs-eks.yaml
+++ b/themes/default/data/registry/packages/lbrlabs-eks.yaml
@@ -11,7 +11,6 @@ keywords:
 - lbrlabs
 logo_url: https://raw.githubusercontent.com/lbrlabs/pulumi-lbrlabs-eks/main/assets/amazon-eks.png
 name: lbrlabs-eks
-native: false
 package_status: ga
 publisher: lbrlabs
 repo_url: https://github.com/lbrlabs/pulumi-lbrlabs-eks

--- a/themes/default/data/registry/packages/ldap.yaml
+++ b/themes/default/data/registry/packages/ldap.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from ldap.
 featured: false
 logo_url: ""
 name: ldap
-native: false
 package_status: ga
 publisher: elastic-infra
 repo_url: https://github.com/elastic-infra/terraform-provider-ldap

--- a/themes/default/data/registry/packages/libvirt.yaml
+++ b/themes/default/data/registry/packages/libvirt.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from libvirt.
 featured: false
 logo_url: ""
 name: libvirt
-native: false
 package_status: public_preview
 publisher: dmacvicar
 repo_url: https://github.com/dmacvicar/terraform-provider-libvirt

--- a/themes/default/data/registry/packages/linode.yaml
+++ b/themes/default/data/registry/packages/linode.yaml
@@ -8,7 +8,6 @@ keywords:
 - linode
 logo_url: ""
 name: linode
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-linode

--- a/themes/default/data/registry/packages/local.yaml
+++ b/themes/default/data/registry/packages/local.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from local.
 featured: false
 logo_url: ""
 name: local
-native: false
 package_status: ga
 publisher: hashicorp
 repo_url: https://github.com/hashicorp/terraform-provider-local

--- a/themes/default/data/registry/packages/logdna.yaml
+++ b/themes/default/data/registry/packages/logdna.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from logdna.
 featured: false
 logo_url: ""
 name: logdna
-native: false
 package_status: ga
 publisher: logdna
 repo_url: https://github.com/logdna/terraform-provider-logdna

--- a/themes/default/data/registry/packages/logfire.yaml
+++ b/themes/default/data/registry/packages/logfire.yaml
@@ -8,7 +8,6 @@ keywords:
 - logfire
 logo_url: https://avatars.githubusercontent.com/u/110818415?s=200&v=4
 name: logfire
-native: false
 package_status: public_preview
 publisher: Pydantic
 repo_url: https://github.com/pydantic/pulumi-logfire

--- a/themes/default/data/registry/packages/logzio.yaml
+++ b/themes/default/data/registry/packages/logzio.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from logzio.
 featured: false
 logo_url: ""
 name: logzio
-native: false
 package_status: ga
 publisher: logzio
 repo_url: https://github.com/logzio/terraform-provider-logzio

--- a/themes/default/data/registry/packages/lxd.yaml
+++ b/themes/default/data/registry/packages/lxd.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from lxd.
 featured: false
 logo_url: ""
 name: lxd
-native: false
 package_status: ga
 publisher: terraform-lxd
 repo_url: https://github.com/terraform-lxd/terraform-provider-lxd

--- a/themes/default/data/registry/packages/mailgun.yaml
+++ b/themes/default/data/registry/packages/mailgun.yaml
@@ -8,7 +8,6 @@ keywords:
 - mailgun
 logo_url: ""
 name: mailgun
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-mailgun

--- a/themes/default/data/registry/packages/matchbox.yaml
+++ b/themes/default/data/registry/packages/matchbox.yaml
@@ -8,7 +8,6 @@ keywords:
 - matchbox
 logo_url: ""
 name: matchbox
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-matchbox

--- a/themes/default/data/registry/packages/megaport.yaml
+++ b/themes/default/data/registry/packages/megaport.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from megaport.
 featured: false
 logo_url: ""
 name: megaport
-native: false
 package_status: ga
 publisher: megaport
 repo_url: https://github.com/megaport/terraform-provider-megaport

--- a/themes/default/data/registry/packages/meraki.yaml
+++ b/themes/default/data/registry/packages/meraki.yaml
@@ -8,7 +8,6 @@ keywords:
 - meraki
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-meraki/assets/assets/meraki.png
 name: meraki
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-meraki

--- a/themes/default/data/registry/packages/metabase.yaml
+++ b/themes/default/data/registry/packages/metabase.yaml
@@ -4,7 +4,6 @@ description: "A Pulumi component for deploying Metabase."
 featured: false
 logo_url: ""
 name: metabase
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-metabase

--- a/themes/default/data/registry/packages/minio.yaml
+++ b/themes/default/data/registry/packages/minio.yaml
@@ -8,7 +8,6 @@ keywords:
 - minio
 logo_url: ""
 name: minio
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-minio

--- a/themes/default/data/registry/packages/mongodbatlas.yaml
+++ b/themes/default/data/registry/packages/mongodbatlas.yaml
@@ -8,7 +8,6 @@ keywords:
 - mongodbatlas
 logo_url: ""
 name: mongodbatlas
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-mongodbatlas

--- a/themes/default/data/registry/packages/mso.yaml
+++ b/themes/default/data/registry/packages/mso.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from mso.
 featured: false
 logo_url: ""
 name: mso
-native: false
 package_status: ga
 publisher: ciscodevnet
 repo_url: https://github.com/ciscodevnet/terraform-provider-mso

--- a/themes/default/data/registry/packages/mssql.yaml
+++ b/themes/default/data/registry/packages/mssql.yaml
@@ -4,7 +4,6 @@ description: A Pulumi Provider for Microsoft SQL Server and Azure SQL
 featured: false
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-mssql/main/docs/mssql.png
 name: mssql
-native: false
 package_status: public_preview
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-mssql

--- a/themes/default/data/registry/packages/mysql.yaml
+++ b/themes/default/data/registry/packages/mysql.yaml
@@ -8,7 +8,6 @@ keywords:
 - mysql
 logo_url: ""
 name: mysql
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-mysql

--- a/themes/default/data/registry/packages/neon.yaml
+++ b/themes/default/data/registry/packages/neon.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from neon.
 featured: false
 logo_url: ""
 name: neon
-native: false
 package_status: public_preview
 publisher: kislerdm
 repo_url: https://github.com/kislerdm/terraform-provider-neon

--- a/themes/default/data/registry/packages/netaddr.yaml
+++ b/themes/default/data/registry/packages/netaddr.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from netaddr.
 featured: false
 logo_url: ""
 name: netaddr
-native: false
 package_status: public_preview
 publisher: ferlab-ste-justine
 repo_url: https://github.com/ferlab-ste-justine/terraform-provider-netaddr

--- a/themes/default/data/registry/packages/netapp-cloudmanager.yaml
+++ b/themes/default/data/registry/packages/netapp-cloudmanager.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from netapp-cloudmanager.
 featured: false
 logo_url: ""
 name: netapp-cloudmanager
-native: false
 package_status: ga
 publisher: netapp
 repo_url: https://github.com/netapp/terraform-provider-netapp-cloudmanager

--- a/themes/default/data/registry/packages/netbox.yaml
+++ b/themes/default/data/registry/packages/netbox.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from netbox.
 featured: false
 logo_url: ""
 name: netbox
-native: false
 package_status: ga
 publisher: e-breuninger
 repo_url: https://github.com/e-breuninger/terraform-provider-netbox

--- a/themes/default/data/registry/packages/netlify.yaml
+++ b/themes/default/data/registry/packages/netlify.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from netlify.
 featured: false
 logo_url: ""
 name: netlify
-native: false
 package_status: public_preview
 publisher: netlify
 repo_url: https://github.com/netlify/terraform-provider-netlify

--- a/themes/default/data/registry/packages/netskope-publisher.yaml
+++ b/themes/default/data/registry/packages/netskope-publisher.yaml
@@ -39,7 +39,6 @@ keywords:
 - yandex
 logo_url: https://raw.githubusercontent.com/johnneerdael/pulumi-netskope-publisher/main/site/source/images/netskope-logo.png
 name: netskope-publisher
-native: false
 package_status: public_preview
 publisher: johnneerdael
 repo_url: https://github.com/johnneerdael/pulumi-netskope-publisher

--- a/themes/default/data/registry/packages/newrelic.yaml
+++ b/themes/default/data/registry/packages/newrelic.yaml
@@ -8,7 +8,6 @@ keywords:
 - new relic
 logo_url: ""
 name: newrelic
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-newrelic

--- a/themes/default/data/registry/packages/nexus.yaml
+++ b/themes/default/data/registry/packages/nexus.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from nexus.
 featured: false
 logo_url: ""
 name: nexus
-native: false
 package_status: ga
 publisher: datadrivers
 repo_url: https://github.com/datadrivers/terraform-provider-nexus

--- a/themes/default/data/registry/packages/ngrok.yaml
+++ b/themes/default/data/registry/packages/ngrok.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing ngrok cloud resources.
 featured: false
 logo_url: https://raw.githubusercontent.com/pierskarsenbarg/pulumi-ngrok/main/docs/ngrok-black.svg
 name: ngrok
-native: false
 package_status: public_preview
 publisher: Piers Karsenbarg
 repo_url: https://github.com/pierskarsenbarg/pulumi-ngrok

--- a/themes/default/data/registry/packages/nomad.yaml
+++ b/themes/default/data/registry/packages/nomad.yaml
@@ -8,7 +8,6 @@ keywords:
 - nomad
 logo_url: ""
 name: nomad
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-nomad

--- a/themes/default/data/registry/packages/ns1.yaml
+++ b/themes/default/data/registry/packages/ns1.yaml
@@ -8,7 +8,6 @@ keywords:
 - ns1
 logo_url: ""
 name: ns1
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-ns1

--- a/themes/default/data/registry/packages/nsxt.yaml
+++ b/themes/default/data/registry/packages/nsxt.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from nsxt.
 featured: false
 logo_url: ""
 name: nsxt
-native: false
 package_status: ga
 publisher: vmware
 repo_url: https://github.com/vmware/terraform-provider-nsxt

--- a/themes/default/data/registry/packages/nuage.yaml
+++ b/themes/default/data/registry/packages/nuage.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: nuage
-native: false
 package_status: public_preview
 publisher: Nuage-Studio
 repo_url: https://github.com/nuage-studio/pulumi-nuage

--- a/themes/default/data/registry/packages/nutanix.yaml
+++ b/themes/default/data/registry/packages/nutanix.yaml
@@ -8,7 +8,6 @@ keywords:
 - nutanix
 logo_url: https://raw.githubusercontent.com/pierskarsenbarg/pulumi-nutanix/main/docs/nutanix-logo.png
 name: nutanix
-native: false
 package_status: public_preview
 publisher: Piers Karsenbarg
 repo_url: https://github.com/pierskarsenbarg/pulumi-nutanix

--- a/themes/default/data/registry/packages/nvidia-aicr.yaml
+++ b/themes/default/data/registry/packages/nvidia-aicr.yaml
@@ -12,7 +12,6 @@ keywords:
 - kubernetes
 logo_url: https://raw.githubusercontent.com/pulumi-labs/pulumi-nvidia-aicr/main/sdk/dotnet/logo.png
 name: nvidia-aicr
-native: true
 package_status: public_preview
 publisher: Pulumi Labs
 repo_url: https://github.com/pulumi-labs/pulumi-nvidia-aicr

--- a/themes/default/data/registry/packages/nxos.yaml
+++ b/themes/default/data/registry/packages/nxos.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing Cisco nxos XE Devices.
 featured: false
 logo_url: "https://www.pulumi.com/logos/tech/cisco.svg"
 name: nxos
-native: false
 package_status: public_preview
 publisher: lbrlabs
 repo_url: https://github.com/lbrlabs/pulumi-nxos

--- a/themes/default/data/registry/packages/oci.yaml
+++ b/themes/default/data/registry/packages/oci.yaml
@@ -10,7 +10,6 @@ keywords:
 - oracle
 logo_url: ""
 name: oci
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-oci

--- a/themes/default/data/registry/packages/octopusdeploy.yaml
+++ b/themes/default/data/registry/packages/octopusdeploy.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from octopusdeploy.
 featured: false
 logo_url: ""
 name: octopusdeploy
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/octopusdeploylabs/terraform-provider-octopusdeploy

--- a/themes/default/data/registry/packages/ohdear.yaml
+++ b/themes/default/data/registry/packages/ohdear.yaml
@@ -12,7 +12,6 @@ keywords:
 - status-page
 logo_url: https://raw.githubusercontent.com/matthiashamacher/pulumi-ohdear/main/assets/logo.png
 name: ohdear
-native: true
 package_status: ga
 publisher: Matthias Hamacher
 repo_url: https://github.com/matthiashamacher/pulumi-ohdear

--- a/themes/default/data/registry/packages/okta.yaml
+++ b/themes/default/data/registry/packages/okta.yaml
@@ -8,7 +8,6 @@ keywords:
 - okta
 logo_url: ""
 name: okta
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-okta

--- a/themes/default/data/registry/packages/onelogin.yaml
+++ b/themes/default/data/registry/packages/onelogin.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from onelogin.
 featured: false
 logo_url: ""
 name: onelogin
-native: false
 package_status: ga
 publisher: onelogin
 repo_url: https://github.com/onelogin/terraform-provider-onelogin

--- a/themes/default/data/registry/packages/onepassword.yaml
+++ b/themes/default/data/registry/packages/onepassword.yaml
@@ -5,7 +5,6 @@ description: Use the 1Password Pulumi provider to access and manage items in you
 featured: false
 logo_url: https://1password.com/logo-images/1password-logo-dark@2x.png
 name: onepassword
-native: false
 package_status: ga
 publisher: 1Password
 repo_url: https://github.com/1Password/pulumi-onepassword

--- a/themes/default/data/registry/packages/opennebula.yaml
+++ b/themes/default/data/registry/packages/opennebula.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from opennebula.
 featured: false
 logo_url: ""
 name: opennebula
-native: false
 package_status: ga
 publisher: opennebula
 repo_url: https://github.com/opennebula/terraform-provider-opennebula

--- a/themes/default/data/registry/packages/opensearch.yaml
+++ b/themes/default/data/registry/packages/opensearch.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from opensearch.
 featured: false
 logo_url: ""
 name: opensearch
-native: false
 package_status: ga
 publisher: opensearch-project
 repo_url: https://github.com/opensearch-project/terraform-provider-opensearch

--- a/themes/default/data/registry/packages/openstack.yaml
+++ b/themes/default/data/registry/packages/openstack.yaml
@@ -8,7 +8,6 @@ keywords:
 - openstack
 logo_url: ""
 name: openstack
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-openstack

--- a/themes/default/data/registry/packages/opentelekomcloud.yaml
+++ b/themes/default/data/registry/packages/opentelekomcloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from opentelekomcloud.
 featured: false
 logo_url: ""
 name: opentelekomcloud
-native: false
 package_status: ga
 publisher: opentelekomcloud
 repo_url: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud

--- a/themes/default/data/registry/packages/openwrt.yaml
+++ b/themes/default/data/registry/packages/openwrt.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from openwrt.
 featured: false
 logo_url: ""
 name: openwrt
-native: false
 package_status: public_preview
 publisher: joneshf
 repo_url: https://github.com/joneshf/terraform-provider-openwrt

--- a/themes/default/data/registry/packages/opsgenie.yaml
+++ b/themes/default/data/registry/packages/opsgenie.yaml
@@ -8,7 +8,6 @@ keywords:
 - opsgenie
 logo_url: ""
 name: opsgenie
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-opsgenie

--- a/themes/default/data/registry/packages/outscale.yaml
+++ b/themes/default/data/registry/packages/outscale.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from outscale.
 featured: false
 logo_url: ""
 name: outscale
-native: false
 package_status: ga
 publisher: outscale
 repo_url: https://github.com/outscale/terraform-provider-outscale

--- a/themes/default/data/registry/packages/ovh.yaml
+++ b/themes/default/data/registry/packages/ovh.yaml
@@ -8,7 +8,6 @@ keywords:
 - ovh
 logo_url: ""
 name: ovh
-native: false
 package_status: ga
 publisher: OVHcloud
 repo_url: https://github.com/ovh/pulumi-ovh

--- a/themes/default/data/registry/packages/packet.yaml
+++ b/themes/default/data/registry/packages/packet.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing Packet cloud resources.
 featured: false
 logo_url: ""
 name: packet
-native: false
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-packet

--- a/themes/default/data/registry/packages/pagerduty.yaml
+++ b/themes/default/data/registry/packages/pagerduty.yaml
@@ -8,7 +8,6 @@ keywords:
 - pagerduty
 logo_url: ""
 name: pagerduty
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-pagerduty

--- a/themes/default/data/registry/packages/panos.yaml
+++ b/themes/default/data/registry/packages/panos.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from panos.
 featured: false
 logo_url: ""
 name: panos
-native: false
 package_status: ga
 publisher: paloaltonetworks
 repo_url: https://github.com/paloaltonetworks/terraform-provider-panos

--- a/themes/default/data/registry/packages/pgedge.yaml
+++ b/themes/default/data/registry/packages/pgedge.yaml
@@ -8,7 +8,6 @@ keywords:
 - pgedge
 logo_url: https://raw.githubusercontent.com/pgEdge/pulumi-pgedge/main/.github/images/logo.png
 name: pgedge
-native: false
 package_status: public_preview
 publisher: pgEdge
 repo_url: https://github.com/pgEdge/pulumi-pgedge

--- a/themes/default/data/registry/packages/pinecone.yaml
+++ b/themes/default/data/registry/packages/pinecone.yaml
@@ -8,7 +8,6 @@ keywords:
 - pinecone
 logo_url: ""
 name: pinecone
-native: true
 package_status: ga
 publisher: pinecone-io
 repo_url: https://github.com/pinecone-io/pulumi-pinecone

--- a/themes/default/data/registry/packages/planetscale.yaml
+++ b/themes/default/data/registry/packages/planetscale.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from planetscale.
 featured: false
 logo_url: ""
 name: planetscale
-native: false
 package_status: ga
 publisher: planetscale
 repo_url: https://github.com/planetscale/terraform-provider-planetscale

--- a/themes/default/data/registry/packages/platform.yaml
+++ b/themes/default/data/registry/packages/platform.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from platform.
 featured: false
 logo_url: ""
 name: platform
-native: false
 package_status: ga
 publisher: jfrog
 repo_url: https://github.com/jfrog/terraform-provider-platform

--- a/themes/default/data/registry/packages/port.yaml
+++ b/themes/default/data/registry/packages/port.yaml
@@ -8,7 +8,6 @@ keywords:
 - port
 logo_url: ""
 name: port
-native: false
 package_status: ga
 publisher: port-labs
 repo_url: https://github.com/port-labs/pulumi-port

--- a/themes/default/data/registry/packages/postgresql.yaml
+++ b/themes/default/data/registry/packages/postgresql.yaml
@@ -8,7 +8,6 @@ keywords:
 - postgresql
 logo_url: ""
 name: postgresql
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-postgresql

--- a/themes/default/data/registry/packages/powerdns.yaml
+++ b/themes/default/data/registry/packages/powerdns.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from powerdns.
 featured: false
 logo_url: ""
 name: powerdns
-native: false
 package_status: ga
 publisher: pan-net
 repo_url: https://github.com/pan-net/terraform-provider-powerdns

--- a/themes/default/data/registry/packages/powerflex.yaml
+++ b/themes/default/data/registry/packages/powerflex.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from powerflex.
 featured: false
 logo_url: ""
 name: powerflex
-native: false
 package_status: ga
 publisher: dell
 repo_url: https://github.com/dell/terraform-provider-powerflex

--- a/themes/default/data/registry/packages/powerplatform.yaml
+++ b/themes/default/data/registry/packages/powerplatform.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider for managing Microsoft Power Platform resources.
 featured: false
 logo_url: https://raw.githubusercontent.com/rpothin/pulumi-powerplatform/main/docs/logo.svg
 name: powerplatform
-native: true
 package_status: public_preview
 publisher: rpothin
 repo_url: https://github.com/rpothin/pulumi-powerplatform

--- a/themes/default/data/registry/packages/powerscale.yaml
+++ b/themes/default/data/registry/packages/powerscale.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from powerscale.
 featured: false
 logo_url: ""
 name: powerscale
-native: false
 package_status: ga
 publisher: dell
 repo_url: https://github.com/dell/terraform-provider-powerscale

--- a/themes/default/data/registry/packages/powerstore.yaml
+++ b/themes/default/data/registry/packages/powerstore.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from powerstore.
 featured: false
 logo_url: ""
 name: powerstore
-native: false
 package_status: ga
 publisher: dell
 repo_url: https://github.com/dell/terraform-provider-powerstore

--- a/themes/default/data/registry/packages/prefect.yaml
+++ b/themes/default/data/registry/packages/prefect.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from prefect.
 featured: false
 logo_url: ""
 name: prefect
-native: false
 package_status: ga
 publisher: prefecthq
 repo_url: https://github.com/prefecthq/terraform-provider-prefect

--- a/themes/default/data/registry/packages/prismacloud.yaml
+++ b/themes/default/data/registry/packages/prismacloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from prismacloud.
 featured: false
 logo_url: ""
 name: prismacloud
-native: false
 package_status: ga
 publisher: paloaltonetworks
 repo_url: https://github.com/paloaltonetworks/terraform-provider-prismacloud

--- a/themes/default/data/registry/packages/prodvana.yaml
+++ b/themes/default/data/registry/packages/prodvana.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing Prodvana cloud resources
 featured: false
 logo_url: https://raw.githubusercontent.com/prodvana/pulumi-prodvana/main/docs/prodvana-icon.svg
 name: prodvana
-native: false
 package_status: public_preview
 publisher: Prodvana
 repo_url: https://github.com/prodvana/pulumi-prodvana

--- a/themes/default/data/registry/packages/propelauth.yaml
+++ b/themes/default/data/registry/packages/propelauth.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from propelauth.
 featured: false
 logo_url: ""
 name: propelauth
-native: false
 package_status: public_preview
 publisher: propelauth
 repo_url: https://github.com/propelauth/terraform-provider-propelauth

--- a/themes/default/data/registry/packages/proxmoxve.yaml
+++ b/themes/default/data/registry/packages/proxmoxve.yaml
@@ -10,7 +10,6 @@ keywords:
 - proxmoxve
 logo_url: https://raw.githubusercontent.com/muhlba91/pulumi-proxmoxve/main/assets/proxmox-logo.png
 name: proxmoxve
-native: false
 package_status: ga
 publisher: Daniel Muehlbachler-Pietrzykowski
 repo_url: https://github.com/muhlba91/pulumi-proxmoxve

--- a/themes/default/data/registry/packages/pulumiservice.yaml
+++ b/themes/default/data/registry/packages/pulumiservice.yaml
@@ -6,7 +6,6 @@ description: A native Pulumi package for creating and managing Pulumi Cloud cons
 featured: false
 logo_url: ""
 name: pulumiservice
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-pulumiservice

--- a/themes/default/data/registry/packages/purrl.yaml
+++ b/themes/default/data/registry/packages/purrl.yaml
@@ -8,7 +8,6 @@ keywords:
 - command
 logo_url: ""
 name: purrl
-native: true
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-purrl

--- a/themes/default/data/registry/packages/qdrant-cloud.yaml
+++ b/themes/default/data/registry/packages/qdrant-cloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from qdrant-cloud.
 featured: false
 logo_url: ""
 name: qdrant-cloud
-native: false
 package_status: ga
 publisher: qdrant
 repo_url: https://github.com/qdrant/terraform-provider-qdrant-cloud

--- a/themes/default/data/registry/packages/qovery.yaml
+++ b/themes/default/data/registry/packages/qovery.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing qovery cloud resources.
 featured: false
 logo_url: ""
 name: qovery
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/dirien/pulumi-qovery

--- a/themes/default/data/registry/packages/rabbitmq.yaml
+++ b/themes/default/data/registry/packages/rabbitmq.yaml
@@ -8,7 +8,6 @@ keywords:
 - rabbitmq
 logo_url: ""
 name: rabbitmq
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-rabbitmq

--- a/themes/default/data/registry/packages/rancher2.yaml
+++ b/themes/default/data/registry/packages/rancher2.yaml
@@ -8,7 +8,6 @@ keywords:
 - rancher2
 logo_url: ""
 name: rancher2
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-rancher2

--- a/themes/default/data/registry/packages/random.yaml
+++ b/themes/default/data/registry/packages/random.yaml
@@ -8,7 +8,6 @@ keywords:
 - random
 logo_url: ""
 name: random
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-random

--- a/themes/default/data/registry/packages/rediscloud.yaml
+++ b/themes/default/data/registry/packages/rediscloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - rediscloud
 logo_url: https://avatars.githubusercontent.com/u/1991868?s=200&v=4
 name: rediscloud
-native: false
 package_status: ga
 publisher: RedisLabs
 repo_url: https://github.com/RedisLabs/pulumi-rediscloud

--- a/themes/default/data/registry/packages/redpanda.yaml
+++ b/themes/default/data/registry/packages/redpanda.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from redpanda.
 featured: false
 logo_url: ""
 name: redpanda
-native: false
 package_status: ga
 publisher: redpanda-data
 repo_url: https://github.com/redpanda-data/terraform-provider-redpanda

--- a/themes/default/data/registry/packages/restapi.yaml
+++ b/themes/default/data/registry/packages/restapi.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from restapi.
 featured: false
 logo_url: ""
 name: restapi
-native: false
 package_status: ga
 publisher: mastercard
 repo_url: https://github.com/mastercard/terraform-provider-restapi

--- a/themes/default/data/registry/packages/rke.yaml
+++ b/themes/default/data/registry/packages/rke.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from rke.
 featured: false
 logo_url: ""
 name: rke
-native: false
 package_status: ga
 publisher: rancher
 repo_url: https://github.com/rancher/terraform-provider-rke

--- a/themes/default/data/registry/packages/rollbar.yaml
+++ b/themes/default/data/registry/packages/rollbar.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from rollbar.
 featured: false
 logo_url: ""
 name: rollbar
-native: false
 package_status: ga
 publisher: rollbar
 repo_url: https://github.com/rollbar/terraform-provider-rollbar

--- a/themes/default/data/registry/packages/rootly.yaml
+++ b/themes/default/data/registry/packages/rootly.yaml
@@ -8,7 +8,6 @@ keywords:
 - rootly
 logo_url: https://raw.githubusercontent.com/rootlyhq/pulumi-rootly/master/logos/rootly.svg
 name: rootly
-native: false
 package_status: ga
 publisher: rootlyhq
 repo_url: https://github.com/rootlyhq/pulumi-rootly

--- a/themes/default/data/registry/packages/routeros.yaml
+++ b/themes/default/data/registry/packages/routeros.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from routeros.
 featured: false
 logo_url: ""
 name: routeros
-native: false
 package_status: ga
 publisher: terraform-routeros
 repo_url: https://github.com/terraform-routeros/terraform-provider-routeros

--- a/themes/default/data/registry/packages/runpod.yaml
+++ b/themes/default/data/registry/packages/runpod.yaml
@@ -12,7 +12,6 @@ keywords:
 - ai
 logo_url: https://avatars.githubusercontent.com/u/95939477?s=200&v=4
 name: runpod
-native: true
 package_status: ga
 publisher: Runpod
 repo_url: https://github.com/runpod/pulumi-runpod-native

--- a/themes/default/data/registry/packages/scaleway.yaml
+++ b/themes/default/data/registry/packages/scaleway.yaml
@@ -9,7 +9,6 @@ keywords:
 - pulumiverse
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-scaleway/master/assets/scaleway.png
 name: scaleway
-native: false
 package_status: ga
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-scaleway

--- a/themes/default/data/registry/packages/scm.yaml
+++ b/themes/default/data/registry/packages/scm.yaml
@@ -9,7 +9,6 @@ keywords:
 - paloaltonetworks
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-scm/main/docs/logo.png
 name: scm
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-scm

--- a/themes/default/data/registry/packages/sdm.yaml
+++ b/themes/default/data/registry/packages/sdm.yaml
@@ -8,7 +8,6 @@ keywords:
 - sdm
 logo_url: https://raw.githubusercontent.com/pierskarsenbarg/pulumi-sdm/main/docs/strongdm-logo.png
 name: sdm
-native: false
 package_status: ga
 publisher: Piers Karsenbarg
 repo_url: https://github.com/pierskarsenbarg/pulumi-sdm

--- a/themes/default/data/registry/packages/sdwan.yaml
+++ b/themes/default/data/registry/packages/sdwan.yaml
@@ -8,7 +8,6 @@ keywords:
 - sdwan
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-sdwan/main/docs/logo.png
 name: sdwan
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-sdwan

--- a/themes/default/data/registry/packages/selectel.yaml
+++ b/themes/default/data/registry/packages/selectel.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from selectel.
 featured: false
 logo_url: ""
 name: selectel
-native: false
 package_status: ga
 publisher: selectel
 repo_url: https://github.com/selectel/terraform-provider-selectel

--- a/themes/default/data/registry/packages/sentry.yaml
+++ b/themes/default/data/registry/packages/sentry.yaml
@@ -8,7 +8,6 @@ keywords:
 - sentry
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-sentry/main/sentry.svg
 name: sentry
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-sentry

--- a/themes/default/data/registry/packages/signalfx.yaml
+++ b/themes/default/data/registry/packages/signalfx.yaml
@@ -8,7 +8,6 @@ keywords:
 - signalfx
 logo_url: ""
 name: signalfx
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-signalfx

--- a/themes/default/data/registry/packages/slack.yaml
+++ b/themes/default/data/registry/packages/slack.yaml
@@ -8,7 +8,6 @@ keywords:
 - slack
 logo_url: ""
 name: slack
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-slack

--- a/themes/default/data/registry/packages/snowflake.yaml
+++ b/themes/default/data/registry/packages/snowflake.yaml
@@ -8,7 +8,6 @@ keywords:
 - snowflake
 logo_url: ""
 name: snowflake
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-snowflake

--- a/themes/default/data/registry/packages/sonarqube.yaml
+++ b/themes/default/data/registry/packages/sonarqube.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from sonarqube.
 featured: false
 logo_url: ""
 name: sonarqube
-native: false
 package_status: public_preview
 publisher: jdamata
 repo_url: https://github.com/jdamata/terraform-provider-sonarqube

--- a/themes/default/data/registry/packages/spectrocloud.yaml
+++ b/themes/default/data/registry/packages/spectrocloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from spectrocloud.
 featured: false
 logo_url: ""
 name: spectrocloud
-native: false
 package_status: public_preview
 publisher: spectrocloud
 repo_url: https://github.com/spectrocloud/terraform-provider-spectrocloud

--- a/themes/default/data/registry/packages/splight.yaml
+++ b/themes/default/data/registry/packages/splight.yaml
@@ -10,7 +10,6 @@ keywords:
 - infrastructure
 logo_url: https://raw.githubusercontent.com/splightplatform/pulumi-splight/main/docs/logo.png
 name: splight
-native: false
 package_status: ga
 publisher: splightplatform
 repo_url: https://github.com/splightplatform/pulumi-splight

--- a/themes/default/data/registry/packages/splunk.yaml
+++ b/themes/default/data/registry/packages/splunk.yaml
@@ -8,7 +8,6 @@ keywords:
 - splunk
 logo_url: ""
 name: splunk
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-splunk

--- a/themes/default/data/registry/packages/spotinst.yaml
+++ b/themes/default/data/registry/packages/spotinst.yaml
@@ -8,7 +8,6 @@ keywords:
 - spotinst
 logo_url: ""
 name: spotinst
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-spotinst

--- a/themes/default/data/registry/packages/sql.yaml
+++ b/themes/default/data/registry/packages/sql.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from sql.
 featured: false
 logo_url: ""
 name: sql
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/paultyng/terraform-provider-sql

--- a/themes/default/data/registry/packages/stackit.yaml
+++ b/themes/default/data/registry/packages/stackit.yaml
@@ -8,7 +8,6 @@ keywords:
 - stackit
 logo_url: https://raw.githubusercontent.com/stackitcloud/pulumi-stackit/main/.github/images/stackit-logo.svg
 name: stackit
-native: false
 package_status: public_preview
 publisher: stackitcloud
 repo_url: https://github.com/stackitcloud/pulumi-stackit

--- a/themes/default/data/registry/packages/statsig.yaml
+++ b/themes/default/data/registry/packages/statsig.yaml
@@ -8,7 +8,6 @@ keywords:
 - statsig
 logo_url: https://statsig-aws-marketplace-asset.s3.us-west-1.amazonaws.com/statsig-logo.png
 name: statsig
-native: false
 package_status: public_preview
 publisher: Statsig
 repo_url: https://github.com/statsig-io/pulumi-statsig

--- a/themes/default/data/registry/packages/statuscake.yaml
+++ b/themes/default/data/registry/packages/statuscake.yaml
@@ -8,7 +8,6 @@ keywords:
 - statuscake
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-statuscake/main/statuscake.svg
 name: statuscake
-native: false
 package_status: ga
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-statuscake

--- a/themes/default/data/registry/packages/std.yaml
+++ b/themes/default/data/registry/packages/std.yaml
@@ -6,7 +6,6 @@ description: Standard library functions
 featured: false
 logo_url: ""
 name: std
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-std

--- a/themes/default/data/registry/packages/str.yaml
+++ b/themes/default/data/registry/packages/str.yaml
@@ -4,7 +4,6 @@ description: Basic string manipulation functions
 featured: false
 logo_url: ""
 name: str
-native: true
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-str

--- a/themes/default/data/registry/packages/stripe.yaml
+++ b/themes/default/data/registry/packages/stripe.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from stripe.
 featured: false
 logo_url: ""
 name: stripe
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/stripe/terraform-provider-stripe

--- a/themes/default/data/registry/packages/sumologic.yaml
+++ b/themes/default/data/registry/packages/sumologic.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from sumologic.
 featured: false
 logo_url: ""
 name: sumologic
-native: false
 package_status: ga
 publisher: sumologic
 repo_url: https://github.com/sumologic/terraform-provider-sumologic

--- a/themes/default/data/registry/packages/supabase.yaml
+++ b/themes/default/data/registry/packages/supabase.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from supabase.
 featured: false
 logo_url: https://raw.githubusercontent.com/supabase/terraform-provider-supabase/refs/heads/main/assets/supabase-logo-wordmark--light.svg
 name: supabase
-native: false
 package_status: ga
 publisher: supabase
 repo_url: https://github.com/supabase/terraform-provider-supabase

--- a/themes/default/data/registry/packages/symbiosis.yaml
+++ b/themes/default/data/registry/packages/symbiosis.yaml
@@ -4,7 +4,6 @@ description: A Pulumi package for creating and managing symbiosis cloud resource
 featured: false
 logo_url: ""
 name: symbiosis
-native: false
 package_status: ga
 publisher: Symbiosis
 repo_url: https://github.com/symbiosis-cloud/pulumi-symbiosis

--- a/themes/default/data/registry/packages/synced-folder.yaml
+++ b/themes/default/data/registry/packages/synced-folder.yaml
@@ -11,7 +11,6 @@ keywords:
 - gcp
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-synced-folder/main/assets/synced-folder.png
 name: synced-folder
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-synced-folder

--- a/themes/default/data/registry/packages/sysdig.yaml
+++ b/themes/default/data/registry/packages/sysdig.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from sysdig.
 featured: false
 logo_url: ""
 name: sysdig
-native: false
 package_status: ga
 publisher: sysdiglabs
 repo_url: https://github.com/sysdiglabs/terraform-provider-sysdig

--- a/themes/default/data/registry/packages/tailscale.yaml
+++ b/themes/default/data/registry/packages/tailscale.yaml
@@ -8,7 +8,6 @@ keywords:
 - tailscale
 logo_url: ""
 name: tailscale
-native: false
 package_status: public_preview
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-tailscale

--- a/themes/default/data/registry/packages/talos.yaml
+++ b/themes/default/data/registry/packages/talos.yaml
@@ -8,7 +8,6 @@ keywords:
 - talos
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-talos/refs/heads/main/assets/talos-logo.png
 name: talos
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-talos

--- a/themes/default/data/registry/packages/temporalcloud.yaml
+++ b/themes/default/data/registry/packages/temporalcloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from temporalcloud.
 featured: false
 logo_url: ""
 name: temporalcloud
-native: false
 package_status: ga
 publisher: temporalio
 repo_url: https://github.com/temporalio/terraform-provider-temporalcloud

--- a/themes/default/data/registry/packages/tencentcloud.yaml
+++ b/themes/default/data/registry/packages/tencentcloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from tencentcloud.
 featured: false
 logo_url: ""
 name: tencentcloud
-native: false
 package_status: ga
 publisher: tencentcloudstack
 repo_url: https://github.com/tencentcloudstack/terraform-provider-tencentcloud

--- a/themes/default/data/registry/packages/terraform-provider.yaml
+++ b/themes/default/data/registry/packages/terraform-provider.yaml
@@ -8,7 +8,6 @@ keywords:
 - catagory/utility
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png
 name: terraform-provider
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-terraform-provider

--- a/themes/default/data/registry/packages/terraform.yaml
+++ b/themes/default/data/registry/packages/terraform.yaml
@@ -9,7 +9,6 @@ keywords:
 - terraform
 logo_url: https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png
 name: terraform
-native: true
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-terraform

--- a/themes/default/data/registry/packages/thoth.yaml
+++ b/themes/default/data/registry/packages/thoth.yaml
@@ -11,7 +11,6 @@ keywords:
 - ai
 logo_url: https://raw.githubusercontent.com/atensecurity/pulumi-thoth/main/docs/logo.png
 name: thoth
-native: false
 package_status: public_preview
 publisher: Aten Security
 repo_url: https://github.com/atensecurity/pulumi-thoth

--- a/themes/default/data/registry/packages/threefold.yaml
+++ b/themes/default/data/registry/packages/threefold.yaml
@@ -9,7 +9,6 @@ keywords:
 - threefold
 logo_url: https://www.threefold.io/images/black_threefold.png
 name: threefold
-native: true
 package_status: public_preview
 publisher: Threefold
 repo_url: https://github.com/threefoldtech/pulumi-threefold

--- a/themes/default/data/registry/packages/time.yaml
+++ b/themes/default/data/registry/packages/time.yaml
@@ -8,7 +8,6 @@ keywords:
 - time
 logo_url: https://raw.githubusercontent.com/pulumiverse/pulumi-time/main/docs/clock-svgrepo-com.png
 name: time
-native: false
 package_status: public_preview
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-time

--- a/themes/default/data/registry/packages/timescale.yaml
+++ b/themes/default/data/registry/packages/timescale.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from timescale.
 featured: false
 logo_url: ""
 name: timescale
-native: false
 package_status: ga
 publisher: timescale
 repo_url: https://github.com/timescale/terraform-provider-timescale

--- a/themes/default/data/registry/packages/tls-self-signed-cert.yaml
+++ b/themes/default/data/registry/packages/tls-self-signed-cert.yaml
@@ -4,7 +4,6 @@ description: ""
 featured: false
 logo_url: ""
 name: tls-self-signed-cert
-native: true
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-tls-self-signed-cert

--- a/themes/default/data/registry/packages/tls.yaml
+++ b/themes/default/data/registry/packages/tls.yaml
@@ -8,7 +8,6 @@ keywords:
 - tls
 logo_url: ""
 name: tls
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-tls

--- a/themes/default/data/registry/packages/turso.yaml
+++ b/themes/default/data/registry/packages/turso.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from turso.
 featured: false
 logo_url: ""
 name: turso
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/celest-dev/terraform-provider-turso

--- a/themes/default/data/registry/packages/twingate.yaml
+++ b/themes/default/data/registry/packages/twingate.yaml
@@ -8,7 +8,6 @@ keywords:
 - twingate
 logo_url: https://raw.githubusercontent.com/Twingate/pulumi-twingate/main/docs/logo.png
 name: twingate
-native: false
 package_status: ga
 publisher: Twingate
 repo_url: https://github.com/twingate/pulumi-twingate

--- a/themes/default/data/registry/packages/ucloud.yaml
+++ b/themes/default/data/registry/packages/ucloud.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from ucloud.
 featured: false
 logo_url: ""
 name: ucloud
-native: false
 package_status: ga
 publisher: ucloud
 repo_url: https://github.com/ucloud/terraform-provider-ucloud

--- a/themes/default/data/registry/packages/unifi.yaml
+++ b/themes/default/data/registry/packages/unifi.yaml
@@ -8,7 +8,6 @@ keywords:
 - unifi
 logo_url: ""
 name: unifi
-native: false
 package_status: public_preview
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-unifi

--- a/themes/default/data/registry/packages/upcloud.yaml
+++ b/themes/default/data/registry/packages/upcloud.yaml
@@ -8,7 +8,6 @@ keywords:
 - upcloud
 logo_url: https://raw.githubusercontent.com/UpCloudLtd/.github/refs/heads/main/profile/logo.png
 name: upcloud
-native: false
 package_status: public_preview
 publisher: UpCloudLtd
 repo_url: https://github.com/UpCloudLtd/pulumi-upcloud

--- a/themes/default/data/registry/packages/upstash.yaml
+++ b/themes/default/data/registry/packages/upstash.yaml
@@ -8,7 +8,6 @@ keywords:
 - upstash
 logo_url: https://upstash.com/static/logo/logo-light.svg
 name: upstash
-native: false
 package_status: public_preview
 publisher: Upstash
 repo_url: https://github.com/upstash/pulumi-upstash

--- a/themes/default/data/registry/packages/vantage.yaml
+++ b/themes/default/data/registry/packages/vantage.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from vantage.
 featured: false
 logo_url: ""
 name: vantage
-native: false
 package_status: public_preview
 publisher: vantage-sh
 repo_url: https://github.com/vantage-sh/terraform-provider-vantage

--- a/themes/default/data/registry/packages/vault.yaml
+++ b/themes/default/data/registry/packages/vault.yaml
@@ -8,7 +8,6 @@ keywords:
 - vault
 logo_url: ""
 name: vault
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-vault

--- a/themes/default/data/registry/packages/vcd.yaml
+++ b/themes/default/data/registry/packages/vcd.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from vcd.
 featured: false
 logo_url: ""
 name: vcd
-native: false
 package_status: ga
 publisher: vmware
 repo_url: https://github.com/vmware/terraform-provider-vcd

--- a/themes/default/data/registry/packages/venafi.yaml
+++ b/themes/default/data/registry/packages/venafi.yaml
@@ -8,7 +8,6 @@ keywords:
 - venafi
 logo_url: ""
 name: venafi
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-venafi

--- a/themes/default/data/registry/packages/vercel.yaml
+++ b/themes/default/data/registry/packages/vercel.yaml
@@ -8,7 +8,6 @@ keywords:
 - vercel
 logo_url: ""
 name: vercel
-native: false
 package_status: ga
 publisher: Pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-vercel

--- a/themes/default/data/registry/packages/vkcs.yaml
+++ b/themes/default/data/registry/packages/vkcs.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from vkcs.
 featured: false
 logo_url: ""
 name: vkcs
-native: false
 package_status: public_preview
 publisher: vk-cs
 repo_url: https://github.com/vk-cs/terraform-provider-vkcs

--- a/themes/default/data/registry/packages/vmc.yaml
+++ b/themes/default/data/registry/packages/vmc.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from vmc.
 featured: false
 logo_url: ""
 name: vmc
-native: false
 package_status: ga
 publisher: vmware
 repo_url: https://github.com/vmware/terraform-provider-vmc

--- a/themes/default/data/registry/packages/volcengine.yaml
+++ b/themes/default/data/registry/packages/volcengine.yaml
@@ -8,7 +8,6 @@ keywords:
 - volcengine
 logo_url: https://avatars.githubusercontent.com/u/67365215
 name: volcengine
-native: false
 package_status: public_preview
 publisher: Volcengine
 repo_url: https://github.com/volcengine/pulumi-volcengine

--- a/themes/default/data/registry/packages/volcenginecc.yaml
+++ b/themes/default/data/registry/packages/volcenginecc.yaml
@@ -9,7 +9,6 @@ keywords:
 - volcenginecc
 logo_url: https://avatars.githubusercontent.com/u/67365215
 name: volcenginecc
-native: false
 package_status: public_preview
 publisher: Volcengine
 repo_url: https://github.com/volcengine/pulumi-volcenginecc

--- a/themes/default/data/registry/packages/vra.yaml
+++ b/themes/default/data/registry/packages/vra.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from vra.
 featured: false
 logo_url: ""
 name: vra
-native: false
 package_status: public_preview
 publisher: vmware
 repo_url: https://github.com/vmware/terraform-provider-vra

--- a/themes/default/data/registry/packages/vsphere.yaml
+++ b/themes/default/data/registry/packages/vsphere.yaml
@@ -8,7 +8,6 @@ keywords:
 - vsphere
 logo_url: ""
 name: vsphere
-native: false
 package_status: ga
 publisher: Pulumi
 repo_url: https://github.com/pulumi/pulumi-vsphere

--- a/themes/default/data/registry/packages/vultr.yaml
+++ b/themes/default/data/registry/packages/vultr.yaml
@@ -8,7 +8,6 @@ keywords:
 - vultr
 logo_url: ""
 name: vultr
-native: false
 package_status: ga
 publisher: dirien
 repo_url: https://github.com/dirien/pulumi-vultr

--- a/themes/default/data/registry/packages/wavefront.yaml
+++ b/themes/default/data/registry/packages/wavefront.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from wavefront.
 featured: false
 logo_url: ""
 name: wavefront
-native: false
 package_status: ga
 publisher: DEPRECATED
 repo_url: https://github.com/vmware/terraform-provider-wavefront

--- a/themes/default/data/registry/packages/xenorchestra.yaml
+++ b/themes/default/data/registry/packages/xenorchestra.yaml
@@ -8,7 +8,6 @@ keywords:
 - xenorchestra
 logo_url: https://raw.githubusercontent.com/vatesfr/pulumi-xenorchestra/8c71624229d953d4fb7d4843d5483e53e21b9459/logo_xo.png
 name: xenorchestra
-native: false
 package_status: ga
 publisher: Vates
 repo_url: https://github.com/vatesfr/pulumi-xenorchestra

--- a/themes/default/data/registry/packages/yandex.yaml
+++ b/themes/default/data/registry/packages/yandex.yaml
@@ -6,7 +6,6 @@ description: A Pulumi package for creating and managing yandex cloud resources.
 featured: false
 logo_url: ""
 name: yandex
-native: false
 package_status: public_preview
 publisher: DEPRECATED
 repo_url: https://github.com/pulumi/pulumi-yandex

--- a/themes/default/data/registry/packages/zenduty.yaml
+++ b/themes/default/data/registry/packages/zenduty.yaml
@@ -6,7 +6,6 @@ description: A Pulumi provider dynamically bridged from zenduty.
 featured: false
 logo_url: ""
 name: zenduty
-native: false
 package_status: ga
 publisher: zenduty
 repo_url: https://github.com/zenduty/terraform-provider-zenduty

--- a/themes/default/data/registry/packages/zia.yaml
+++ b/themes/default/data/registry/packages/zia.yaml
@@ -6,7 +6,6 @@ description: A native Pulumi provider for Zscaler Internet Access (ZIA).
 featured: false
 logo_url: ""
 name: zia
-native: true
 package_status: ga
 publisher: Zscaler
 repo_url: https://github.com/zscaler/pulumi-zia

--- a/themes/default/data/registry/packages/zitadel.yaml
+++ b/themes/default/data/registry/packages/zitadel.yaml
@@ -8,7 +8,6 @@ keywords:
 - zitadel
 logo_url: ""
 name: zitadel
-native: false
 package_status: public_preview
 publisher: pulumiverse
 repo_url: https://github.com/pulumiverse/pulumi-zitadel

--- a/themes/default/data/registry/packages/zpa.yaml
+++ b/themes/default/data/registry/packages/zpa.yaml
@@ -10,7 +10,6 @@ keywords:
 - zscaler
 logo_url: https://raw.githubusercontent.com/zscaler/pulumi-zpa/master/assets/zscaler.png
 name: zpa
-native: false
 package_status: ga
 publisher: Zscaler
 repo_url: https://github.com/zscaler/pulumi-zpa


### PR DESCRIPTION
Stacked on #12439 — review and merge that one first.

Mechanical follow-up: one deleted `native:` line per generated package YAML, 312 files, no other change. Split out of #12439 so the behavioral change stays reviewable.

Nothing reads the field any more and `resourcedocsgen` no longer emits it, so the next regeneration of each file would drop it regardless. Merging #12439 without this is safe on its own — the three sites that unmarshal `PackageMeta` use `ghodss/yaml`, which ignores unknown fields.

Verified the site still renders all 312 package cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCUrytgvtCgtr4KAP8X7M9