### PR TITLE
Rewrite the architecture doc around its three update paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Every package in the registry is described by a YAML file at `themes/default/dat
 
 - API doc generation (`resourcedocsgen`)
 - Registry publication (`scripts/ci/publish_to_registry.py`, with `scripts/ci/push-registry.py` as a fallback)
-- The nightly community package update workflow
+- The scheduled community package update workflow
 
 ### Go Tools
 
@@ -80,7 +80,7 @@ Every package in the registry is described by a YAML file at `themes/default/dat
 
 The CI build script (`scripts/ci/build.sh`) writes to **`themes/default/content/registry/packages/`**.
 
-This difference is intentional — local API doc generation stays out of the Hugo theme tree. Within `themes/default/content/registry/packages/<pkg>/`, the `api-docs/` subdirectory is regenerated on every build and is git-ignored, so never commit it. The landing pages are different: `_index.md` — plus `installation-configuration.md` for the packages that have one, which is optional, since only `_index.md` is required — is committed and maintained by the `generate-package-metadata.yml` publish workflow, and bundled when onboarding a package so it renders before the next nightly run. Do not hand-edit any of these files; regenerate them with `resourcedocsgen`.
+This difference is intentional — local API doc generation stays out of the Hugo theme tree. Within `themes/default/content/registry/packages/<pkg>/`, the `api-docs/` subdirectory is regenerated on every build and is git-ignored, so never commit it. The landing pages are different: `_index.md` — plus `installation-configuration.md` for the packages that have one, which is optional, since only `_index.md` is required — is committed and maintained by the `generate-package-metadata.yml` publish workflow, and bundled when onboarding a package so it renders before the next scheduled run. Do not hand-edit any of these files; regenerate them with `resourcedocsgen`.
 
 Additionally, `resourcedocsgen` writes **LLM docs** to **`llm-docs-out/registry/packages/`** (repo root, git-ignored). These are terminal-friendly markdown bundles (`llm-docs.json`) uploaded to S3 separately from the Hugo site. The LLM docs format is specified in `docs/llm-markdown-spec.md`.
 
@@ -99,7 +99,7 @@ Each CI build syncs to a uniquely named S3 bucket. A Pulumi IaC program in `infr
 To add or update a community provider package:
 
 1. Edit (or create) its YAML file in `themes/default/data/registry/packages/`.
-2. The nightly `generate-package-metadata.yml` workflow handles version bumps automatically for community packages tracked in `community-packages/package-list.json`.
+2. The scheduled `generate-package-metadata.yml` workflow handles version bumps automatically for community packages tracked in `community-packages/package-list.json`.
 3. First-party Pulumi provider repos trigger `publish-provider-update.yml` via `repository_dispatch`.
 
 On every push to `master`, `publish_to_registry.py` publishes packages to the live Pulumi registry service — the Pulumi Cloud store behind `pulumi package add`, which is separate from the rendered site. `push-registry.py` runs only if that step fails.

--- a/BUILD-AND-DEPLOY.md
+++ b/BUILD-AND-DEPLOY.md
@@ -13,8 +13,9 @@ This document describes the build, test, and deployment system for the `pulumi/r
    - [4.1 Makefile Targets](#41-makefile-targets)
    - [4.2 Hugo Build](#42-hugo-build)
    - [4.3 resourcedocsgen Tool](#43-resourcedocsgen-tool)
-   - [4.4 CI Build Script](#44-ci-build-script-scriptscibuilds)
+   - [4.4 CI Build Script](#44-ci-build-script-scriptscibuildsh)
    - [4.5 Versioned Documentation](#45-versioned-documentation)
+   - [4.7 Build Caching](#47-build-caching)
 5. [GitHub Actions Workflows](#github-actions-workflows)
    - [5.1 pull-request.yml — PR Validation + Preview Deploy](#51-pull-requestyml--pr-validation--preview-deploy)
    - [5.2 push.yml — Production Build + Deploy](#52-pushyml--production-build--deploy)
@@ -85,10 +86,10 @@ The canonical tool versions are tracked in `mise.toml`:
 | Tool | Version |
 |---|---|
 | Go | 1.26 |
-| Node.js | 20 |
+| Node.js | 24 |
 | Yarn | 1.22.22 |
 | Hugo | 0.157 (extended) |
-| golangci-lint | 2.1.6 |
+| golangci-lint | 2.10.1 |
 | yq | latest |
 
 Install and manage all tools via [mise](https://mise.jdx.dev/):
@@ -156,14 +157,20 @@ mise trust && mise install
 | Hugo 0.157 (extended) | Static site generation from templates and content |
 | resourcedocsgen | Generates provider API reference docs from Pulumi schemas |
 | Pulumi IaC | Manages AWS resources; reads metadata file to update CloudFront origin |
-| Algolia | Search index; updated as part of production deploys via `scripts/search/main.js` |
+| Algolia | Search index; production deploys build `search-index.json` with `scripts/search/main.js` and upload it to the origin bucket (`scripts/generate-search-index.sh`) for the search index update job to load |
 | AWS S3 | Hosts built site content as a static website origin |
 | AWS CloudFront | CDN serving the site; origin pointed at S3 bucket by Pulumi IaC |
 | AWS SSM Parameter Store | Maps commit SHAs to their corresponding S3 origin buckets |
 
 ### Multi-Repo Touchpoints
 
-- **`pulumi/pulumi-*` provider repos**: Trigger `publish-provider-update.yml` via `repository_dispatch` when a new provider version is released.
+- **`pulumi/pulumi-*` provider repos**: Trigger `publish-provider-update.yml` via a `resource-provider` `repository_dispatch` when a new provider version is released. Most get that step from `pulumi/ci-mgmt` templates.
+- **`pulumi/terraform-to-pulumi-registry-pipeline`** (internal): Watches dynamically bridged Terraform providers, stores their generated schemas in S3, and triggers `publish-provider-update.yml` via a `push-provider-update` `repository_dispatch`.
+- **Partner and community package repos**: Listed in `community-packages/package-list.json`. `generate-package-metadata.yml` reads their latest GitHub release, schema, and `docs/`.
+- **`pulumi/ci-mgmt`**: Provider CI templates that send the `resource-provider` dispatch, and the source of `provider-ci/providers.json`, which `scripts/generate-versioned-docs.sh` reads.
+- **`pulumi/registry-mirror-tools`**: Tools used by `scripts/generate-versioned-docs.sh` and `scripts/ci/publish_to_registry.py`.
+
+See [docs/architecture.md](./docs/architecture.md) for how these fit together.
 
 ---
 
@@ -548,9 +555,15 @@ PR opened / committed
         ├── test-provider-api-docs
         │       └── make ensure build-assets → make test_provider_api_docs
         │
+        ├── test-infra
+        │       └── make test-infra
+        │
+        ├── check-publish
+        │       └── python3 scripts/ci/community-package/cli.py check-publish → post fact-sheet
+        │
         ├── preview  (skipped for fork PRs; skipped for automation/tfgen-provider-docs label)
         │       ├── Fetch ESC secrets
-        │       ├── Install Node 22, Go 1.26, Hugo 0.157
+        │       ├── Install Node 24, Go 1.26, Hugo 0.157
         │       ├── Validate community-packages/package-list.json
         │       ├── Configure AWS credentials → assume testing account role
         │       ├── Install s5cmd v2.3.0
@@ -572,7 +585,7 @@ PR opened / committed
 
 **Skipping preview for fork PRs**: Fork PRs are excluded at the workflow level. The `preview` job has an `if:` condition that only allows it to run when `github.event.pull_request.head.repo.full_name == github.repository`, so the job is never scheduled for PRs from forks. `pull-request.sh` also contains a defensive credential check (for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `PULUMI_ACCESS_TOKEN`) as a fallback, but this code path is not expected to be reached in practice.
 
-**The `sentinel` job**: The sentinel job creates a GitHub status check called `"Sentinel"` only after all required jobs pass. This single required check simplifies branch protection rules. The sentinel job runs for non-fork PRs and for `repository_dispatch` events (condition: `github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository`).
+**The `sentinel` job**: The sentinel job creates a GitHub status check called `"Sentinel"` only after all required jobs pass. This single required check simplifies branch protection rules. The sentinel job runs only for PRs from branches in this repository (condition: `github.event.pull_request.head.repo.full_name == github.repository`).
 
 **Key environment variables in `preview` job**:
 
@@ -600,7 +613,7 @@ Push to master
         │
         └── build job
                 ├── Fetch ESC secrets (OIDC)
-                ├── Install Node 22, Go 1.26, Hugo 0.157
+                ├── Install Node 24, Go 1.26, Hugo 0.157
                 ├── Checkout (using PULUMI_BOT_TOKEN for private module access)
                 ├── Configure AWS credentials
                 │       └── Assume arn:aws:iam::388588623842:role/ContinuousDelivery
@@ -623,6 +636,8 @@ Push to master
                 │       ├── scripts/ci/run-pulumi.sh update
                 │       │       └── pulumi -C infrastructure update --yes
                 │       │           (reads origin-bucket-metadata.json, updates CloudFront)
+                │       ├── scripts/ci/invalidate-docs-cdn.sh
+                │       │       └── Invalidate /registry/* on the www.pulumi.com CloudFront distribution
                 │       └── scripts/ci/make-s3-redirects.sh
                 │               └── Apply 301 redirects from scripts/redirects/
                 ├── Archive origin-bucket-metadata.json as artifact
@@ -652,7 +667,7 @@ Push to master
 
 #### `testing-deploy.yml` — Manual Test Environment Deploy
 
-Identical to `push.yml` but triggered manually via `workflow_dispatch` and deploys to the testing environment (account `571684982431`, role `arn:aws:iam::571684982431:role/ContinuousDelivery`). Uses Go 1.21.x (note: older than production).
+Identical to `push.yml` but triggered manually via `workflow_dispatch` and deploys to the testing environment (account `571684982431`, role `arn:aws:iam::571684982431:role/ContinuousDelivery`). Reads its Go version from `tools/resourcedocsgen/go.mod`, like production.
 
 #### `pull-request-closed.yml` — PR Preview Cleanup
 
@@ -673,7 +688,7 @@ A reusable `workflow_call` workflow. Called by `pull-request.yml` for `tools/res
 
 Jobs:
 
-- **lint**: Sparse checkout → golangci-lint v2.1.6 with `--config .golangci.yml`
+- **lint**: Sparse checkout → golangci-lint v2.10.1 with `--config .golangci.yml`
 - **test**: Sparse checkout → `go test ./... -v`
 
 #### `check-links.yml` — Link Validation
@@ -682,7 +697,7 @@ Jobs:
 
 Runs `make check_links` which calls `yarn run check-links`, which runs `node scripts/link-checker/check-links.js "https://www.pulumi.com/registry" 2` (2 retries on failure). Broken links are reported to the `#registry-ops` Slack channel.
 
-Node version: 22.x; Hugo 0.157.0 installed but not explicitly used.
+Node version: 24.x; Hugo 0.157.0 installed but not explicitly used.
 
 #### `run-browser-tests.yml` — Scheduled Browser Tests
 
@@ -690,16 +705,16 @@ Node version: 22.x; Hugo 0.157.0 installed but not explicitly used.
 
 Runs `make run-browser-tests` on a `pulumi-ubuntu-8core` runner. Assumes the production AWS role (`388588623842:role/ContinuousDelivery`) to be able to reach the live site.
 
-Node version: 22.x; Hugo 0.157.0 installed.
+Node version: 24.x; Hugo 0.157.0 installed.
 
-#### `generate-package-metadata.yml` — Nightly Community Package Check
+#### `generate-package-metadata.yml` — Scheduled Community Package Check
 
-**Trigger**: Daily at 5:30 AM UTC and 5:30 PM UTC; also `workflow_dispatch`
+**Trigger**: Daily at 5:30 AM UTC and 5:30 PM UTC; also `workflow_dispatch`, and a push to `master` that changes `community-packages/package-list.json`
 
 **Flow**:
 
 1. `generate-packages-list` job: Runs `python generate_package_list.py` in `community-packages/` to build a matrix of community provider repos to check.
-2. `check-for-package-update` job (matrix, max-parallel: 1): For each provider, runs `resourcedocsgen pkgversion` to check if a new version is available. If so, runs `resourcedocsgen metadata from-github` to generate updated metadata and opens a PR via `.github/actions/new-provider-version-pr`.
+2. `check-for-package-update` job (matrix, max-parallel: 8): For each provider, runs `resourcedocsgen pkgversion` to check if a new version is available. If so, runs `resourcedocsgen metadata from-github` to generate updated metadata and opens a PR via `.github/actions/new-provider-version-pr`.
 3. PRs are skipped if an open PR already exists for that provider (deduplication check via `list_pull_requests` in `scripts/common.sh`).
 
 #### `community-package-*.yml` — Community Package Verified Check
@@ -719,14 +734,14 @@ After merge, `generate-package-metadata.yml` (above) generates and publishes the
 
 **Trigger**: `repository_dispatch` with event types `resource-provider` or `push-provider-update`
 
-Used by first-party Pulumi provider repos to trigger documentation regeneration when a new provider version is released.
+Used by first-party Pulumi provider repos, and by `pulumi/terraform-to-pulumi-registry-pipeline` for dynamically bridged Terraform providers, to trigger documentation regeneration when a new provider version is released.
 
-| Event type | Use case | Required inputs |
-|---|---|---|
-| `resource-provider` | GitHub-hosted provider (Pulumi repo) | `project-shortname`, `ref` (version tag) |
-| `push-provider-update` | Opaque provider (no assumed GitHub structure) | `project-shortname`, `schema-url`, `index-url` |
+| Event type | Use case | Required inputs | Optional inputs |
+|---|---|---|---|
+| `resource-provider` | GitHub-hosted provider (Pulumi repo) | `project-shortname`, `ref` (version tag) | `schema-path` |
+| `push-provider-update` | Opaque provider (no assumed GitHub structure) | `project-shortname`, `schema-url`, `index-url` | — |
 
-For `resource-provider`: Calls `resourcedocsgen metadata from-github` → creates a PR. For `push-provider-update`: Downloads schema from `schema-url`, extracts version from schema, calls `resourcedocsgen metadata from-urls` → creates a PR.
+For `resource-provider`: Calls `resourcedocsgen metadata from-github` → creates a PR. For `push-provider-update`: Downloads schema from `schema-url`, extracts version from schema, checks the schema's publisher is in `publisher-names.json`, calls `resourcedocsgen metadata from-urls` → creates a PR.
 
 #### `bucket-cleanup.yml` — Remove Stale S3 Preview Buckets
 
@@ -1102,13 +1117,13 @@ The `export-repo-secrets.yml` workflow provides a manual escape hatch to sync Gi
 
 | Tool | `mise.toml` | `pull-request.yml` (preview) | `push.yml` (production) | `testing-deploy.yml` |
 |---|---|---|---|---|
-| Node.js | 20 | 22.x | 22.x | 22.x |
+| Node.js | 24 | 24.x | 24.x | 24.x |
 | Go | 1.26 | `tools/resourcedocsgen/go.mod` | `tools/resourcedocsgen/go.mod` | `tools/resourcedocsgen/go.mod` |
 | Hugo | 0.157 | 0.157.0 | 0.157.0 | 0.157.0 |
-| golangci-lint | 2.1.6 | v2.1.6 (check-go.yml) | — | — |
+| golangci-lint | 2.10.1 | v2.10.1 (check-go.yml) | — | — |
 | s5cmd | — | v2.3.0 | v2.3.0 | v2.3.0 |
 
-Note: `mise.toml` specifies Node 20 for local development, while CI workflows use Node 22. The `lint-markdown` and `lint-scripts` jobs in `pull-request.yml` use Node 23.x. The `bucket-cleanup.yml` workflow uses Node 18.x.
+Note: `mise.toml` and the CI workflows use Node 24, including `bucket-cleanup.yml` and every job in `pull-request.yml`. The exception is `community-package-check.yml`, which pins Node 20.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,114 +1,191 @@
-# Architecture
+# Registry architecture
 
-Definitions:
+This repository keeps two things current with every package release:
 
-- **Registry Repo**: Metadata, templates, scripts & workflow. Builds pulumi.com/registry
-- **Registry API**: Part of pulumi-service. AKA "Private Registry"
+- **The registry site** at [pulumi.com/registry](https://www.pulumi.com/registry), a static Hugo site built from this repository and hosted on AWS.
+- **The Registry API**, the Pulumi Cloud service behind `pulumi package add`. The site build reads package schemas from it, and each production deploy publishes new package versions to it.
 
-## Information Flow Diagram
+Every package is described by a metadata file, `themes/default/data/registry/packages/<package>.yaml`, which records its version, schema URL, publisher, and display details. A new version reaches neither destination until a pull request updates that file and merges to `master`. So every release follows the same shape: something notices the new version and opens a pull request, the pull request merges once its checks pass, and the merge rebuilds the site and publishes the package.
 
 ```mermaid
-flowchart TD
-    %% Input Sources
-    IP[Internal Provider Publish]
-    TF[Any TF Provider Cron]
-    TP[3rd Party Provider Cron]
-    
-    %% Processing Components
-    TFP[Schema Convert Lambda]
-    S3[Write to S3 Bucket]
+flowchart LR
+    accTitle: How a new package version reaches the registry
+    accDescr: A Pulumi provider release, the Terraform provider pipeline, or the partner and community check opens an update pull request in pulumi/registry. When it merges, push.yml rebuilds pulumi.com/registry and publishes to the Registry API.
 
-    %% Registry Processing
-    RD[Repository Dispatch Handler]
-    PR[Pull Request<br/>Update Metadata YAML]
-    
-    %% Build & Deploy
-    MASTER[Master Branch Push]
-    BUILD[Pull schemas<br/>Gen markdown<br/>Build Hugo]
-    DEPLOY[Search Index Update<br/>Infrastructure up<br/>Create Redirects]
-    
-    %% Output
-    SITE[pulumi.com/registry]
-    
-    %% Flows
-    IP -->|repository_dispatch<br/>resource-provider| RD
-    
-    TF -->|Check watched providers| TFP
-    TFP -->|Download binary & extract schema| S3
-    S3 -->|repository_dispatch<br/>push-provider-update| RD
-    
-    TP -->|Read package-list.json<br/>Check new version<br/>Write metadata| PR
-    
-    RD -->|Fetch & validate schema<br/>Write metadata| PR
-    PR -->|Merge| MASTER
-    
-    MASTER -->|Trigger push.yml| BUILD
-    BUILD --> DEPLOY
-    DEPLOY --> SITE
-    
-    %% Styling
-    classDef aws fill:#09bbc9,stroke:#000
-    classDef input fill:#6b3a7d,stroke:#000
-    classDef process fill:#0e9e4d,stroke:#000
-    classDef output fill:#ec3024,stroke:#000
-    
-    class TF,TFP,S3 aws
-    class IP,TP input
-    class MASTER,RD,PR,BUILD,DEPLOY process
-    class SITE output
+    subgraph providers ["pulumi/pulumi-*"]
+        release["Pulumi provider release"]
+    end
+
+    subgraph tfpipeline ["pulumi/terraform-to-pulumi-registry-pipeline"]
+        pipeline["Terraform provider check"]
+    end
+
+    subgraph registry ["pulumi/registry"]
+        community["Partner and community check"]
+        pr["Update pull request"]
+        push["push.yml"]
+        community --> pr
+        pr -->|merge to master| push
+    end
+
+    subgraph cloud ["Pulumi Cloud"]
+        api["Registry API"]
+    end
+
+    release --> pr
+    pipeline --> pr
+    push --> site["pulumi.com/registry"]
+    push --> api
 ```
 
-## Registry Package Updates
+## Registry package updates
 
-There are currently three sources of information for updating the registry:
+A new package version enters the registry through one of three paths, depending on where the package comes from. All three end the same way, with an [update pull request](#update-pull-requests) against the package's metadata file.
 
-1. Internal Providers (Pulumi repos)
-2. TF Providers (OpenTofu registry)
-3. 3rd Party Providers (other GitHub orgs)
+| Path | Covers | Triggered by | Runs in |
+|---|---|---|---|
+| [Pulumi providers](#pulumi-providers) | Providers in `pulumi/pulumi-<name>` repositories | The provider's release workflow | The provider repository, then `pulumi/registry` |
+| [Terraform providers](#terraform-providers) | Dynamically bridged Terraform providers | A recurring schedule | `pulumi/terraform-to-pulumi-registry-pipeline`, then `pulumi/registry` |
+| [Partner and community packages](#partner-and-community-packages) | Packages listed in `community-packages/package-list.json` | A recurring schedule | `pulumi/registry` |
 
-### Internal Provider
+### Pulumi providers
 
-When a provider is published, the provider's CI job dispatches a GitHub Actions `repository_dispatch` event of the type `resource-provider` to the `pulumi/registry` repository (see [Repository Dispatch Handling](#repository-dispatch-handling)). Here's an example of [AWS dispatching the `resource-provider` event type](https://github.com/pulumi/pulumi-aws/blob/ac9d16db7c9bbf56ff8a2e0c2746693b7309c2e1/.github/workflows/publish.yml#L240-L251). See [Repository Dispatch Handling](#repository-dispatch-handling) for what happens to this event.
+```mermaid
+flowchart LR
+    accTitle: Pulumi provider update path
+    accDescr: A release in a pulumi/pulumi-* provider repository sends a resource-provider event to pulumi/registry, where publish-provider-update.yml generates metadata from the release tag and opens an update pull request.
 
-### TF Provider
+    subgraph provider ["pulumi/pulumi-* provider repository"]
+        release["Release published"] --> send["Send resource-provider event"]
+    end
 
-For dynamically bridged providers–where we don't maintain a dedicated repository for the bridging source and releases–we need to poll for changes and build the schema so we can generate Pulumi registry docs. This runs twice per day.
+    subgraph registry ["pulumi/registry"]
+        handler["publish-provider-update.yml"] --> metadata["Generate metadata at the release tag"]
+        metadata --> pr["Update pull request"]
+    end
 
-1. Source provider list is read from an S3 object (pushed from the `watched-providers` config value in the [Pulumi.yaml](https://github.com/pulumi/terraform-to-pulumi-registry-pipeline/blob/main/Pulumi.yaml))
-2. If there's a new version available, we download the binary in a sandbox lambda and push the schema to an S3 bucket.
-3. Send a `repository_dispatch` event to `pulumi/registry` of type `push-provider-update` with URLs to where the files are available in the bucket (see [Repository Dispatch Handling](#repository-dispatch-handling)).
+    send -->|repository_dispatch| handler
+```
 
-See [terraform-to-pulumi-registry-pipeline](https://github.com/pulumi/terraform-to-pulumi-registry-pipeline) (internal) for more detail on the lambda-based pipeline.
+Pulumi's own providers tell the registry about a release as it happens. When a provider publishes a release, its release workflow sends a `repository_dispatch` event of type `resource-provider` to this repository. Most provider repositories get this step from a [`pulumi/ci-mgmt`](https://github.com/pulumi/ci-mgmt) template. The `base` template, used by bridged providers, sends the event with a GitHub Action in [`publish.yml`](https://github.com/pulumi/ci-mgmt/blob/a385cbd207ddc170b47fa79e340d13bb5414e3bc/provider-ci/internal/pkg/templates/base/.github/workflows/publish.yml#L234-L267). The `native` template, used by native providers and some components, sends it with `pulumictl create docs-build` in [`release.yml`](https://github.com/pulumi/ci-mgmt/blob/a385cbd207ddc170b47fa79e340d13bb5414e3bc/provider-ci/internal/pkg/templates/native/.github/workflows/release.yml#L676-L707). A few repositories with hand-written release workflows, such as `pulumi/pulumi-azure-native`, call `pulumictl create docs-build` directly.
 
-### 3rd Party
+The event's `client_payload` carries:
 
-For provider which are published by third parties via GitHub repositories (as Pulumi providers rather than TF providers), we use a [scheduled GitHub Actions workflow](https://github.com/pulumi/registry/blob/master/.github/workflows/generate-package-metadata.yml) to check for updates to publish. This is run twice a day.
+- `project-shortname`: the package name, such as `aws`.
+- `ref`: the release tag, such as `v7.2.0`.
+- `schema-path` (optional): the schema's path in the provider repository, when it isn't the default `provider/cmd/pulumi-resource-<name>/schema.json`.
 
-1. Read the list of third-party providers from [community-packages/package-list.json](https://github.com/pulumi/registry/blob/master/community-packages/package-list.json).
-2. For each, check if the latest published version is newer than the version recorded in the metadata file [themes/default/data/registry/packages/[PROVIDER].yaml](https://github.com/pulumi/registry/tree/master/themes/default/data/registry/packages).
-3. If there's a new version, download the schema from the repository, validate it and open a pull request to update the metadata file.
+[`publish-provider-update.yml`](../.github/workflows/publish-provider-update.yml) handles the event by running `resourcedocsgen metadata from-github` against `pulumi/pulumi-<project-shortname>` at that tag, with Pulumi as the publisher. The command reads the schema, checks its name, version, category, and publisher, and writes the metadata file. It also copies the provider's `docs/_index.md` into this repository as the package's Overview page, along with `docs/installation-configuration.md` when the provider has one. The workflow then opens an [update pull request](#update-pull-requests).
 
-### Repository Dispatch Handling
+Because the repository is derived from `project-shortname`, this path only works for providers that live at `pulumi/pulumi-<name>`. A Pulumi-maintained package that doesn't match that pattern can be listed in `package-list.json` instead, which puts it on the [partner and community path](#partner-and-community-packages).
 
-The [publish-provider-update](https://github.com/pulumi/registry/blob/master/.github/workflows/publish-provider-update.yml) workflow supports 2 types of events:
+### Terraform providers
 
-1. `resource-provider(PROVIDER_SHORT_NAME, PROVIDER_VERSION, PROVIDER_SCHEMA_PATH?)` (see [Internal Provider](#internal-provider))
-2. `push-provider-update(PROVIDER_SHORT_NAME, PROVIDER_SCHEMA_URL, PROVIDER_INDEX_URL)` (see [TF Provider](#tf-provider))
+Dynamically bridged Terraform providers, the ones you use with `pulumi package add terraform-provider <name>`, have no provider repository of their own and no release workflow to notify the registry. A pipeline in AWS watches for their releases instead. It's defined in [`pulumi/terraform-to-pulumi-registry-pipeline`](https://github.com/pulumi/terraform-to-pulumi-registry-pipeline), which is internal, so links into it only work for members of the Pulumi GitHub organization.
 
-When one of these events is received, we fetch the schema, validate it, then open a pull request to update the relevant metadata file: [themes/default/data/registry/packages/[PROVIDER].yaml](https://github.com/pulumi/registry/tree/master/themes/default/data/registry/packages).
+```mermaid
+flowchart LR
+    accTitle: Terraform provider update path
+    accDescr: On a schedule, the pipeline in pulumi/terraform-to-pulumi-registry-pipeline checks watched providers for new versions, generates each new schema into S3, and sends a push-provider-update event. publish-provider-update.yml in pulumi/registry reads the schema from storage and opens an update pull request.
 
-## Pull requests
+    subgraph pipeline ["pulumi/terraform-to-pulumi-registry-pipeline (AWS)"]
+        check["Scheduled version check"] -->|new version| generate["Generate schema"]
+        generate --> storage[("Schema storage")]
+        generate --> send["Send push-provider-update event"]
+    end
 
-When a pull request is opened by the above processes we auto-merge the PR if all checks pass (validation & site build).
+    subgraph registry ["pulumi/registry"]
+        handler["publish-provider-update.yml"] --> metadata["Generate metadata from storage URLs"]
+        metadata --> pr["Update pull request"]
+    end
+
+    send -->|repository_dispatch| handler
+    metadata -.->|reads| storage
+```
+
+On a recurring schedule, the pipeline checks each provider in the `watched-providers` list in its [`Pulumi.yaml`](https://github.com/pulumi/terraform-to-pulumi-registry-pipeline/blob/main/Pulumi.yaml). Only providers on that list are covered, not every Terraform provider. For each one, it compares the latest stable version in the provider's registry, such as the OpenTofu registry, with the version pulumi.com/registry has. When there's a new version, a Lambda function runs `pulumi package get-schema` on the provider, stores the schema and an Overview page in an S3 bucket behind a CDN, and sends a `repository_dispatch` event of type `push-provider-update` to this repository. The pipeline reports its own failures as GitHub issues.
+
+The event's `client_payload` carries:
+
+- `project-shortname`: the package name.
+- `schema-url`: the schema's URL in the pipeline's storage.
+- `index-url`: the Overview page's URL in the same storage.
+
+The version isn't part of the payload. [`publish-provider-update.yml`](../.github/workflows/publish-provider-update.yml) downloads the schema, reads the version from it, and checks that the schema's publisher is listed in [`publisher-names.json`](../tools/resourcedocsgen/pkg/publishers/publisher-names.json). It then runs `resourcedocsgen metadata from-urls`, which applies the same schema checks as the Pulumi providers path and writes a metadata file that points at those URLs, so they have to stay available after the pull request merges. The workflow then opens an [update pull request](#update-pull-requests).
+
+### Partner and community packages
+
+```mermaid
+flowchart LR
+    accTitle: Partner and community package update path
+    accDescr: generate-package-metadata.yml in pulumi/registry reads package-list.json, compares each package repository's latest GitHub release with the registry, generates metadata from the repository at that tag, and opens an update pull request.
+
+    subgraph registry ["pulumi/registry"]
+        list["package-list.json"] --> check["generate-package-metadata.yml"]
+        check --> pr["Update pull request"]
+    end
+
+    subgraph upstream ["Package repository (partner or community)"]
+        release["Latest GitHub release"]
+    end
+
+    check -.->|reads latest release| release
+```
+
+Packages that don't notify the registry themselves are picked up by checking their GitHub releases. Most are maintained by Pulumi partners and community members, including the [Pulumiverse](https://github.com/pulumiverse) organization, and a few Pulumi-maintained components are listed the same way. Each has an entry in [`community-packages/package-list.json`](../community-packages/package-list.json), and adding one is how a package joins the registry. See [Adding a new package](./adding-a-new-package.md) for that process.
+
+[`generate-package-metadata.yml`](../.github/workflows/generate-package-metadata.yml) runs on a recurring schedule (the cron is in the workflow file) and on demand. It also runs whenever a merge to `master` changes `package-list.json`, so a newly added package doesn't wait for the next scheduled run. For each entry, the workflow:
+
+1. Skips the package if an update pull request for it is already open.
+1. Compares the tag of the repository's latest GitHub release with `version` in the package's metadata file.
+1. When they differ, runs `resourcedocsgen metadata from-github` against the repository at that tag, which reads the schema and docs the same way the [Pulumi providers](#pulumi-providers) path does, and opens an [update pull request](#update-pull-requests).
+
+## Update pull requests
+
+All three paths open their pull requests with the same composite action, [`.github/actions/new-provider-version-pr`](../.github/actions/new-provider-version-pr/action.yml). Each pull request is authored by `pulumi-bot` on a branch named `<package>/publish-metadata`, so a package has at most one open update pull request at a time.
+
+The action turns on squash auto-merge when it creates the pull request, and [`auto-approve-for-auto-merge.yml`](../.github/workflows/auto-approve-for-auto-merge.yml) approves pull requests from `pulumi-bot`. The pull request then merges on its own once the `Sentinel` status passes. [`pull-request.yml`](../.github/workflows/pull-request.yml) reports that status only after every required job succeeds, including linting, the Go and infrastructure tests, a full preview build of the site, and a check that every package's metadata can be turned into a Registry API publish request. An update that would break the build stays open for a maintainer to look at.
+
+If either update workflow fails, it posts to the `#registry-ops` Slack channel. For the full list of pull request checks, see [`pull-request.yml` in BUILD-AND-DEPLOY.md](../BUILD-AND-DEPLOY.md#51-pull-requestyml--pr-validation--preview-deploy).
 
 ## Publish
 
-When the master branch is updated, we build and publish the whole registry static site (see [.github/workflows/push.yml](https://github.com/pulumi/registry/blob/master/.github/workflows/push.yml))
+Every push to `master`, whether it's an update pull request or any other change, runs [`push.yml`](../.github/workflows/push.yml). It rebuilds and deploys the whole site, then publishes changed packages to the Registry API.
 
-1. Build the hugo site (`make ci_push` --> [`scripts/ci/push.sh`](https://github.com/pulumi/registry/blob/master/scripts/ci/push.sh)):
-   1. [`scripts/ci/build.sh`](https://github.com/pulumi/registry/blob/master/scripts/ci/build.sh) runs `resourcedocsgen docs registry ...` which downloads all schemas from their sources and generates markdown files.
-   2. Hugo builds the static site.
-2. Push the built site to a new S3 bucket (see [scripts/ci/sync.sh](https://github.com/pulumi/registry/blob/master/scripts/ci/sync.sh)) and update an SSM parameter keyed by the commit hash.
-3. Update the search indexes (see [scripts/generate-search-index.sh](https://github.com/pulumi/registry/blob/master/scripts/generate-search-index.sh)).
-4. Run the Pulumi infrastructure deployment.
-5. Create [S3 redirects](https://github.com/pulumi/registry/blob/master/scripts/ci/make-s3-redirects.sh).
+```mermaid
+flowchart LR
+    accTitle: Publish on push to master
+    accDescr: push.yml builds the site while reading schemas from the Registry API, syncs it to a new S3 bucket, points CloudFront at that bucket to update pulumi.com/registry, then publishes changed packages to the Registry API.
+
+    merge["Push to master"] --> build
+
+    subgraph registry ["pulumi/registry: push.yml"]
+        build["Build site"] --> sync["Sync to a new S3 bucket"]
+        sync --> swap["Point CloudFront at the bucket"]
+        swap --> publish["Publish changed packages"]
+    end
+
+    subgraph cloud ["Pulumi Cloud"]
+        api[("Registry API")]
+    end
+
+    build -.->|read schemas| api
+    publish --> api
+    swap --> site["pulumi.com/registry"]
+```
+
+The workflow runs these steps in order:
+
+1. [`scripts/ci/build.sh`](../scripts/ci/build.sh) generates API docs for every package with `resourcedocsgen docs registry`, restoring packages that haven't changed from cache, and then builds the site with Hugo. Each schema is read from the Registry API, falling back to the `schema_file_url` in the metadata file when the API doesn't have that version yet. That fallback is how a version merged moments ago gets built before it's published.
+1. [`scripts/ci/sync.sh`](../scripts/ci/sync.sh) uploads the built site and its LLM-friendly docs bundles to a new S3 bucket for this commit, runs browser smoke tests against it, and records the bucket in `origin-bucket-metadata.json`. The search index is uploaded to the same bucket.
+1. `pulumi up` on the [`infrastructure/`](../infrastructure) program reads `origin-bucket-metadata.json` and points the CloudFront origin at the new bucket, so the live site switches to the new build in one step. The workflow then invalidates cached registry pages on the pulumi.com CDN and creates the S3 redirects.
+1. [`scripts/ci/publish_to_registry.py`](../scripts/ci/publish_to_registry.py) publishes each package whose metadata file changed in the push to the Registry API.
+
+For every step, its environment, and the AWS resources involved, see [`push.yml`](../BUILD-AND-DEPLOY.md#52-pushyml--production-build--deploy), [Deployment infrastructure](../BUILD-AND-DEPLOY.md#deployment-infrastructure), and [Registry publication](../BUILD-AND-DEPLOY.md#registry-publication) in BUILD-AND-DEPLOY.md.
+
+## Learn more
+
+- [Adding a new package](./adding-a-new-package.md) — how a partner or community package gets listed, and what maintainers check before merging.
+- [Previewing your package's docs](./previewing-package-docs.md) — how to see a release's pages before its update pull request merges.
+- [Previewing registry changes](./previewing-registry-changes.md) — how to build and preview a change to this repository.
+- [BUILD-AND-DEPLOY.md](../BUILD-AND-DEPLOY.md) — the full reference for the build, every workflow, and the deployment infrastructure.


### PR DESCRIPTION
`docs/architecture.md` crammed three unrelated update workflows into one Mermaid chart, called partner and community packages "3rd Party", and had drifted from the code. It listed the dispatch handler's internal env var names rather than the `client_payload` fields senders use, linked a stale AWS workflow, and never mentioned the Registry API publish that runs on every push to `master`. Every node color also failed contrast in at least one of GitHub's themes.

It stays one page rather than splitting, because the three paths are short and converge on the same pull request and publish stages. Each path gets its own diagram, grouped by the repo that runs each step, and fragile specifics like "twice a day" point at the workflow file instead.

## Changes
- Rewrite `docs/architecture.md` with an overview, one section and diagram per update path, and the shared update-PR and publish stages
- Correct stale facts in `BUILD-AND-DEPLOY.md`: tool versions, community check triggers and parallelism, the Sentinel condition, the missing CDN invalidation step, the Algolia claim, and a broken ToC anchor
- Replace "nightly" with "scheduled" in `AGENTS.md`

The `#registry-package-updates` and `#publish` anchors the previewing docs link to still resolve. The page leaves out the `push-registry.py` fallback, since #11998 removes it.

`make lint` passes, and all five diagrams render with mermaid-cli in light and dark themes.

Fixes #12457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQZaUTwQoEeqh263CNnXZa
