### PR TITLE
Delist the gcp-global-cloudrun component

### DIFF
--- a/themes/default/data/registry/packages/gcp-global-cloudrun.yaml
+++ b/themes/default/data/registry/packages/gcp-global-cloudrun.yaml
@@ -5,7 +5,7 @@ featured: false
 logo_url: ""
 name: gcp-global-cloudrun
 package_status: public_preview
-publisher: Paul Stack
+publisher: DEPRECATED
 repo_url: "https://github.com/pulumi/pulumi-gcp-global-cloudrun"
 schema_file_path: /provider/cmd/pulumi-resource-gcp-global-cloudrun/schema.json
 title: GCP Global CloudRun


### PR DESCRIPTION
`gcp-global-cloudrun` is still listed in the registry and still published to the Pulumi Cloud package store, but nobody maintains it — the last substantive commit was May 2023, and the open issues include "Defunct demo" and a 2022 offer to take over maintenance that was never answered. pulumi/docs#18570 already pulled its card from the Google Cloud IaC landing page.

## Changes

- Set `publisher: DEPRECATED` in `gcp-global-cloudrun.yaml`

That one field is the whole delisting mechanism: `package.html` stamps `data-deprecated` on the card so `packages.ts` hides it from the grid unless the reader ticks the "Deprecated" type filter, and both `publish_to_registry.py` and `push-registry.py` skip the package on the next deploy. The package isn't in `community-packages/package-list.json`, so there's nothing to remove there, and the YAML and `_index.md` stay put — the page keeps resolving for anyone on an old link.

What this deliberately doesn't do: the issue asked for a deprecation banner on `/registry/packages/gcp-global-cloudrun/`, and the metadata change alone won't produce one. Banners live in `package-alert.html` as a hardcoded per-package `if/else` chain, so 29 of the 31 deprecated packages render nothing. Making that generic is #12455 rather than a one-off branch here.

Archiving `pulumi/pulumi-gcp-global-cloudrun` (the issue's second ask) still needs doing — it takes repo admin, which I don't have.

Verified with `make lint`.

Fixes #10691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ2fnbakUfT68ZwuXSUYE5
